### PR TITLE
Fix attributes and dataset format in data visualisation script

### DIFF
--- a/egomimic/rldb/embodiment/embodiment.py
+++ b/egomimic/rldb/embodiment/embodiment.py
@@ -41,8 +41,17 @@ def get_embodiment(index):
     return EMBODIMENT_ID_TO_KEY.get(index, None)
 
 
+_EMBODIMENT_ALIASES = {
+    "SCALE": "SCALE_BIMANUAL",
+    "EVA": "EVA_BIMANUAL",
+    "ARIA": "ARIA_BIMANUAL",
+    "MECKA": "MECKA_BIMANUAL",
+}
+
+
 def get_embodiment_id(embodiment_name):
     embodiment_name = embodiment_name.upper()
+    embodiment_name = _EMBODIMENT_ALIASES.get(embodiment_name, embodiment_name)
     return EMBODIMENT[embodiment_name].value
 
 

--- a/egomimic/scripts/tutorials/zarr_data_viz.ipynb
+++ b/egomimic/scripts/tutorials/zarr_data_viz.ipynb
@@ -70,8 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_map = Eva.get_keymap()\n",
-    "transform_list = Eva.get_transform_list()\n",
+    "key_map = Eva.get_keymap(keymap_mode=\"\")\n",
+    "transform_list = Eva.get_transform_list(mode=\"cartesian\")\n",
     "\n",
     "resolver = S3EpisodeResolver(\n",
     "    TEMP_DIR, key_map=key_map, transform_list=transform_list\n",
@@ -137,7 +137,7 @@
    "source": [
     "intrinsics_key = \"base\"\n",
     "\n",
-    "key_map = Aria.get_keymap(mode=\"cartesian\")\n",
+    "key_map = Aria.get_keymap(keymap_mode=\"cartesian\")\n",
     "transform_list = Aria.get_transform_list(mode=\"cartesian\")\n",
     "\n",
     "resolver = S3EpisodeResolver(\n",
@@ -208,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_map = Aria.get_keymap(mode=\"keypoints\")\n",
+    "key_map = Aria.get_keymap(keymap_mode=\"keypoints\")\n",
     "transform_list = Aria.get_transform_list(mode=\"keypoints_headframe_ypr\")\n",
     "\n",
     "resolver = S3EpisodeResolver(\n",
@@ -338,7 +338,7 @@
     "from egomimic.rldb.filters import DatasetFilter\n",
     "intrinsics_key = \"base\"\n",
     "\n",
-    "key_map = Scale.get_keymap(mode=\"cartesian\", annotations=True)\n",
+    "key_map = Scale.get_keymap(keymap_mode=\"cartesian\", annotation_key=\"annotations\")\n",
     "transform_list = None\n",
     "\n",
     "resolver = S3EpisodeResolver(\n",
@@ -349,7 +349,7 @@
     "\n",
     "filters = DatasetFilter(\n",
     "    filter_lambdas=[\n",
-    "        \"lambda row: row['episode_hash'] in {'2026-03-16-01-22-26-448000'}\"\n",
+    "        \"lambda row: row['episode_hash'] in {'2026-03-18-19-03-29-311551'}\"\n",
     "    ]\n",
     ")\n",
     "\n",
@@ -382,7 +382,7 @@
     "for i, batch in enumerate(loader):\n",
     "    vis = Scale.viz_transformed_batch(batch, mode=\"annotations\", viz_batch_key=\"annotations\")\n",
     "    ims_annotations.append(vis)\n",
-    "    if i > 10:\n",
+    "    if i > 500:\n",
     "        break\n",
     "mpy.show_video(ims_annotations, fps=30)"
    ]
@@ -398,7 +398,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "emimic (3.11.14)",
+   "display_name": "emimic",
    "language": "python",
    "name": "python3"
   },
@@ -412,7 +412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

### Bug Fixes

[egomimic/scripts/tutorials/zarr_data_viz.ipynb](https://github.com/GaTech-RL2/EgoVerse/blob/main/egomimic/scripts/tutorials/zarr_data_viz.ipynb)

- Fixed `Eva.get_keymap()` -> `Eva.get_keymap(keymap_mode="")` and `Eva.get_transform_list()` -> `Eva.get_transform_list(mode="cartesian")` since both methods require explicit arguments (Cell 4)
- Fixed `Aria.get_keymap(mode=...)` -> `Aria.get_keymap(keymap_mode=...)` for `cartesian` and `keypoints` sections (wrong parameter name `mode` vs `keymap_mode` from the base Embodiment signature) (Cells 8, 11)
- Fixed `Scale.get_keymap(mode=..., annotations=True)` -> `Scale.get_keymap(keymap_mode=..., annotation_key="annotations")`; Scale inherits `get_keymap()` from base Embodiment (I think the previous version matched with Mecka class) (Cell 18)
- Updated Annotation Viz episode hash from `2026-03-16-01-22-26-448000` (This one seems to have not annotations as I did `print(batch['annotations']) and it shows only blank bracket` to `2026-03-18-19-03-29-311551` (Cell 18)

[egomimic/rldb/embodiment/embodiment.py](https://github.com/TharitSinsunthorn/EgoVerse/blob/fix/zarr_data_viz_notebook/egomimic/rldb/embodiment/embodiment.py)

- Added `_EMBODIMENT_ALIASES` dict and applied it in `get_embodiment_id()` to resolve short embodiment names stored in zarr attrs (e.g. "`scale`", "`eva`", "`aria`", "`mecka`") to their full enum names ("`SCALE_BIMANUAL`", "`EVA_BIMANUAL`", etc.)
- Root cause: Scale zarr files store embodiment="scale" but EMBODIMENT enum only defines SCALE_BIMANUAL, causing KeyError: 'SCALE' when loading any Scale episode batch (verified in [sql_tutorial.ipynb](https://github.com/GaTech-RL2/EgoVerse/blob/main/egomimic/scripts/tutorials/sql_tutorial.ipynb))

## Test

- [ ]  Run all cells in `zarr_data_viz.ipynb` end-to-end
- [ ]  Eva section: YPR axes overlay and traj+rotation video render without error
- [ ]  Aria section: trajectory, YPR axes, and keypoints videos render without error
- [ ]  Gaze section: gaze overlay renders without error
- [ ]  Annotation Viz section: video renders with annotation text overlaid at bottom of frame, text changes between "Fold" and "Unfold" phases