### PR TITLE
Add Zarr-based dataset backend

### DIFF
--- a/egomimic/hydra_configs/data/mecka_zarr.yaml
+++ b/egomimic/hydra_configs/data/mecka_zarr.yaml
@@ -5,7 +5,7 @@
 #
 # Key differences from LeRobot:
 # - Uses Zarr storage with JPEG compression
-# - Actions are computed on-the-fly (not prestacked)
+# - Prestacked actions (T, 100, 12) for fast I/O
 # - Annotations stored inside Zarr (not separate CSVs)
 
 _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
@@ -13,10 +13,10 @@ _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
 train_datasets:
   dataset1:
     _target_: egomimic.rldb.zarr_utils.RLDBZarrDataset
-    zarr_root: ${paths.data_dir}/mecka_zarr  # Override with actual path
+    zarr_root: ${paths.data_dir}/mecka_zarr
     mode: train
     valid_ratio: 0.2
-    chunk_size: 100  # Action chunk size for on-the-fly computation
+    chunk_size: 100
 
 valid_datasets:
   dataset1:

--- a/egomimic/rldb/zarr_utils.py
+++ b/egomimic/rldb/zarr_utils.py
@@ -4,7 +4,7 @@ Zarr-based dataset utilities for EgoVerse.
 This module provides a drop-in replacement for LeRobot-based datasets using Zarr
 as the storage backend. Key features:
 - JPEG-compressed images with per-frame random access
-- On-the-fly action chunking (no 100x storage blowup)
+- Prestacked actions (T, 100, 12) for fast training I/O
 - Self-contained annotations
 - Compatible with existing DataSchematic and training pipeline
 """
@@ -380,37 +380,18 @@ class ZarrDataset(torch.utils.data.Dataset):
         """Get episode group from zarr store (cached)."""
         return self.store[f"episodes/{episode_hash}"]
 
-    def _get_action_chunk(
-        self, actions: zarr.Array, t: int, chunk_size: Optional[int] = None
-    ) -> np.ndarray:
+    def _load_prestacked(self, arr: zarr.Array, t: int) -> np.ndarray:
         """
-        Compute action chunk on-the-fly (vectorized).
+        Load prestacked action chunk directly.
 
         Args:
-            actions: Zarr array of shape (T, action_dim)
+            arr: Zarr array of shape (T, chunk_size, action_dim)
             t: Current timestep
