### PR TITLE
SFS -> Zarr conversion script

### DIFF
--- a/egomimic/scripts/zarr_data_viz.ipynb
+++ b/egomimic/scripts/zarr_data_viz.ipynb
@@ -319,7 +319,7 @@
     "}\n",
     "\n",
     "ACTION_CHUNK_LENGTH = 100\n",
-    "ACTION_STRIDE = 3\n",
+    "ACTION_STRIDE = 1\n",
     "\n",
     "transform_list = build_aria_bimanual_transform_list(\n",
     "    chunk_length=ACTION_CHUNK_LENGTH,\n",


### PR DESCRIPTION
## What

Adds `sfs_to_egoverse_zarr.py` — takes Scale task IDs, downloads SFS data, and writes local `.zarr` episodes via `ZarrWriter`.

## Writer fix (`zarr_writer.py`)

`_write_language_annotations` tried to build a numpy structured dtype with `VariableLengthBytes()` as a field — numpy can't interpret Zarr-only types, so it crashed with `TypeError`. 

Fix: JSON-encode each annotation row to UTF-8 bytes and store as a flat `VariableLengthBytes` array — same pattern the image writer already uses.