### PR TITLE
Add bulk zarr norm-stats loader

### DIFF
--- a/egomimic/rldb/zarr/utils.py
+++ b/egomimic/rldb/zarr/utils.py
@@ -151,6 +151,197 @@ class DataSchematic(object):
 
         self.shapes_infered = True
 
+    def infer_norm_from_episodes(
+        self,
+        dataset,
+        dataset_name,
+        sample_frac: float = 1.0,
+        seed: int = 42,
+        max_samples: int | None = None,
+        max_episodes: int | None = None,
+        benchmark_dir: str | None = None,
+    ):
+        """Infer norm stats via bulk zarr reads with optional deterministic subsampling."""
+        import zarr
+
+        embodiment = dataset_name
+        if isinstance(embodiment, str):
+            embodiment = get_embodiment_id(embodiment)
+
+        norm_keys = []
+        norm_keys.extend(self.keys_of_type("proprio_keys", embodiment))
+        norm_keys.extend(self.keys_of_type("action_keys", embodiment))
+        if len(norm_keys) == 0:
+            logger.warning(
+                f"[NormStats] No proprio/action keys for embodiment={embodiment}"
+            )
+            return
+
+        zarr_key_map = {}
+        for k in norm_keys:
+            zk = self.keyname_to_zarr_key(k, embodiment)
+            if zk is not None:
+                zarr_key_map[k] = zk
+        if len(zarr_key_map) == 0:
+            logger.warning(
+                f"[NormStats] No zarr keys resolved for embodiment={embodiment}"
+            )
+            return
+
+        ep_paths = []
+        if hasattr(dataset, "datasets"):
+            for ds in dataset.datasets.values():
+                if hasattr(ds, "episode_path"):
+                    ep_paths.append(ds.episode_path)
+        if len(ep_paths) == 0:
+            raise ValueError(
+                "infer_norm_from_episodes requires a dataset with episode_path entries"
+            )
+        ep_paths = list(ep_paths)
+
+        rng = np.random.RandomState(seed)
+        if max_episodes is not None:
+            if max_episodes <= 0:
+                raise ValueError("max_episodes must be > 0 when provided")
+            if max_episodes < len(ep_paths):
+                selected = rng.choice(len(ep_paths), size=max_episodes, replace=False)
+                selected = np.sort(selected)
+                ep_paths = [ep_paths[i] for i in selected]
+
+        logger.info(f"[NormStats] embodiment={embodiment} norm_keys={norm_keys}")
+        logger.info(
+            f"[NormStats] bulk-reading {len(ep_paths)} episodes "
+            f"(sample_frac={sample_frac}, max_samples={max_samples})"
+        )
+
+        collected = {k: [] for k in zarr_key_map}
+        loading_start_time = time.time()
+        for ep_path in tqdm(ep_paths, desc="[NormStats] reading episodes"):
+            store = zarr.open_group(str(ep_path), mode="r")
+            first_key = next(iter(zarr_key_map.values()))
+            n_frames = int(
+                dict(store.attrs).get("total_frames", store[first_key].shape[0])
+            )
+            for key_name, zarr_key in zarr_key_map.items():
+                arr = store[zarr_key][:n_frames]
+                collected[key_name].append(arr)
+
+        loading_time = time.time() - loading_start_time
+        logger.info(f"[NormStats] bulk read done in {loading_time:.1f}s")
+
+        total_frames_available = 0
+        for k in list(collected.keys()):
+            if len(collected[k]) == 0:
+                del collected[k]
+                continue
+            collected[k] = np.concatenate(collected[k], axis=0)
+            if total_frames_available == 0:
+                total_frames_available = collected[k].shape[0]
+
+        if total_frames_available <= 0:
+            raise ValueError("No frames available for norm inference")
+
+        n_samples = int(math.ceil(sample_frac * total_frames_available))
+        n_samples = max(1, min(n_samples, total_frames_available))
+        if max_samples is not None:
+            n_samples = min(n_samples, max_samples)
+
+        if n_samples < total_frames_available:
+            sample_idx = np.sort(
+                rng.choice(total_frames_available, size=n_samples, replace=False)
+            )
+            for k in list(collected.keys()):
+                collected[k] = collected[k][sample_idx]
+
+        logger.info(
+            f"[NormStats] sampling {n_samples}/{total_frames_available} "
+            f"(~{100 * n_samples / total_frames_available:.1f}%) frames"
+        )
+
+        benchmark_stats = None
+        if benchmark_dir is not None:
+            os.makedirs(benchmark_dir, exist_ok=True)
+            benchmark_file = os.path.join(benchmark_dir, "benchmark.json")
+            benchmark_stats = {"loading_time": loading_time, "stats": {}}
+
+        computing_start_time = time.time()
+        total_frames = n_samples
+        for k in list(collected.keys()):
+            X = collected[k]
+
+            mean = np.mean(X, axis=0)
+            std = np.std(X, axis=0)
+            minv = np.min(X, axis=0)
+            maxv = np.max(X, axis=0)
+            median = np.median(X, axis=0)
+            q1 = np.percentile(X, 1, axis=0)
+            q99 = np.percentile(X, 99, axis=0)
+
+            self.norm_stats[embodiment][k] = {
+                "mean": torch.from_numpy(np.array(mean, dtype=np.float32)).float(),
+                "std": torch.from_numpy(np.array(std, dtype=np.float32)).float(),
+                "min": torch.from_numpy(np.array(minv, dtype=np.float32)).float(),
+                "max": torch.from_numpy(np.array(maxv, dtype=np.float32)).float(),
+                "median": torch.from_numpy(np.array(median, dtype=np.float32)).float(),
+                "quantile_1": torch.from_numpy(np.array(q1, dtype=np.float32)).float(),
+                "quantile_99": torch.from_numpy(
+                    np.array(q99, dtype=np.float32)
+                ).float(),
+            }
+
+            if benchmark_stats is not None:
+                stat_dir = os.path.join(benchmark_dir, str(embodiment), k)
+                os.makedirs(stat_dir, exist_ok=True)
+                mean_path = os.path.join(stat_dir, "mean.pt")
+                std_path = os.path.join(stat_dir, "std.pt")
+                min_path = os.path.join(stat_dir, "min.pt")
+                max_path = os.path.join(stat_dir, "max.pt")
+                median_path = os.path.join(stat_dir, "median.pt")
+                quantile_1_path = os.path.join(stat_dir, "quantile_1.pt")
+                quantile_99_path = os.path.join(stat_dir, "quantile_99.pt")
+
+                torch.save(self.norm_stats[embodiment][k]["mean"], mean_path)
+                torch.save(self.norm_stats[embodiment][k]["std"], std_path)
+                torch.save(self.norm_stats[embodiment][k]["min"], min_path)
+                torch.save(self.norm_stats[embodiment][k]["max"], max_path)
+                torch.save(self.norm_stats[embodiment][k]["median"], median_path)
+                torch.save(
+                    self.norm_stats[embodiment][k]["quantile_1"], quantile_1_path
+                )
+                torch.save(
+                    self.norm_stats[embodiment][k]["quantile_99"], quantile_99_path
+                )
+
+                if benchmark_stats["stats"].get(embodiment, None) is None:
+                    benchmark_stats["stats"][embodiment] = {}
+                benchmark_stats["stats"][embodiment][k] = {
+                    "mean": mean_path,
+                    "std": std_path,
+                    "min": min_path,
+                    "max": max_path,
+                    "median": median_path,
+                    "quantile_1": quantile_1_path,
+                    "quantile_99": quantile_99_path,
+                }
+
+            logger.info(
+                f"[NormStats] key={k} samples={X.shape[0]} stat_shape={mean.shape}"
+            )
+            del collected[k]
+
+        computing_time = time.time() - computing_start_time
+        if benchmark_stats is not None:
+            benchmark_stats["computing_time"] = computing_time
+            benchmark_stats["frames"] = total_frames
+            with open(benchmark_file, "w") as f:
+                json.dump(benchmark_stats, f, indent=4)
+
+        logger.info(
+            f"[NormStats] Finished norm inference, episodes={len(ep_paths)} "
+            f"frames={total_frames} loading_time={loading_time:.2f}s "
+            f"computing_time={computing_time:.2f}s"
+        )
+
     def infer_norm_from_dataset(
         self,
         dataset,

--- a/egomimic/scripts/profile_norm_stats_methods.py
+++ b/egomimic/scripts/profile_norm_stats_methods.py
@@ -1,0 +1,167 @@
+import argparse
+import bisect
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import zarr
+
+from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+from egomimic.rldb.zarr.utils import DataSchematic
+
+
+KEYS = [
+    "observations.state.ee_pose",
+    "observations.state.joint_positions",
+    "actions_joints",
+    "actions_cartesian",
+]
+STAT_NAMES = ["mean", "std", "min", "max", "median", "quantile_1", "quantile_99"]
+
+
+class _EpisodeDataset:
+    def __init__(self, episode_path: Path):
+        self.episode_path = episode_path
+
+
+class _DonutDataset:
+    """Dataset shim for both infer_norm_from_episodes and infer_norm_from_dataset."""
+
+    def __init__(self, episode_paths: list[Path]):
+        self.datasets = {p.stem: _EpisodeDataset(p) for p in episode_paths}
+        self._groups = []
+        self._lengths = []
+        for p in episode_paths:
+            group = zarr.open_group(str(p), mode="r")
+            n_frames = int(dict(group.attrs).get("total_frames", group[KEYS[0]].shape[0]))
+            self._groups.append(group)
+            self._lengths.append(n_frames)
+
+        self._cum_lengths = []
+        running = 0
+        for n in self._lengths:
+            running += n
+            self._cum_lengths.append(running)
+
+    def __len__(self) -> int:
+        return self._cum_lengths[-1] if self._cum_lengths else 0
+
+    def __getitem__(self, idx: int):
+        ep_idx = bisect.bisect_right(self._cum_lengths, idx)
+        prev = 0 if ep_idx == 0 else self._cum_lengths[ep_idx - 1]
+        local_idx = idx - prev
+        group = self._groups[ep_idx]
+        return {k: np.asarray(group[k][local_idx]) for k in KEYS}
+
+
+def _build_schematic(embodiment_name: str) -> DataSchematic:
+    schematic_dict = {
+        embodiment_name: {
+            KEYS[0]: {"key_type": "proprio_keys", "zarr_key": KEYS[0]},
+            KEYS[1]: {"key_type": "proprio_keys", "zarr_key": KEYS[1]},
+            KEYS[2]: {"key_type": "action_keys", "zarr_key": KEYS[2]},
+            KEYS[3]: {"key_type": "action_keys", "zarr_key": KEYS[3]},
+        }
+    }
+    viz_img_key = {embodiment_name: "observations.images.base_0_rgb"}
+    return DataSchematic(schematic_dict, viz_img_key)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Profile infer_norm_from_episodes vs infer_norm_from_dataset on zarr episodes."
+    )
+    parser.add_argument(
+        "--dataset-dir",
+        type=Path,
+        default=Path("/opt/dlami/nvme/aseem/robot_zarr_dataset/donuts_flat"),
+    )
+    parser.add_argument("--max-episodes", type=int, default=300)
+    parser.add_argument("--embodiment", type=str, default="scale_aloha_bimanual")
+    parser.add_argument("--batch-size", type=int, default=512)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Optional path to write profile report JSON",
+    )
+    args = parser.parse_args()
+
+    episode_paths = sorted(args.dataset_dir.glob("*.zarr"))
+    if not episode_paths:
+        raise RuntimeError(f"No .zarr episodes found in {args.dataset_dir}")
+    if args.max_episodes > 0:
+        episode_paths = episode_paths[: args.max_episodes]
+
+    print(f"[profile] dataset_dir={args.dataset_dir}", flush=True)
+    print(f"[profile] selected_episodes={len(episode_paths)}", flush=True)
+    print(f"[profile] embodiment={args.embodiment}", flush=True)
+    print(
+        f"[profile] dataloader batch_size={args.batch_size} num_workers={args.num_workers}",
+        flush=True,
+    )
+
+    dataset = _DonutDataset(episode_paths)
+    print(f"[profile] total_frames={len(dataset)}", flush=True)
+
+    # Method A: bulk episode reads
+    print("[profile] running infer_norm_from_episodes...", flush=True)
+    bulk_schematic = _build_schematic(args.embodiment)
+    bulk_t0 = time.perf_counter()
+    bulk_schematic.infer_norm_from_episodes(dataset, args.embodiment)
+    bulk_t1 = time.perf_counter()
+
+    # Method B: existing DataLoader path
+    print("[profile] running infer_norm_from_dataset...", flush=True)
+    dl_schematic = _build_schematic(args.embodiment)
+    dl_t0 = time.perf_counter()
+    dl_schematic.infer_norm_from_dataset(
+        dataset,
+        args.embodiment,
+        sample_frac=1.0,
+        seed=42,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+    )
+    dl_t1 = time.perf_counter()
+
+    emb_id = get_embodiment_id(args.embodiment)
+    diffs = {}
+    for key in KEYS:
+        diffs[key] = {}
+        for stat in STAT_NAMES:
+            bulk = bulk_schematic.norm_stats[emb_id][key][stat].float()
+            dl = dl_schematic.norm_stats[emb_id][key][stat].float()
+            delta = (bulk - dl).abs()
+            diffs[key][stat] = {
+                "max_abs_diff": float(delta.max().item()),
+                "mean_abs_diff": float(delta.mean().item()),
+            }
+
+    bulk_seconds = bulk_t1 - bulk_t0
+    dl_seconds = dl_t1 - dl_t0
+    report = {
+        "dataset_dir": str(args.dataset_dir),
+        "episodes": len(episode_paths),
+        "frames": len(dataset),
+        "embodiment": args.embodiment,
+        "bulk_seconds": round(bulk_seconds, 4),
+        "dataloader_seconds": round(dl_seconds, 4),
+        "speedup_x": round(dl_seconds / bulk_seconds, 4) if bulk_seconds > 0 else None,
+        "diffs": diffs,
+    }
+
+    print("[profile] done", flush=True)
+    print(json.dumps(report, indent=2), flush=True)
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(report, indent=2))
+        print(f"[profile] wrote report to {args.output_json}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `infer_norm_from_episodes` to compute norm stats via bulk zarr episode reads.
- Add profiling script to compare bulk and DataLoader methods and report timing plus numeric diffs.