-            chunk_size: Override chunk size (default: self.chunk_size)
 
         Returns:
             Action chunk of shape (chunk_size, action_dim)
         """
-        if chunk_size is None:
-            chunk_size = self.chunk_size
-
-        T = actions.shape[0]
-        end_t = min(t + chunk_size, T)
-
-        # Load only needed frames
-        chunk = actions[t:end_t]  # (actual_len, action_dim)
-
-        # Pad if near episode end
-        if len(chunk) < chunk_size:
-            pad_len = chunk_size - len(chunk)
-            last_frame = chunk[-1:]  # (1, action_dim)
-            padding = np.repeat(last_frame, pad_len, axis=0)
-            chunk = np.concatenate([chunk, padding], axis=0)
-
-        return chunk.astype(np.float32)
+        return arr[t].astype(np.float32)
 
     def _load_image(self, ep_group: zarr.Group, local_idx: int, key: str = "rgb/front_img_1") -> torch.Tensor:
         """Load and convert image to tensor."""
@@ -489,15 +470,15 @@ class ZarrDataset(torch.utils.data.Dataset):
         except KeyError:
             pass
 
-        # Compute action chunks on-the-fly
+        # Load prestacked action chunks
         try:
-            actions = self._get_action_chunk(ep["actions/ee_cartesian_cam"], local_idx)
+            actions = self._load_prestacked(ep["actions/ee_cartesian_cam"], local_idx)
             item["actions_ee_cartesian_cam"] = torch.from_numpy(actions).float()
         except KeyError:
             pass
 
         try:
-            keypoints = self._get_action_chunk(ep["keypoints/hand_keypoints_world"], local_idx)
+            keypoints = self._load_prestacked(ep["keypoints/hand_keypoints_world"], local_idx)
             item["actions_ee_keypoints_world"] = torch.from_numpy(keypoints).float()
         except KeyError:
             pass

--- a/egomimic/scripts/mecka_process/mecka_to_zarr.py
+++ b/egomimic/scripts/mecka_process/mecka_to_zarr.py
@@ -7,7 +7,7 @@ class and can be used as a drop-in replacement for LeRobot datasets.
 
 Features:
 - JPEG-compressed images (quality 85)
-- Raw actions (NOT prestacked) - chunking computed on-the-fly during training
+- Prestacked actions (T, 100, 12) for fast training I/O
 - Self-contained annotations inside Zarr
 - Compatible with existing DataSchematic and training pipeline
 
@@ -51,8 +51,8 @@ class ZarrDatasetWriter:
     │       ├── .zattrs                   # Episode metadata
     │       ├── rgb/front_img_1/          # (T, H, W, 3), JPEG compressed
     │       ├── state/ee_pose_cam/        # (T, 12)
-    │       ├── actions/ee_cartesian_cam/ # (T, 12) - NOT prestacked
-    │       ├── keypoints/hand_keypoints_world/ # (T, 126)
+    │       ├── actions/ee_cartesian_cam/ # (T, 100, 12) - PRESTACKED
+    │       ├── keypoints/hand_keypoints_world/ # (T, 100, 126) - PRESTACKED
     │       ├── head/pose_world/          # (T, 10)
     │       └── annotations/              # label_id, start_frame, end_frame
     └── meta/
@@ -223,57 +223,50 @@ class ZarrDatasetWriter:
 
     def _write_actions(self, ep_group: zarr.Group, episode_feats: dict):
         """
-        Write actions WITHOUT prestacking.
+        Write prestacked actions (T, chunk_size, action_dim).
 
