### PR TITLE
bug fix for dataset pinned version to 4.0.0

### DIFF
--- a/external/lerobot/pyproject.toml
+++ b/external/lerobot/pyproject.toml
@@ -54,7 +54,7 @@ pre-commit = {version = ">=3.7.0", optional = true}
 debugpy = {version = ">=1.8.1", optional = true}
 pytest = {version = ">=8.1.0", optional = true}
 pytest-cov = {version = ">=5.0.0", optional = true}
-datasets = ">=2.19.0"
+datasets = "==4.0.0"
 imagecodecs = { version = ">=2024.1.1", optional = true }
 rerun-sdk = ">=0.21.0"
 deepdiff = ">=7.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ typing_extensions
 pyarrow==19.0.1
 simplejpeg
 prettytable
+datasets==4.0.0


### PR DESCRIPTION
datasets were loading really slowly, 2+ hours.
<img width="1109" height="254" alt="image" src="https://github.com/user-attachments/assets/461ff779-bc2d-4f7b-ab64-3af4656b7c13" />
hanging after generating train splits.

solution was pinning 'dataset' version to 4.0.0