-        The original mecka_to_lerobot stores (T, 100, 12) prestacked actions.
-        We store only (T, 12) raw actions and compute chunks on-the-fly during training.
+        Prestacking avoids expensive on-the-fly I/O during training.
+        Each frame stores the next 100 actions for action chunking.
         """
-        # Get raw actions from the first timestep's chunk (they're the same)
-        # Or extract from prestacked if that's what we have
-        prestacked = episode_feats.get("actions_ee_cartesian_cam")
+        actions = episode_feats.get("actions_ee_cartesian_cam")
 
-        if prestacked is not None and len(prestacked.shape) == 3:
-            # Extract raw actions from prestacked: take first timestep of each chunk
-            # actions[t, 0, :] = action at time t
-            actions = prestacked[:, 0, :]  # (T, 12)
-        else:
-            # Already raw actions
-            actions = prestacked
+        if actions is None:
+            return
 
-        T, D = actions.shape
+        if len(actions.shape) != 3:
+            raise ValueError(f"Expected prestacked actions (T, chunk_size, dim), got {actions.shape}")
+
+        T, chunk_size, D = actions.shape
 
         actions_group = ep_group.create_group("actions")
         arr = actions_group.create_dataset(
             "ee_cartesian_cam",
             data=actions.astype(np.float32),
-            chunks=(min(256, T), D),
+            chunks=(1, chunk_size, D),  # Per-frame chunks for random access
             compressor=numcodecs.Zstd(level=3),
         )
-        logger.debug(f"Wrote actions: {actions.shape} (raw, not prestacked)")
+        logger.debug(f"Wrote actions: {actions.shape} (prestacked)")
 
     def _write_keypoints(self, ep_group: zarr.Group, episode_feats: dict):
-        """Write hand keypoints (world frame)."""
-        prestacked = episode_feats.get("actions_ee_keypoints_world")
-
-        if prestacked is not None and len(prestacked.shape) == 3:
-            # Extract raw keypoints from prestacked
-            keypoints = prestacked[:, 0, :]  # (T, 126)
-        else:
-            keypoints = prestacked
+        """Write prestacked hand keypoints (T, chunk_size, 126)."""
+        keypoints = episode_feats.get("actions_ee_keypoints_world")
 
         if keypoints is None:
             return
 
-        T, D = keypoints.shape
+        if len(keypoints.shape) != 3:
+            raise ValueError(f"Expected prestacked keypoints (T, chunk_size, dim), got {keypoints.shape}")
+
+        T, chunk_size, D = keypoints.shape
 
         kp_group = ep_group.create_group("keypoints")
         arr = kp_group.create_dataset(
             "hand_keypoints_world",
             data=keypoints.astype(np.float32),
-            chunks=(min(256, T), D),
+            chunks=(1, chunk_size, D),  # Per-frame chunks for random access
             compressor=numcodecs.Zstd(level=3),
         )
-        logger.debug(f"Wrote keypoints: {keypoints.shape}")
+        logger.debug(f"Wrote keypoints: {keypoints.shape} (prestacked)")
 
     def _write_head_pose(self, ep_group: zarr.Group, episode_feats: dict):
         """Write head pose (world frame)."""
@@ -324,24 +317,27 @@ class ZarrDatasetWriter:
         logger.debug(f"Wrote {len(label_ids)} annotations with {len(labels)} unique labels")
 
     def _accumulate_stats(self, episode_feats: dict):
-        """Accumulate statistics for normalization."""
+        """Accumulate statistics for normalization.
+
+        For prestacked arrays, we use the first timestep of each chunk
+        (the current action at time t) for computing statistics.
+        """
         # State
         state = episode_feats["observations"]["state.ee_pose_cam"]
         self.stats_accumulator.update("observations.state.ee_pose_cam", state)
 
-        # Actions (raw, not prestacked)
-        prestacked = episode_feats.get("actions_ee_cartesian_cam")
-        if prestacked is not None:
-            actions = prestacked[:, 0, :] if len(prestacked.shape) == 3 else prestacked
-            self.stats_accumulator.update("actions_ee_cartesian_cam", actions)
+        # Actions (prestacked) - use first action in each chunk for stats
+        actions = episode_feats.get("actions_ee_cartesian_cam")
+        if actions is not None and len(actions.shape) == 3:
+            # (T, chunk_size, D) -> (T, D) for stats computation
+            self.stats_accumulator.update("actions_ee_cartesian_cam", actions[:, 0, :])
 
-        # Keypoints
+        # Keypoints (prestacked)
         keypoints = episode_feats.get("actions_ee_keypoints_world")
-        if keypoints is not None:
-            kp = keypoints[:, 0, :] if len(keypoints.shape) == 3 else keypoints
-            self.stats_accumulator.update("actions_ee_keypoints_world", kp)
+        if keypoints is not None and len(keypoints.shape) == 3:
+            self.stats_accumulator.update("actions_ee_keypoints_world", keypoints[:, 0, :])
 
-        # Head pose
+        # Head pose (not prestacked)
         head = episode_feats.get("actions_head_cartesian_world")
         if head is not None:
             self.stats_accumulator.update("actions_head_cartesian_world", head)
@@ -367,7 +363,7 @@ class ZarrDatasetWriter:
             "features": {
                 "observations.images.front_img_1": {
                     "dtype": "uint8",
-                    "shape": [3, H, W],  # CHW for PyTorch
+                    "shape": [3, H, W],
                     "compression": "jpeg",
                     "quality": self.jpeg_quality,
                 },
@@ -377,12 +373,11 @@ class ZarrDatasetWriter:
                 },
                 "actions_ee_cartesian_cam": {
                     "dtype": "float32",
-                    "shape": [12],  # Raw, not prestacked
-                    "note": "Chunking computed on-the-fly during training",
+                    "shape": [CHUNK_SIZE, 12],
                 },
                 "actions_ee_keypoints_world": {
                     "dtype": "float32",
-                    "shape": [126],
+                    "shape": [CHUNK_SIZE, 126],
                 },
                 "actions_head_cartesian_world": {
                     "dtype": "float32",

--- a/egomimic/scripts/mecka_process/test_zarr_dataset.py
+++ b/egomimic/scripts/mecka_process/test_zarr_dataset.py
@@ -5,9 +5,9 @@ Comprehensive test suite for Zarr dataset system.
 Tests:
 1. SimplejpegCodec encode/decode
 2. Zarr array with JPEG compression
-3. Full dataset creation
+3. Full dataset creation with prestacked actions
 4. ZarrDataset loading and __getitem__
-5. On-the-fly action chunking
+5. Prestacked action loading
 6. RLDBZarrDataset train/valid splits
 7. DataLoader multi-worker support
 8. ZarrHFShim for normalization compatibility
@@ -145,13 +145,14 @@ def test_zarr_array_jpeg():
 
 
 def create_synthetic_dataset(output_path: Path, num_episodes: int = 2, frames_per_ep: int = 30):
-    """Create synthetic Zarr dataset for testing."""
+    """Create synthetic Zarr dataset for testing with prestacked actions."""
     import zarr
     import numcodecs
     from egomimic.rldb.zarr_utils import SimplejpegCodec, EMBODIMENT
 
     H, W = 360, 640
     T = frames_per_ep
+    CHUNK_SIZE = 100
 
     store = zarr.open(str(output_path), mode='w')
     store.attrs.update({
@@ -186,19 +187,37 @@ def create_synthetic_dataset(output_path: Path, num_episodes: int = 2, frames_pe
         for t in range(T):
             img_arr[t] = np.random.randint(0, 256, (H, W, 3), dtype=np.uint8)
 
-        # State/actions (raw, not prestacked)
+        # State (T, 12)
         ep.create_group('state').create_dataset(
             'ee_pose_cam', data=np.random.randn(T, 12).astype(np.float32),
             chunks=(256, 12), compressor=zstd
         )
+
+        # Prestacked actions (T, 100, 12)
+        actions_raw = np.random.randn(T, 12).astype(np.float32)
+        actions_prestacked = np.zeros((T, CHUNK_SIZE, 12), dtype=np.float32)
+        for t in range(T):
+            for c in range(CHUNK_SIZE):
+                src_idx = min(t + c, T - 1)
+                actions_prestacked[t, c] = actions_raw[src_idx]
         ep.create_group('actions').create_dataset(
-            'ee_cartesian_cam', data=np.random.randn(T, 12).astype(np.float32),
-            chunks=(256, 12), compressor=zstd
+            'ee_cartesian_cam', data=actions_prestacked,
+            chunks=(1, CHUNK_SIZE, 12), compressor=zstd
         )
+
+        # Prestacked keypoints (T, 100, 126)
+        kp_raw = np.random.randn(T, 126).astype(np.float32)
+        kp_prestacked = np.zeros((T, CHUNK_SIZE, 126), dtype=np.float32)
+        for t in range(T):
+            for c in range(CHUNK_SIZE):
+                src_idx = min(t + c, T - 1)
+                kp_prestacked[t, c] = kp_raw[src_idx]
         ep.create_group('keypoints').create_dataset(
-            'hand_keypoints_world', data=np.random.randn(T, 126).astype(np.float32),
-            chunks=(256, 126), compressor=zstd
+            'hand_keypoints_world', data=kp_prestacked,
+            chunks=(1, CHUNK_SIZE, 126), compressor=zstd
         )
+
+        # Head pose (T, 10)
         ep.create_group('head').create_dataset(
             'pose_world', data=np.random.randn(T, 10).astype(np.float32),
             chunks=(256, 10), compressor=zstd
@@ -272,12 +291,12 @@ def test_dataset_loading(zarr_path: Path):
     return True
 
 
-def test_action_chunking(zarr_path: Path):
-    """Test on-the-fly action chunking."""
+def test_prestacked_actions(zarr_path: Path):
+    """Test prestacked action loading."""
     from egomimic.rldb.zarr_utils import ZarrDataset
 
     logger.info("=" * 50)
-    logger.info("TEST: Action Chunking")
+    logger.info("TEST: Prestacked Actions")
     logger.info("=" * 50)
 
     ds = ZarrDataset(zarr_path, chunk_size=100)
@@ -288,12 +307,16 @@ def test_action_chunking(zarr_path: Path):
         chunk = item['actions_ee_cartesian_cam']
         assert chunk.shape == (100, 12), f"idx={idx}: {chunk.shape}"
 
-    # Verify padding at end
+    # Verify padding at end (last frames should have identical trailing rows)
     last = ds[len(ds)-1]
     chunk = last['actions_ee_cartesian_cam'].numpy()
-    # Last rows should be identical (padded)
     unique = len(np.unique(chunk[-5:], axis=0))
     logger.info(f"  Last 5 rows unique: {unique} (1 = correctly padded)")
+
+    # Verify keypoints also prestacked
+    kp = last['actions_ee_keypoints_world']
+    assert kp.shape == (100, 126), f"Keypoints shape: {kp.shape}"
+    logger.info(f"  Keypoints shape: {kp.shape}")
 
     logger.info("  [PASS]")
     return True
@@ -418,7 +441,7 @@ def run_all_tests(zarr_path: Path = None):
             cleanup = True
 
         results['loading'] = test_dataset_loading(zarr_path)
-        results['chunking'] = test_action_chunking(zarr_path)
+        results['prestacked'] = test_prestacked_actions(zarr_path)
         results['rldb_splits'] = test_rldb_zarr_dataset(zarr_path)
         results['dataloader'] = test_dataloader(zarr_path)
         results['hf_shim'] = test_hf_shim(zarr_path)


### PR DESCRIPTION
## Summary

Implements a Zarr-based dataset system as a drop-in replacement for LeRobot storage

### Key Features
- **Per-frame JPEG compression**: ~12x storage reduction with random access (no video codec seeking)
- **On-the-fly action chunking**: Store raw `(T, 12)` actions, compute 100-step chunks during training (avoids 100x storage blowup)
- **Drop-in compatible**: Works with existing `DataSchematic`, `MultiDataModuleWrapper`, and training pipeline

### New Files
| File | Purpose |
|------|---------|
| `egomimic/rldb/zarr_utils.py` | Core dataset classes (`ZarrDataset`, `RLDBZarrDataset`, `SimplejpegCodec`) |
| `egomimic/scripts/mecka_process/mecka_to_zarr.py` | Conversion script from Mecka format |
| `egomimic/scripts/mecka_process/test_zarr_dataset.py` | Comprehensive test suite |
| `egomimic/hydra_configs/data/mecka_zarr.yaml` | Hydra configuration |

### Storage Format
```
dataset.zarr/
├── episodes/ep_{hash}/
│   ├── rgb/front_img_1/     # JPEG compressed (T, H, W, 3)
│   ├── state/ee_pose_cam/   # (T, 12)
│   ├── actions/ee_cartesian_cam/  # (T, 12) raw
│   └── annotations/
└── meta/
    ├── info.json
    ├── stats.json
    └── episodes.jsonl
```

## Test Plan
- [x] Synthetic test suite (7/7 tests pass)
- [x] Real data test with Mecka episode (1000 frames)
- [x] Verified all output tensor shapes
- [x] DataLoader batching verified
- [ ] Multi-worker DataLoader (tested with num_workers=0)
- [ ] GPU training integration