### PR TITLE
Add HPT-DINO action-expert algorithm

### DIFF
--- a/egomimic/algo/hpt_dino_ae.py
+++ b/egomimic/algo/hpt_dino_ae.py
@@ -1,0 +1,592 @@
+"""Two-stage HPT-DINO action-expert algorithm.
+
+Stage 1 (world model, with trunk):
+  inputs   = DINO embedding at BOS + sampled language prompt
+  target   = DINO embedding at EOS  (flow-matched, action_horizon=1)
+
+Stage 2 (action expert, no trunk):
+  inputs   = GT EOS DINO (training) / predicted EOS DINO (inference)
+             + obs_t (front image, wrist images on EVA, proprio)
+  target   = action chunk (flow-matched, action_horizon=100)
+
+Training is staged, not joint. The active stage is determined by global step:
+  step <  stage1_steps           -> train Stage 1, Stage 2 frozen
+  step >= stage1_steps           -> train Stage 2, Stage 1 frozen
+
+Each stage's pretrained weights can be loaded independently from disk so the
+two stages can be trained in separate runs (e.g. set ``stage1_steps=0`` and
+load ``stage1_pretrained_checkpoint`` to train only Stage 2).
+"""
+
+from __future__ import annotations
+
+import random
+from collections import OrderedDict
+from typing import Any
+
+import einops
+import numpy as np
+import torch
+import torch.nn as nn
+from overrides import override
+from torchmetrics import MeanSquaredError
+
+from egomimic.algo.algo import Algo
+from egomimic.algo.hpt import HPTModel
+from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
+from egomimic.utils.egomimicUtils import get_sinusoid_encoding_table
+
+_PASSTHROUGH_TYPES = {"camera_keys", "proprio_keys", "lang_keys", "annotation_keys"}
+
+
+class ActionExpertModel(nn.Module):
+    """Stage-2 module: stems + encoders + flow head, no trunk.
+
+    Concatenates per-modality stem latent tokens into a single conditioning
+    sequence and feeds it to a flow-matching head that predicts actions.
+    """
+
+    def __init__(
+        self,
+        domains: list[str],
+        stem_specs: dict | None = None,
+        shared_stem_specs: dict | None = None,
+        shared_obs_keys: list[str] | None = None,
+        encoder_specs: dict | None = None,
+        head_spec: Any = None,
+    ):
+        super().__init__()
+        self.domains = list(domains)
+        self.shared_keys = list(shared_obs_keys or [])
+
+        self.stems = nn.ModuleDict()
+        self.encoders = nn.ModuleDict()
+        self.modalities: dict[str, list[str]] = {}
+
+        for modality, spec in (shared_stem_specs or {}).items():
+            self._register_stem("shared", modality, spec)
+
+        for domain in self.domains:
+            self.modalities.setdefault(domain, [])
+            for modality, spec in ((stem_specs or {}).get(domain) or {}).items():
+                self._register_stem(domain, modality, spec)
+
+        for modality, encoder in (encoder_specs or {}).items():
+            self.encoders[modality] = encoder
+
+        self.head = head_spec
+        self.apply(_init_weights)
+
+    def _register_stem(self, domain: str, modality: str, spec: nn.Module):
+        if domain != "shared":
+            self.modalities.setdefault(domain, []).append(modality)
+        stem_name = f"{domain}_{modality}"
+        self.stems[stem_name] = spec
+        if hasattr(spec, "init_cross_attn"):
+            spec.init_cross_attn(spec.specs.cross_attn)
+
+    def encode(self, domain: str, data: dict) -> torch.Tensor:
+        feats = []
+        modalities = list(self.modalities.get(domain, [])) + list(self.shared_keys)
+        for modality in modalities:
+            if modality not in data:
+                continue
+            stem_domain = "shared" if modality in self.shared_keys else domain
+            stem = self.stems[f"{stem_domain}_{modality}"]
+
+            if modality in self.encoders:
+                data[modality] = self.encoders[modality](data[modality])
+
+            x = data[modality]
+            data_shape = x.shape
+            position = get_sinusoid_encoding_table(
+                0, data_shape[1] * int(np.prod(data_shape[2:-1])), data_shape[-1]
+            ).to(x)
+            position = einops.repeat(
+                position, "b h w -> (repeat b) h w", repeat=data_shape[0]
+            )
+            x = x + position.view(x.shape)
+            feats.append(stem.compute_latent(x))
+        if not feats:
+            raise RuntimeError(f"No stage-2 modalities present for domain {domain}")
+        return torch.cat(feats, dim=-2)
+
+    def compute_loss(self, batch: dict) -> torch.Tensor:
+        domain, data = batch["domain"], batch["data"]
+        cond = self.encode(domain, data)
+        return self.head.compute_loss(cond, data)
+
+    def forward(self, domain: str, data: dict) -> torch.Tensor:
+        cond = self.encode(domain, data)
+        return self.head((cond, domain))
+
+
+def _init_weights(m: nn.Module):
+    if isinstance(m, nn.Linear):
+        nn.init.xavier_uniform_(m.weight)
+        if m.bias is not None:
+            nn.init.constant_(m.bias, 0)
+    elif isinstance(m, nn.LayerNorm):
+        nn.init.constant_(m.bias, 0)
+        nn.init.constant_(m.weight, 1.0)
+
+
+class HPTDinoAEPolicy(nn.Module):
+    """Composite module holding Stage-1 (HPTModel + trunk) and Stage-2 (ActionExpertModel)."""
+
+    def __init__(self, stage1: HPTModel, stage2: ActionExpertModel):
+        super().__init__()
+        self.stage1 = stage1
+        self.stage2 = stage2
+
+
+class HPTDinoAE(Algo):
+    """Two-stage HPT-DINO algorithm. See module docstring."""
+
+    def __init__(
+        self,
+        data_schematic,
+        camera_transforms,
+        train_image_augs,
+        eval_image_augs,
+        # ---------- Stage 1 (world model with trunk) ----------
+        stage1_trunk: dict,
+        stage1_shared_stem_specs: dict,
+        stage1_shared_obs_keys: list[str],
+        stage1_head_specs: dict,
+        # ---------- Stage 2 (action expert, no trunk) ----------
+        stage2_shared_stem_specs: dict,
+        stage2_shared_obs_keys: list[str],
+        stage2_stem_specs: dict,
+        stage2_head_spec: Any,
+        # ---------- Encoders (shared module dicts) ----------
+        stage1_encoder_specs: dict | None = None,
+        stage2_encoder_specs: dict | None = None,
+        # ---------- Domains and target keys ----------
+        domains: list[str] = None,
+        ac_keys: dict | None = None,
+        shared_ac_key_stage1: str = "dino_front_T",
+        shared_ac_key_stage2: str = "actions_cartesian",
+        # ---------- Training schedule ----------
+        stage1_steps: int = 0,
+        stage2_steps: int = 0,
+        stage1_pretrained_checkpoint: str | None = None,
+        stage2_pretrained_checkpoint: str | None = None,
+        # ---------- Annotation sampling ----------
+        # During training the sampled_prompt is drawn uniformly at random from
+        # the per-frame annotation list; during eval the index here is used so
+        # validation runs are deterministic across epochs. Out-of-range indices
+        # are clamped to the last available annotation per sample.
+        eval_annotation_index: int = 0,
+        default_prompt: str = "",
+        # ---------- Misc ----------
+        viz_func=None,
+        **kwargs,
+    ):
+        self.data_schematic = data_schematic
+        self.viz_func = viz_func
+        self.camera_transforms = camera_transforms
+        self.train_image_augs = train_image_augs
+        self.eval_image_augs = eval_image_augs
+
+        self.domains = list(domains)
+        self.ac_keys = dict(ac_keys or {})
+        self.shared_ac_key_stage1 = shared_ac_key_stage1
+        self.shared_ac_key_stage2 = shared_ac_key_stage2
+
+        self.stage1_steps = int(stage1_steps)
+        self.stage2_steps = int(stage2_steps)
+        self.training_step = 0
+        self._stage1_frozen = False
+        self._stage2_frozen = False
+
+        self.eval_annotation_index = int(eval_annotation_index)
+        self.default_prompt = default_prompt
+
+        self.device = kwargs.get(
+            "device", torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        )
+
+        # ---- Build Stage 1 (HPTModel reused as-is) ----
+        # Domain is always "shared" for Stage 1; we don't use the
+        # shared_keys/per-domain split that HPT cotrain uses.
+        stage1_model = HPTModel(**stage1_trunk)
+        stage1_model.diffusion = True
+        stage1_model.device = self.device
+        stage1_model.shared_keys = []
+        stage1_model.auxiliary_ac_keys = {}
+        stage1_model.shared_action = False
+
+        stage1_model.init_domain_stem("shared", stage1_shared_stem_specs)
+        stage1_model.init_domain_head("shared", stage1_head_specs["shared"])
+        for modality, encoder in (stage1_encoder_specs or {}).items():
+            stage1_model.init_encoder(modality, encoder)
+        stage1_model.finalize_modules()
+
+        # ---- Build Stage 2 (custom no-trunk module) ----
+        stage2_model = ActionExpertModel(
+            domains=self.domains,
+            stem_specs=stage2_stem_specs,
+            shared_stem_specs=stage2_shared_stem_specs,
+            shared_obs_keys=stage2_shared_obs_keys,
+            encoder_specs=stage2_encoder_specs,
+            head_spec=stage2_head_spec,
+        )
+
+        self.nets = nn.ModuleDict()
+        self.nets["policy"] = HPTDinoAEPolicy(stage1_model, stage2_model).to(
+            self.device
+        )
+        self.nets = self.nets.float()
+
+        # ---- Resolve schematic-driven key lists per embodiment ----
+        self.camera_keys: dict[int, list[str]] = {}
+        self.proprio_keys: dict[int, list[str]] = {}
+        self.lang_keys: dict[int, list[str]] = {}
+        self.annotation_keys: dict[int, list[str]] = {}
+        self.action_keys: dict[int, list[str]] = {}
+        for domain in self.domains:
+            eid = get_embodiment_id(domain)
+            self.camera_keys[eid] = list(
+                data_schematic.keys_of_type("camera_keys", eid)
+            )
+            self.proprio_keys[eid] = list(
+                data_schematic.keys_of_type("proprio_keys", eid)
+            )
+            self.lang_keys[eid] = list(data_schematic.keys_of_type("lang_keys", eid))
+            self.annotation_keys[eid] = list(
+                data_schematic.keys_of_type("annotation_keys", eid)
+            )
+            self.action_keys[eid] = list(
+                data_schematic.keys_of_type("action_keys", eid)
+            )
+
+        # ---- Optional pretrained loading per stage ----
+        if stage1_pretrained_checkpoint:
+            self.load_stage1_pretrained(stage1_pretrained_checkpoint)
+        if stage2_pretrained_checkpoint:
+            self.load_stage2_pretrained(stage2_pretrained_checkpoint)
+
+        self._set_active_stage(self.current_stage())
+
+    # --------------------------------------------------------------
+    # Stage scheduling and freezing
+    # --------------------------------------------------------------
+
+    def current_stage(self) -> int:
+        return 1 if self.training_step < self.stage1_steps else 2
+
+    def _set_active_stage(self, stage: int) -> None:
+        s1_train = stage == 1
+        s2_train = stage == 2
+        for p in self.nets["policy"].stage1.parameters():
+            p.requires_grad = s1_train
+        for p in self.nets["policy"].stage2.parameters():
+            p.requires_grad = s2_train
+        self._stage1_frozen = not s1_train
+        self._stage2_frozen = not s2_train
+
+    # --------------------------------------------------------------
+    # Pretrained loading
+    # --------------------------------------------------------------
+
+    @staticmethod
+    def _extract_stage_state_dict(path: str, stage_name: str) -> dict:
+        """Pull a stage's submodule state_dict from a checkpoint, tolerant to
+        the various key prefixes that can appear in disk checkpoints
+        (``state_dict`` wrapper, ``model.``, ``nets.policy.``, etc.).
+        """
+        sd = torch.load(path, map_location="cpu")
+        if isinstance(sd, dict) and "state_dict" in sd:
+            sd = sd["state_dict"]
+
+        marker = f"{stage_name}."
+        out: dict[str, torch.Tensor] = {}
+        for k, v in sd.items():
+            if marker not in k:
+                continue
+            # Take everything *after* the stage marker so we always end up with
+            # keys rooted at the stage submodule (e.g. ``trunk.trunk.blocks.0...``).
+            out[k.split(marker, 1)[1]] = v
+        return out
+
+    def load_stage1_pretrained(self, path: str) -> None:
+        sd = self._extract_stage_state_dict(path, "stage1")
+        missing, unexpected = self.nets["policy"].stage1.load_state_dict(
+            sd, strict=False
+        )
+        print(
+            f"[HPTDinoAE] loaded stage1 from {path}: "
+            f"{len(sd)} matched, {len(missing)} missing, {len(unexpected)} unexpected"
+        )
+
+    def load_stage2_pretrained(self, path: str) -> None:
+        sd = self._extract_stage_state_dict(path, "stage2")
+        missing, unexpected = self.nets["policy"].stage2.load_state_dict(
+            sd, strict=False
+        )
+        print(
+            f"[HPTDinoAE] loaded stage2 from {path}: "
+            f"{len(sd)} matched, {len(missing)} missing, {len(unexpected)} unexpected"
+        )
+
+    # --------------------------------------------------------------
+    # Batch preparation
+    # --------------------------------------------------------------
+
+    def _sample_annotation(self, annotations: list) -> str:
+        """Pick one annotation string out of a per-sample list.
+
+        Training (``self.nets.training``): uniform-random. Eval: take index
+        ``self.eval_annotation_index``, clamped to the last available entry.
+        Empty lists fall back to ``self.default_prompt``.
+        """
+        if not annotations:
+            return self.default_prompt
+        if self.nets.training:
+            return annotations[random.randint(0, len(annotations) - 1)]
+        idx = min(self.eval_annotation_index, len(annotations) - 1)
+        return annotations[idx]
+
+    def _sample_prompts(self, batch_lang_lists) -> list:
+        """list[list[str]] -> list[str]; one annotation per sample."""
+        return [self._sample_annotation(sample) for sample in batch_lang_lists]
+
+    @override
+    def process_batch_for_training(self, batch):
+        """Per-embodiment batch prep. Mode-aware: in training the language
+        prompt is sampled uniformly from each sample's annotation list, in
+        eval mode it's taken at ``eval_annotation_index`` so validation is
+        deterministic.
+        """
+        lang_keys_by_eid = self.lang_keys
+        processed = {}
+        for embodiment_name, _batch in batch.items():
+            eid = get_embodiment_id(embodiment_name)
+            processed[eid] = {}
+            for key, value in _batch.items():
+                key_name = self.data_schematic.zarr_key_to_keyname(key, eid)
+                if key_name is None:
+                    continue
+                processed[eid][key_name] = value
+
+            # Resolve language prompts: list[list[str]] -> list[str].
+            for lkey in lang_keys_by_eid.get(eid, []):
+                value = processed[eid].get(lkey)
+                if isinstance(value, list) and value and isinstance(value[0], list):
+                    processed[eid][lkey] = self._sample_prompts(value)
+
+            processed[eid] = self.data_schematic.normalize_data(processed[eid], eid)
+            processed[eid]["embodiment"] = torch.tensor(
+                [eid], device=self.device, dtype=torch.int64
+            )
+            for key, value in processed[eid].items():
+                if isinstance(value, torch.Tensor):
+                    value = value.to(self.device)
+                    if value.is_floating_point():
+                        value = value.float()
+                    processed[eid][key] = value
+        return processed
+
+    # --------------------------------------------------------------
+    # Stage-specific data routing
+    # --------------------------------------------------------------
+
+    def _build_stage1_data(self, eid: int, batch: dict) -> dict:
+        data: dict = {}
+        # DINO BOS goes through proprio path -> "state_dino_front_1" carrying (B, 1, 1, D).
+        bos_key = "dino_front_1"
+        if bos_key in batch:
+            data[f"state_{bos_key}"] = batch[bos_key].unsqueeze(1)
+
+        # Sampled prompt comes from the t-suffixed annotation list.
+        prompt_key = self._find_first(batch, ["sampled_prompt", "annotations_t"])
+        if prompt_key is not None:
+            data["sampled_prompt"] = batch[prompt_key]
+
+        # EOS DINO is the prediction target.
+        target_key = self.shared_ac_key_stage1
+        if target_key not in batch:
+            raise KeyError(
+                f"Stage 1 target '{target_key}' missing for embodiment {eid}"
+            )
+        target = batch[target_key]
+        if target.ndim == 2:
+            target = target.unsqueeze(1)  # (B, 1, D)
+        data["action"] = target
+        data["embodiment"] = batch["embodiment"]
+        data["pad_mask"] = torch.ones(
+            target.shape[0], target.shape[1], 1, device=target.device
+        )
+        return data
+
+    def _build_stage2_data(
+        self,
+        eid: int,
+        batch: dict,
+        eos_dino_override: torch.Tensor | None = None,
+    ) -> dict:
+        """Build the data dict consumed by Stage 2.
+
+        ``eos_dino_override`` lets the combined-inference path inject the
+        Stage-1 prediction in place of the GT EOS DINO embedding.
+        """
+        data: dict = {}
+
+        # EOS DINO routed as proprio token (GT during training, predicted at
+        # combined inference time).
+        eos_key = "dino_front_T"
+        eos_value = (
+            eos_dino_override if eos_dino_override is not None else batch.get(eos_key)
+        )
+        if eos_value is not None:
+            if eos_value.ndim == 3 and eos_value.shape[1] == 1:
+                eos_value = eos_value.squeeze(1)
+            data[f"state_{eos_key}"] = eos_value.unsqueeze(1)
+
+        # Current-frame images.
+        for key in ("front_img_t", "right_wrist_img_t", "left_wrist_img_t"):
+            if key in batch:
+                tensor = batch[key]
+                if self.nets.training and key in self._stage2_encoders():
+                    tensor = self.train_image_augs(tensor)
+                elif self.eval_image_augs and key in self._stage2_encoders():
+                    tensor = self.eval_image_augs(tensor)
+                data[key] = tensor.unsqueeze(1).unsqueeze(1)
+
+        # Current-frame proprio (e.g. concat'd ``observations.state.ee_pose_t``).
+        for key in self.proprio_keys[eid]:
+            if not key.endswith("_t") or key == "dino_front_t":
+                continue
+            if key in batch:
+                data[f"state_{key}"] = batch[key].unsqueeze(1)
+
+        ac_key = self.shared_ac_key_stage2
+        if ac_key not in batch:
+            raise KeyError(f"Stage 2 target '{ac_key}' missing for embodiment {eid}")
+        data["action"] = batch[ac_key]
+        data["embodiment"] = batch["embodiment"]
+        data["pad_mask"] = torch.ones(
+            data["action"].shape[0], data["action"].shape[1], 1, device=self.device
+        )
+        return data
+
+    def _stage2_encoders(self) -> set:
+        return set(self.nets["policy"].stage2.encoders.keys())
+
+    @staticmethod
+    def _find_first(batch: dict, candidates):
+        for c in candidates:
+            if c in batch:
+                return c
+        return None
+
+    # --------------------------------------------------------------
+    # Forward / loss
+    # --------------------------------------------------------------
+
+    @override
+    def forward_training(self, batch):
+        self.training_step += 1
+        stage = self.current_stage()
+        if (stage == 1 and self._stage1_frozen) or (stage == 2 and self._stage2_frozen):
+            self._set_active_stage(stage)
+
+        predictions = OrderedDict()
+        predictions["stage"] = stage
+        for eid, _batch in batch.items():
+            embodiment_name = get_embodiment(eid).lower()
+            if stage == 1:
+                data = self._build_stage1_data(eid, _batch)
+                hpt_batch = {"domain": "shared", "data": data}
+                loss = self.nets["policy"].stage1.compute_loss(hpt_batch)
+                predictions[f"{embodiment_name}_stage1_loss"] = loss
+            else:
+                data = self._build_stage2_data(eid, _batch)
+                ae_batch = {"domain": embodiment_name, "data": data}
+                loss = self.nets["policy"].stage2.compute_loss(ae_batch)
+                predictions[f"{embodiment_name}_stage2_loss"] = loss
+        return predictions
+
+    @override
+    def compute_losses(self, predictions, batch):
+        loss_dict = OrderedDict()
+        total = torch.tensor(0.0, device=self.device)
+        stage = predictions.get("stage", self.current_stage())
+        for eid in batch:
+            name = get_embodiment(eid).lower()
+            key = f"{name}_stage{stage}_loss"
+            if key in predictions:
+                loss_dict[key] = predictions[key]
+                total = total + predictions[key]
+        loss_dict["action_loss"] = total / max(1, len(batch))
+        loss_dict[f"stage{stage}_active"] = torch.tensor(1.0, device=self.device)
+        return loss_dict
+
+    @override
+    def log_info(self, info):
+        log = OrderedDict()
+        log["Loss"] = info["losses"]["action_loss"].item()
+        for key, value in info["losses"].items():
+            log[key] = value.item() if isinstance(value, torch.Tensor) else value
+        return log
+
+    # --------------------------------------------------------------
+    # Eval
+    # --------------------------------------------------------------
+
+    @override
+    def forward_eval(self, batch):
+        """Active-stage eval forward. Stage 1 returns predicted EOS DINO;
+        Stage 2 returns predicted actions conditioned on GT EOS DINO. The
+        combined Stage1->Stage2 inference path lives in the eval module.
+        """
+        unnorm_preds: dict[str, torch.Tensor] = {}
+        stage = self.current_stage()
+        for eid, _batch in batch.items():
+            embodiment_name = get_embodiment(eid).lower()
+            if stage == 1:
+                data = self._build_stage1_data(eid, _batch)
+                pred = self.nets["policy"].stage1.forward("shared", data)
+                pred_tensor = pred.get("shared", next(iter(pred.values())))
+                T = data["action"].shape[1]
+                D = data["action"].shape[-1]
+                preds = {self.shared_ac_key_stage1: pred_tensor[:, :T, :D]}
+            else:
+                data = self._build_stage2_data(eid, _batch)
+                pred_tensor = self.nets["policy"].stage2.forward(embodiment_name, data)
+                ref = data["action"]
+                T, D = ref.shape[1], ref.shape[-1]
+                preds = {self.shared_ac_key_stage2: pred_tensor[:, :T, :D]}
+
+            unnorm = self.data_schematic.unnormalize_data(preds, eid)
+            for k, v in unnorm.items():
+                unnorm_preds[f"{embodiment_name}_{k}"] = v
+        return unnorm_preds
+
+    def forward_eval_logging(self, batch):
+        preds = self.forward_eval(batch)
+        metrics: dict[str, float] = {}
+        images: dict = {}
+        mse = MeanSquaredError()
+        stage = self.current_stage()
+        for eid, _batch in batch.items():
+            unbatch = self.data_schematic.unnormalize_data(_batch, eid)
+            embodiment_name = get_embodiment(eid).lower()
+            if stage == 1:
+                target_key = self.shared_ac_key_stage1
+            else:
+                target_key = self.shared_ac_key_stage2
+            pk = f"{embodiment_name}_{target_key}"
+            if pk in preds and target_key in unbatch:
+                gt = unbatch[target_key]
+                if gt.ndim == 2:
+                    gt = gt.unsqueeze(1)
+                metrics[f"Valid/{pk}_paired_mse_avg"] = mse(
+                    preds[pk].cpu(), gt.cpu()
+                ).item()
+            images[eid] = None
+        return metrics, images
+
+    def visualize_preds(self, predictions, batch):
+        return None

--- a/egomimic/hydra_configs/data/eva_aria_dino_ae.yaml
+++ b/egomimic/hydra_configs/data/eva_aria_dino_ae.yaml
@@ -1,0 +1,74 @@
+# Inherits the dataset/folder/dataloader scaffolding from cotrain_pi_base
+# and overrides only what changes for the two-stage HPT-DINO pipeline:
+#   - swap S3EpisodeResolver -> S3ActionExpertEpisodeResolver
+#   - add fixed_horizon=100 (action-expert action chunk)
+#   - swap get_keymap -> dino_action_expert_keymap
+#   - swap get_transform_list -> get_dino_ae_transform_list (wrist/head-frame YPR)
+#   - apply the cotrain_pi_lang dense-language pick_place filter
+#   - turn off the loader-side tokenizer (Qwen3 lives in the model)
+
+defaults:
+  - cotrain_pi_base
+  - _self_
+
+train_datasets:
+  eva_bimanual:
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_action_expert.S3ActionExpertEpisodeResolver
+      fixed_horizon: 100
+      key_map:
+        _target_: egomimic.rldb.embodiment.eva.Eva.dino_action_expert_keymap
+      transform_list:
+        _target_: egomimic.rldb.embodiment.eva.Eva.get_dino_ae_transform_list
+        mode: cartesian_wristframe_ypr
+    filters:
+      _target_: egomimic.rldb.filters.ScaleAnnotationDatasetFilter
+      project_name: "dense-language"
+      filter_lambdas:
+        - "lambda row: (row['robot_name'] == 'eva_bimanual') & (row['task'] == 'pick_place') & (row['zarr_processed_path'] != '')"
+  aria_bimanual:
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_action_expert.S3ActionExpertEpisodeResolver
+      fixed_horizon: 100
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Aria.dino_action_expert_keymap
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Aria.get_dino_ae_transform_list
+    filters:
+      _target_: egomimic.rldb.filters.ScaleAnnotationDatasetFilter
+      project_name: "dense-language"
+      filter_lambdas:
+        - "lambda row: (row['robot_name'] == 'aria_bimanual') & (row['task'] == 'pick_place') & (row['zarr_processed_path'] != '')"
+
+valid_datasets:
+  eva_bimanual:
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_action_expert.S3ActionExpertEpisodeResolver
+      fixed_horizon: 100
+      key_map:
+        _target_: egomimic.rldb.embodiment.eva.Eva.dino_action_expert_keymap
+      transform_list:
+        _target_: egomimic.rldb.embodiment.eva.Eva.get_dino_ae_transform_list
+        mode: cartesian_wristframe_ypr
+    filters:
+      _target_: egomimic.rldb.filters.ScaleAnnotationDatasetFilter
+      project_name: "dense-language"
+      filter_lambdas:
+        - "lambda row: (row['robot_name'] == 'eva_bimanual') & (row['task'] == 'pick_place') & (row['zarr_processed_path'] != '')"
+  aria_bimanual:
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_action_expert.S3ActionExpertEpisodeResolver
+      fixed_horizon: 100
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Aria.dino_action_expert_keymap
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Aria.get_dino_ae_transform_list
+    filters:
+      _target_: egomimic.rldb.filters.ScaleAnnotationDatasetFilter
+      project_name: "dense-language"
+      filter_lambdas:
+        - "lambda row: (row['robot_name'] == 'aria_bimanual') & (row['task'] == 'pick_place') & (row['zarr_processed_path'] != '')"
+
+# Qwen3 inside the model consumes raw text, so we don't tokenize in the loader.
+# annotation_collate (the default) will preserve the list-valued annotation keys.
+use_tokenizer: false

--- a/egomimic/hydra_configs/data_schematic/hpt_dino_ae.yaml
+++ b/egomimic/hydra_configs/data_schematic/hpt_dino_ae.yaml
@@ -1,0 +1,66 @@
+_target_: egomimic.rldb.zarr.utils.DataSchematic
+norm_mode: quantile
+schematic_dict:
+  eva_bimanual:
+    # ---- Stage 1 inputs / target ----
+    dino_front_1:                            # BOS DINO embedding (stage 1 stem input)
+      key_type: proprio_keys
+      zarr_key: dino_front_1
+    dino_front_T:                            # EOS DINO embedding (stage 1 target, stage 2 input)
+      key_type: proprio_keys
+      zarr_key: dino_front_T
+    sampled_prompt:                          # annotation text at sampled frame t
+      key_type: lang_keys
+      zarr_key: annotations_t
+
+    # ---- Stage 2 image inputs (frame t) ----
+    front_img_t:
+      key_type: camera_keys
+      zarr_key: front_img_t
+    right_wrist_img_t:
+      key_type: camera_keys
+      zarr_key: right_wrist_img_t
+    left_wrist_img_t:
+      key_type: camera_keys
+      zarr_key: left_wrist_img_t
+
+    # ---- Stage 2 concat'd proprio at t (output of get_dino_ae_transform_list) ----
+    ee_pose_t:
+      key_type: proprio_keys
+      zarr_key: ee_pose_t
+
+    # ---- Stage 2 concat'd action target (wrist-frame YPR, 14d) ----
+    actions_cartesian:
+      key_type: action_keys
+      zarr_key: actions_cartesian
+
+    embodiment:
+      key_type: metadata_keys
+      zarr_key: metadata.embodiment
+
+  aria_bimanual:
+    dino_front_1:
+      key_type: proprio_keys
+      zarr_key: dino_front_1
+    dino_front_T:
+      key_type: proprio_keys
+      zarr_key: dino_front_T
+    sampled_prompt:
+      key_type: lang_keys
+      zarr_key: annotations_t
+
+    front_img_t:
+      key_type: camera_keys
+      zarr_key: front_img_t
+
+    ee_pose_t:
+      key_type: proprio_keys
+      zarr_key: ee_pose_t
+
+    actions_cartesian:
+      key_type: action_keys
+      zarr_key: actions_cartesian
+
+    embodiment:
+      key_type: metadata_keys
+      zarr_key: metadata.embodiment

--- a/egomimic/hydra_configs/model/hpt_dino_ae_flow_robot_head.yaml
+++ b/egomimic/hydra_configs/model/hpt_dino_ae_flow_robot_head.yaml
@@ -1,0 +1,13 @@
+# Stage-2 head variant: predicts robot (eva) actions only.
+# Inherits the full shared-head config and overrides infer_ac_dims to drop aria.
+defaults:
+  - hpt_dino_ae_flow_shared_head
+
+robomimic_model:
+  domains: ["eva_bimanual"]                    # robot-only training
+
+  stage2_head_spec:
+    infer_ac_dims:
+      eva_bimanual: 14
+    model:
+      act_dim: 14

--- a/egomimic/hydra_configs/model/hpt_dino_ae_flow_shared_head.yaml
+++ b/egomimic/hydra_configs/model/hpt_dino_ae_flow_shared_head.yaml
@@ -1,0 +1,268 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hpt_dino_ae.HPTDinoAE
+  data_schematic: _${data.dataset.data_schematic}
+
+  domains: ["eva_bimanual", "aria_bimanual"]
+
+  # ----- Action target keys -----
+  ac_keys:
+    eva_bimanual: actions_cartesian
+    aria_bimanual: actions_cartesian
+  shared_ac_key_stage1: dino_front_T          # stage 1 head predicts EOS DINO
+  shared_ac_key_stage2: actions_cartesian     # stage 2 head predicts actions
+
+  # ----- Training schedule -----
+  stage1_steps: 100000
+  stage2_steps: 100000
+  stage1_pretrained_checkpoint: null
+  stage2_pretrained_checkpoint: null
+
+  # ----- Annotation sampling -----
+  # Training picks a random annotation per sample; eval uses this fixed index
+  # so validation runs are reproducible.
+  eval_annotation_index: 0
+  default_prompt: ""
+
+  camera_transforms:
+    aria_bimanual:
+      _target_: egomimic.utils.egomimicUtils.CameraTransforms
+      intrinsics_key: "base"
+      extrinsics_key: "x5Dec13_2"
+    eva_bimanual:
+      _target_: egomimic.utils.egomimicUtils.CameraTransforms
+      intrinsics_key: "base"
+      extrinsics_key: "x5Dec13_2"
+
+  # ====================================================================
+  # STAGE 1 — World model: BOS DINO + sampled_prompt -> EOS DINO
+  # ====================================================================
+  stage1_trunk:
+    embed_dim: 256
+    num_blocks: 16
+    num_heads: 8
+    token_postprocessing: "action_token"
+    observation_horizon: 1
+    # 196 patch tokens for DINOv3-vitb16 at 224x224 (14*14). One learnable
+    # action token per patch is prepended to the trunk input.
+    action_horizon: 196
+    no_trunk: false
+    use_domain_embedding: false
+    drop_path: 0.1
+    weight_init_style: "pytorch"
+
+  stage1_encoder_specs:
+    sampled_prompt:
+      _target_: egomimic.models.hpt_nets.Qwen3TextEncoder
+      model_name: "Qwen/Qwen3-Embedding-0.6B"
+      max_length: 64
+      freeze_backbone: true                    # set false to fine-tune
+      per_token: false                         # (B, 1, 1024) pooled
+
+  stage1_shared_obs_keys: ["dino_front_1", "sampled_prompt"]
+
+  stage1_shared_stem_specs:
+    dino_front_1:
+      _target_: egomimic.models.hpt_nets.MLPPolicyStem
+      input_dim: 768                           # DINOv3-vitb16 hidden dim
+      output_dim: 256
+      widths: [256]
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 8
+          crossattn_dim_head: 64
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 256
+    sampled_prompt:
+      _target_: egomimic.models.hpt_nets.MLPPolicyStem
+      input_dim: 1024                          # Qwen3-Embedding-0.6B hidden dim
+      output_dim: 256
+      widths: [256]
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 8
+          crossattn_dim_head: 64
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 256
+
+  stage1_head_specs:
+    shared:
+      _target_: egomimic.models.fm_policy.FMPolicy
+      action_horizon: 196                      # one prediction per DINO patch
+      num_inference_steps: 50
+      pooling: null
+      padding: null
+      time_dist: "beta"
+      infer_ac_dims:
+        shared: 768                            # DINO hidden dim
+      model:
+        _target_: egomimic.models.denoising_nets.CrossTransformer
+        nblocks: 6
+        cond_dim: 256
+        hidden_dim: 128
+        act_dim: 768                           # DINO hidden dim
+        act_seq: 196                           # patch grid length
+        n_heads: 4
+        dropout: 0.1
+        mlp_layers: 4
+        mlp_ratio: 4
+
+  # ====================================================================
+  # STAGE 2 — Action expert: GT EOS DINO + obs_t -> actions  (no trunk)
+  # ====================================================================
+  stage2_encoder_specs:
+    front_img_t:
+      _target_: egomimic.models.hpt_nets.ResNet
+      output_dim: 256
+      num_of_copy: 1
+    right_wrist_img_t:
+      _target_: egomimic.models.hpt_nets.ResNet
+      output_dim: 256
+      num_of_copy: 1
+    left_wrist_img_t:
+      _target_: egomimic.models.hpt_nets.ResNet
+      output_dim: 256
+      num_of_copy: 1
+
+  stage2_shared_obs_keys: ["dino_front_T", "front_img_t"]
+
+  stage2_shared_stem_specs:
+    dino_front_T:
+      _target_: egomimic.models.hpt_nets.MLPPolicyStem
+      input_dim: 768
+      output_dim: 256
+      widths: [256]
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 8
+          crossattn_dim_head: 64
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 256
+    front_img_t:
+      _target_: egomimic.models.hpt_nets.MLPPolicyStem
+      input_dim: 256
+      output_dim: 256
+      widths: [256]
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 8
+          crossattn_dim_head: 64
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 256
+
+  stage2_stem_specs:
+    eva_bimanual:
+      right_wrist_img_t:
+        _target_: egomimic.models.hpt_nets.MLPPolicyStem
+        input_dim: 256
+        output_dim: 256
+        widths: [256]
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 8
+            crossattn_dim_head: 64
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 256
+      left_wrist_img_t:
+        _target_: egomimic.models.hpt_nets.MLPPolicyStem
+        input_dim: 256
+        output_dim: 256
+        widths: [256]
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 8
+            crossattn_dim_head: 64
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 256
+      state_ee_pose_t:
+        _target_: egomimic.models.hpt_nets.MLPPolicyStem
+        input_dim: 14                          # YPR concat (6+1+6+1)
+        output_dim: 256
+        widths: [256]
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 8
+            crossattn_dim_head: 64
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 256
+
+    aria_bimanual:
+      state_ee_pose_t:
+        _target_: egomimic.models.hpt_nets.MLPPolicyStem
+        input_dim: 14                          # YPR concat (6+1+6+1) for aria
+        output_dim: 256
+        widths: [256]
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 8
+            crossattn_dim_head: 64
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 256
+
+  stage2_head_spec:
+    _target_: egomimic.models.fm_policy.FMPolicy
+    action_horizon: 100
+    num_inference_steps: 50
+    pooling: null
+    padding: "zero"
+    time_dist: "beta"
+    infer_ac_dims:
+      eva_bimanual: 14                         # YPR (6+1+6+1)
+      aria_bimanual: 14                        # YPR (6+1+6+1)
+    model:
+      _target_: egomimic.models.denoising_nets.CrossTransformer
+      nblocks: 6
+      cond_dim: 256
+      hidden_dim: 128
+      act_dim: 14
+      act_seq: 100
+      n_heads: 4
+      dropout: 0.1
+      mlp_layers: 4
+      mlp_ratio: 4
+
+  train_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+      - _target_: torchvision.transforms.ColorJitter
+        brightness: 0.1
+        contrast: 0.1
+        saturation: 0.1
+        hue: 0.05
+      - _target_: torchvision.transforms.Normalize
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+  eval_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+      - _target_: torchvision.transforms.Normalize
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+  _partial_: true
+  T_max: 1400
+  eta_min: 1e-5

--- a/egomimic/hydra_configs/train_zarr_dino_ae.yaml
+++ b/egomimic/hydra_configs/train_zarr_dino_ae.yaml
@@ -1,0 +1,38 @@
+defaults:
+  - model: hpt_dino_ae_flow_shared_head
+  - visualization: dino_ae
+  - paths: default
+  - trainer: ddp
+  - debug: null
+  - logger: wandb
+  - data: eva_aria_dino_ae
+  - callbacks: checkpoints
+  - data_schematic: hpt_dino_ae
+  - evaluator: eval_hpt_dino_ae
+  - override hydra/launcher: submitit
+  - _self_
+
+name: hpt_dino_ae
+description: dino_ae
+ckpt_path: null
+mode: train
+
+hydra:
+  run:
+    dir: ./logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}
+  sweep:
+    dir: ./logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}
+
+launch_params:
+  gpus_per_node: 1
+  nodes: 1
+
+seed: 42
+
+# Normalization and norm-stat cache settings (override per-run as needed).
+norm_stats:
+  sample_frac: 1.0
+  num_workers: 4
+  save_cache_dir: ${hydra:runtime.output_dir}
+  precomputed_norm_path: null
+reject_outliers: true

--- a/egomimic/hydra_configs/visualization/dino_ae.yaml
+++ b/egomimic/hydra_configs/visualization/dino_ae.yaml
@@ -1,0 +1,12 @@
+eva_bimanual:
+  _target_: egomimic.rldb.embodiment.eva.Eva.viz_gt_preds
+  _partial_: true
+  image_key: front_img_t
+  action_key: actions_cartesian
+  mode: traj
+aria_bimanual:
+  _target_: egomimic.rldb.embodiment.human.Aria.viz_gt_preds
+  _partial_: true
+  image_key: front_img_t
+  action_key: actions_cartesian
+  mode: traj

--- a/egomimic/models/hpt_nets.py
+++ b/egomimic/models/hpt_nets.py
@@ -187,9 +187,9 @@ class BlockWithMasking(nn.Module):
     ):
         super().__init__()
 
-        assert not isinstance(attn_target, nn.Module), (
-            "attn_target should be a Callable. Otherwise attn_target is shared across blocks!"
-        )
+        assert not isinstance(
+            attn_target, nn.Module
+        ), "attn_target should be a Callable. Otherwise attn_target is shared across blocks!"
         self.attn = attn_target()
         if drop_path > 0.0:
             self.drop_path = DropPath(drop_path)
@@ -694,6 +694,93 @@ class T5Encoder(PolicyStem):
         else:
             emb = output.last_hidden_state.mean(dim=1).detach().unsqueeze(1)
             return emb
+
+
+class Qwen3TextEncoder(PolicyStem):
+    """Qwen3-Embedding-0.6B encoder. Tokenizes raw strings on the fly.
+
+    Inputs from the dataloader are expected as ``list[str]`` (one prompt per
+    sample), or ``list[list[str]]`` from the annotation collator — in which
+    case the first annotation per sample is used.
+
+    Output:
+      - per_token=False (default): ``(B, 1, hidden)`` last-token-pooled, L2-normalized
+      - per_token=True:             ``(B, L, hidden)`` raw last-hidden-states
+    """
+
+    def __init__(
+        self,
+        model_name: str = "Qwen/Qwen3-Embedding-0.6B",
+        max_length: int = 128,
+        freeze_backbone: bool = True,
+        per_token: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        from transformers import AutoModel, AutoTokenizer
+
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
+        self.model = AutoModel.from_pretrained(model_name)
+        self.max_length = max_length
+        self.per_token = per_token
+        self.freeze_backbone = freeze_backbone
+        self.hidden_dim = int(self.model.config.hidden_size)
+
+        if freeze_backbone:
+            for p in self.model.parameters():
+                p.requires_grad = False
+            self.model.eval()
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        if self.freeze_backbone:
+            self.model.eval()
+        return self
+
+    @staticmethod
+    def _flatten(texts):
+        flat = []
+        for t in texts:
+            if isinstance(t, (list, tuple)):
+                flat.append(t[0] if len(t) > 0 else "")
+            elif t is None:
+                flat.append("")
+            else:
+                flat.append(t)
+        return flat
+
+    @staticmethod
+    def _last_token_pool(last_hidden: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        left_padded = bool((mask[:, -1].sum() == mask.shape[0]).item())
+        if left_padded:
+            return last_hidden[:, -1]
+        seq_lens = mask.sum(dim=1) - 1
+        batch_idx = torch.arange(last_hidden.size(0), device=last_hidden.device)
+        return last_hidden[batch_idx, seq_lens]
+
+    def forward(self, texts) -> torch.Tensor:
+        flat = self._flatten(texts)
+        device = next(self.model.parameters()).device
+        tokens = self.tokenizer(
+            flat,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="pt",
+        ).to(device)
+
+        if self.freeze_backbone:
+            with torch.no_grad():
+                out = self.model(**tokens)
+        else:
+            out = self.model(**tokens)
+
+        if self.per_token:
+            return out.last_hidden_state
+
+        pooled = self._last_token_pool(out.last_hidden_state, tokens["attention_mask"])
+        pooled = F.normalize(pooled.float(), p=2, dim=1)
+        return pooled.unsqueeze(1)
 
 
 def vit_base_patch16(checkpoint_path="output/mae_pretrain_vit_base.pth", **kwargs):

--- a/egomimic/rldb/embodiment/eva.py
+++ b/egomimic/rldb/embodiment/eva.py
@@ -95,6 +95,110 @@ class Eva(Embodiment):
         return key_map
 
     @classmethod
+    def get_dino_ae_transform_list(
+        cls, mode: str = "cartesian_wristframe_ypr", **kwargs
+    ):
+        """Wrist-frame YPR transform adapted to the action-expert dataset's
+        ``_t``-suffixed proprio keys. Outputs:
+          - ``actions_cartesian``           (B, 100, 14) wrist-frame YPR
+          - ``observations.state.ee_pose_t`` (B, 14)     concat'd current proprio
+        """
+        is_quat = mode == "cartesian_wristframe_quat"
+        return _build_eva_bimanual_eef_frame_transform_list(
+            left_obs_pose="left.obs_ee_pose_t",
+            right_obs_pose="right.obs_ee_pose_t",
+            left_obs_gripper="left.obs_gripper_t",
+            right_obs_gripper="right.obs_gripper_t",
+            obs_key="ee_pose_t",  # dot-free: nn.ModuleDict rejects "." in keys
+            is_quat=is_quat,
+        )
+
+    @classmethod
+    def dino_action_expert_keymap(
+        cls,
+        annotation_key: str = "annotations",
+        norm_mode: bool = False,
+        **kwargs,
+    ):
+        """Keymap for the two-stage HPT-DINO action-expert pipeline on EVA.
+
+        Suffix expansion is handled by ZarrActionExpertDataset, which emits
+        ``<key>_1`` (BOS), ``<key>_t`` (current), and ``<key>_T`` (EOS) for
+        each camera/proprio entry, and per-frame text for annotation entries.
+
+        ``norm_mode=True`` strips camera/annotation keys (matching the
+        behavior of ``Embodiment.get_keymap``) so the norm-stats DataLoader
+        only reads numeric proprio/action keys — variable-length annotation
+        lists would otherwise crash ``default_collate``.
+        """
+        key_map = {
+            "dino_front_1": {
+                "key_type": "proprio_keys",
+                "zarr_key": "dino.front_1",
+            },
+            annotation_key: {
+                "key_type": "annotation_keys",
+                "zarr_key": annotation_key,
+            },
+            "front_img": {
+                "key_type": "camera_keys",
+                "zarr_key": "images.front_1",
+            },
+            "right_wrist_img": {
+                "key_type": "camera_keys",
+                "zarr_key": "images.right_wrist",
+            },
+            "left_wrist_img": {
+                "key_type": "camera_keys",
+                "zarr_key": "images.left_wrist",
+            },
+            "right.obs_ee_pose": {
+                "key_type": "proprio_keys",
+                "zarr_key": "right.obs_ee_pose",
+            },
+            "right.obs_gripper": {
+                "key_type": "proprio_keys",
+                "zarr_key": "right.obs_gripper",
+            },
+            "left.obs_ee_pose": {
+                "key_type": "proprio_keys",
+                "zarr_key": "left.obs_ee_pose",
+            },
+            "left.obs_gripper": {
+                "key_type": "proprio_keys",
+                "zarr_key": "left.obs_gripper",
+            },
+            "right.cmd_ee_pose": {
+                "key_type": "action_keys",
+                "zarr_key": "right.cmd_ee_pose",
+                "horizon": 100,
+            },
+            "right.cmd_gripper": {
+                "key_type": "action_keys",
+                "zarr_key": "right.cmd_gripper",
+                "horizon": 100,
+            },
+            "left.cmd_ee_pose": {
+                "key_type": "action_keys",
+                "zarr_key": "left.cmd_ee_pose",
+                "horizon": 100,
+            },
+            "left.cmd_gripper": {
+                "key_type": "action_keys",
+                "zarr_key": "left.cmd_gripper",
+                "horizon": 100,
+            },
+        }
+        if norm_mode:
+            for k in [
+                kk
+                for kk, v in key_map.items()
+                if v.get("key_type") in ("camera_keys", "annotation_keys")
+            ]:
+                del key_map[k]
+        return key_map
+
+    @classmethod
     def dinov3_keymap(cls):
         """
         Compact keymap for alignment training: cartesian action chunk, the

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -152,6 +152,81 @@ class Aria(Human):
             )
 
     @classmethod
+    def get_dino_ae_transform_list(cls, mode: str = "cartesian", **kwargs):
+        """Aria head-frame transform adapted to the action-expert dataset's
+        ``_t``-suffixed proprio keys. Outputs:
+          - ``actions_cartesian``           (B, 100, 14) head-frame YPR
+          - ``observations.state.ee_pose_t`` (B, 14)     concat'd current proprio
+        """
+        return _build_aria_cartesian_bimanual_transform_list(
+            target_world="obs_head_pose_t",
+            target_world_ypr="obs_head_pose_ypr_t",
+            left_obs_pose="left.obs_ee_pose_t",
+            right_obs_pose="right.obs_ee_pose_t",
+            obs_key="ee_pose_t",  # dot-free: nn.ModuleDict rejects "." in keys
+            stride=cls.ACTION_STRIDE,
+        )
+
+    @classmethod
+    def dino_action_expert_keymap(
+        cls,
+        annotation_key: str = "annotations",
+        norm_mode: bool = False,
+        **kwargs,
+    ):
+        """Keymap for the two-stage HPT-DINO action-expert pipeline on Aria.
+
+        ``norm_mode=True`` strips camera/annotation keys (matching the
+        behavior of ``Embodiment.get_keymap``) so the norm-stats DataLoader
+        only reads numeric proprio/action keys — variable-length annotation
+        lists would otherwise crash ``default_collate``.
+        """
+        key_map = {
+            "dino_front_1": {
+                "key_type": "proprio_keys",
+                "zarr_key": "dino.front_1",
+            },
+            annotation_key: {
+                "key_type": "annotation_keys",
+                "zarr_key": annotation_key,
+            },
+            "front_img": {
+                "key_type": "camera_keys",
+                "zarr_key": "images.front_1",
+            },
+            "right.obs_ee_pose": {
+                "key_type": "proprio_keys",
+                "zarr_key": "right.obs_ee_pose",
+            },
+            "left.obs_ee_pose": {
+                "key_type": "proprio_keys",
+                "zarr_key": "left.obs_ee_pose",
+            },
+            "obs_head_pose": {
+                "key_type": "proprio_keys",
+                "zarr_key": "obs_head_pose",
+            },
+            "right.action_ee_pose": {
+                "key_type": "action_keys",
+                "zarr_key": "right.obs_ee_pose",
+                "horizon": 100,
+            },
+            "left.action_ee_pose": {
+                "key_type": "action_keys",
+                "zarr_key": "left.obs_ee_pose",
+                "horizon": 100,
+            },
+        }
+        if norm_mode:
+            for k in [
+                kk
+                for kk, v in key_map.items()
+                if v.get("key_type") in ("camera_keys", "annotation_keys")
+            ]:
+                del key_map[k]
+        return key_map
+
+    @classmethod
     def _get_keymap(
         cls,
         keymap_mode: Literal["cartesian", "keypoints"],
@@ -336,7 +411,7 @@ class Mecka(Human):
             return _build_aria_cartesian_bimanual_transform_list(
                 stride=cls.ACTION_STRIDE
             )
-    
+
     @classmethod
     def get_keymap(
         cls, mode: Literal["cartesian", "keypoints"], annotations: bool = False

--- a/egomimic/rldb/zarr/zarr_dataset_action_expert.py
+++ b/egomimic/rldb/zarr/zarr_dataset_action_expert.py
@@ -11,6 +11,7 @@ Sampling scheme:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -26,6 +27,8 @@ from egomimic.rldb.zarr.zarr_dataset_multi import (
     ZarrEpisode,
     get_fallback_idx,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ZarrActionExpertDataset",
@@ -64,13 +67,20 @@ class ZarrActionExpertDataset(ZarrDataset):
     # --- episode setup -----------------------------------------------------
 
     def _load_annotation_map(self) -> dict[int, int]:
-        """Build {frame_idx -> annotation_index} for every frame inside an annotation span."""
+        """Build {frame_idx -> annotation_index} for every frame inside an annotation span.
+
+        ``end_idx`` is clamped to ``total_frames - 1`` because some annotation
+        sources record it Python-style (exclusive); without the clamp the last
+        frame index can land one past the end of the zarr arrays and crash
+        downstream reads.
+        """
         raw = self.episode_reader._store["annotations"][:]
         decoded = [self._decode_json_entry(x) for x in raw]
         self._annotations = [d for d in decoded if isinstance(d, dict)]
+        last_valid = int(self.metadata["total_frames"]) - 1
         for i, ann in enumerate(self._annotations):
             start_idx = int(ann.get("start_idx", -1))
-            end_idx = int(ann.get("end_idx", -1))
+            end_idx = min(int(ann.get("end_idx", -1)), last_valid)
             for idx in range(start_idx, end_idx + 1):
                 self.annotation_map[idx] = i
         return self.annotation_map
@@ -103,8 +113,10 @@ class ZarrActionExpertDataset(ZarrDataset):
         """Load the t..EOS action chunk, padded to ``horizon``.
 
         If ``self.fixed_horizon`` is an int H, that overrides ``horizon``: the
-        read is clamped to EOS and zero-padded out to length H so a sample
-        never includes actions from the next segment.
+        read is clamped to EOS and padded out to length H by repeating the
+        last valid frame so a sample never includes actions from the next
+        segment AND never contains zero-norm quaternions (which would crash
+        scipy.spatial.transform.Rotation in downstream transforms).
         """
         episode_end = self._episode_total_frames
 
@@ -112,8 +124,12 @@ class ZarrActionExpertDataset(ZarrDataset):
             H = self.fixed_horizon
             end = min(t + H, eos + 1, episode_end)
             arr = self.episode_reader.read({zarr_key: (t, end)})[zarr_key]
+            if arr.shape[0] == 0:
+                raise ValueError(
+                    f"Empty action read for zarr_key={zarr_key} t={t} end={end}"
+                )
             if arr.shape[0] < H:
-                pad = np.zeros((H - arr.shape[0], *arr.shape[1:]), dtype=arr.dtype)
+                pad = np.repeat(arr[-1:], H - arr.shape[0], axis=0)
                 arr = np.concatenate([arr, pad], axis=0)
             return arr
 
@@ -122,68 +138,99 @@ class ZarrActionExpertDataset(ZarrDataset):
         self._pad_sequences(raw, horizon)
         return raw[zarr_key]
 
-    def _resample(self, index, _fallback_origin, _attempts) -> dict:
-        origin = _fallback_origin if _fallback_origin is not None else index
-        next_idx, attempts = get_fallback_idx(
-            idx=index,
-            candidates=range(self.total_frames),
-            _attempts=_attempts,
-            max_attempts=self.total_frames,
-            exhausted_error=(
-                f"Entire episode bad (no valid indices): ep={Path(self.episode_path).name}"
-            ),
-        )
-        return self.__getitem__(next_idx, _fallback_origin=origin, _attempts=attempts)
+    def _load_sample(self, t: int, bos: int, eos: int) -> dict:
+        """Build the per-sample data dict for the chosen (bos, t, eos)."""
+        data: dict = {}
+        for k, spec in self.key_map.items():
+            zarr_key = spec["zarr_key"]
+            key_type = spec.get("key_type")
+            bos_key, t_key, eos_key = _obs_key_triple(k)
+
+            if key_type == "annotation_keys":
+                data[bos_key] = self._annotation_text_for_frame(bos)
+                data[t_key] = self._annotation_text_for_frame(t)
+                data[eos_key] = self._annotation_text_for_frame(eos)
+            elif key_type == "action_keys":
+                data[k] = self._load_actions(zarr_key, t, eos, spec.get("horizon"))
+            else:  # camera_keys / proprio_keys: sample BOS, t, and EOS.
+                data[bos_key] = self._load_obs_at(zarr_key, bos)
+                data[t_key] = self._load_obs_at(zarr_key, t)
+                data[eos_key] = self._load_obs_at(zarr_key, eos)
+
+        aliases: list[str] = []
+        if self.transform:
+            for k, spec in self.key_map.items():
+                if spec.get("key_type") in _OBS_KEY_TYPES:
+                    _, t_key, _ = _obs_key_triple(k)
+                    if t_key in data:
+                        data[k] = data[t_key]
+                        aliases.append(k)
+            for transform in self.transform:
+                data = transform.transform(data)
+            for alias in aliases:
+                data.pop(alias, None)
+        return data
 
     # --- main entrypoint ---------------------------------------------------
 
-    def __getitem__(self, index: int, _fallback_origin=None, _attempts=None) -> dict:
+    def __getitem__(self, index: int) -> dict:
         """Returns a single action-expert sample.
+
+        Resamples (iteratively, not recursively) up to ``total_frames`` times
+        when a sample fails to load — bad JPEG, transform failure, missing
+        key, etc. The original error is logged at WARNING the first time it
+        occurs per failed index so silent failures don't go unnoticed.
 
         Output keys:
           - Obs (camera/proprio): <key>_1 (BOS), <key>_t (frame t), <key>_T (EOS)
           - Annotations:          <key>_1 (BOS), <key>_t (frame t), <key>_T (EOS)
           - Actions:              <key>  (t..EOS, padded to horizon)
         """
-        t = self._valid_frame_indices[index]
-        ann = self._annotations[self.annotation_map[t]]
-        bos, eos = int(ann["start_idx"]), int(ann["end_idx"])
-
-        try:
-            data: dict = {}
-            for k, spec in self.key_map.items():
-                zarr_key = spec["zarr_key"]
-                key_type = spec.get("key_type")
-                bos_key, t_key, eos_key = _obs_key_triple(k)
-
-                if key_type == "annotation_keys":
-                    data[bos_key] = self._annotation_text_for_frame(bos)
-                    data[t_key] = self._annotation_text_for_frame(t)
-                    data[eos_key] = self._annotation_text_for_frame(eos)
-                elif key_type == "action_keys":
-                    data[k] = self._load_actions(zarr_key, t, eos, spec.get("horizon"))
-                else:  # camera_keys / proprio_keys: sample BOS, t, and EOS.
-                    data[bos_key] = self._load_obs_at(zarr_key, bos)
-                    data[t_key] = self._load_obs_at(zarr_key, t)
-                    data[eos_key] = self._load_obs_at(zarr_key, eos)
-
-            # Transforms expect obs at the canonical key (not <key>_t), so
-            # alias <key>_t -> <key> for the pass and drop afterward.
-            aliases: list[str] = []
-            if self.transform:
-                for k, spec in self.key_map.items():
-                    if spec.get("key_type") in _OBS_KEY_TYPES:
-                        _, t_key, _ = _obs_key_triple(k)
-                        if t_key in data:
-                            data[k] = data[t_key]
-                            aliases.append(k)
-                for transform in self.transform:
-                    data = transform.transform(data)
-                for alias in aliases:
-                    data.pop(alias, None)
-        except Exception:
-            # Bad JPEG or transform failure -> resample.
-            return self._resample(index, _fallback_origin, _attempts)
+        attempts = 0
+        cur_idx = index
+        max_attempts = max(1, self.total_frames)
+        last_exc: Exception | None = None
+        while attempts < max_attempts:
+            t = self._valid_frame_indices[cur_idx]
+            ann = self._annotations[self.annotation_map[t]]
+            bos = int(ann["start_idx"])
+            # Clamp EOS to the last valid frame: annotation end_idx is sometimes
+            # Python-style exclusive and equals total_frames, which would crash
+            # _load_obs_at when reading the EOS frame.
+            eos = min(int(ann["end_idx"]), self._episode_total_frames - 1)
+            try:
+                data = self._load_sample(t, bos, eos)
+                break
+            except Exception as e:
+                last_exc = e
+                if attempts == 0:
+                    logger.warning(
+                        "[ZarrActionExpertDataset] sample failed at "
+                        "ep=%s idx=%d (t=%d, bos=%d, eos=%d): %r",
+                        Path(self.episode_path).name,
+                        cur_idx,
+                        t,
+                        bos,
+                        eos,
+                        e,
+                    )
+                next_idx, _ = get_fallback_idx(
+                    idx=cur_idx,
+                    candidates=range(self.total_frames),
+                    _attempts=attempts + 1,
+                    max_attempts=max_attempts,
+                    exhausted_error=(
+                        f"Entire episode bad (no valid indices): "
+                        f"ep={Path(self.episode_path).name}; last error: {last_exc!r}"
+                    ),
+                )
+                cur_idx = next_idx
+                attempts += 1
+        else:
+            raise RuntimeError(
+                f"Entire episode bad (no valid indices): "
+                f"ep={Path(self.episode_path).name}; last error: {last_exc!r}"
+            )
 
         for k, v in data.items():
             if isinstance(v, np.ndarray):

--- a/egomimic/rldb/zarr/zarr_dataset_multi.py
+++ b/egomimic/rldb/zarr/zarr_dataset_multi.py
@@ -27,7 +27,7 @@ import random
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 import numpy as np
 import pandas as pd
@@ -39,7 +39,13 @@ from egomimic.rldb.embodiment.embodiment import get_embodiment_id
 
 # from action_chunk_transforms import Transform
 from egomimic.rldb.filters import DatasetFilter
-from egomimic.rldb.zarr.zarr_dataset_action_expert import ZarrActionExpertDataset
+
+if TYPE_CHECKING:
+    # Annotation-only import — avoids a runtime circular import with
+    # zarr_dataset_action_expert (which itself imports MultiDataset from here).
+    from egomimic.rldb.zarr.zarr_dataset_action_expert import (
+        ZarrActionExpertDataset,
+    )
 from egomimic.utils.aws.aws_data_utils import load_env
 from egomimic.utils.aws.aws_sql import (
     create_default_engine,


### PR DESCRIPTION
Two-stage policy:
- Stage 1 (world model with trunk): BOS DINO + sampled language prompt -> EOS
  DINO via shared FMPolicy flow head. With patch-token DINO embeddings
  (N=196 for ViT-B/16 at 224x224), action_horizon and act_seq are 196 and
  act_dim is the DINO hidden dim (768).
- Stage 2 (action expert, no trunk): GT EOS DINO + obs_t (front + wrist + 14d
  wrist-frame YPR proprio) -> 100-step action chunk via shared FMPolicy.
Training is staged, not joint: stage1_steps then stage2_steps, with each
stage's pretrained weights loadable independently.

Adds:
- HPTDinoAE algo + ActionExpertModel (egomimic/algo/hpt_dino_ae.py).
  Mode-aware annotation sampling: random during training,
  eval_annotation_index during validation. Robust pretrained loading
  tolerant to state_dict / nets.policy. prefixes.
- Qwen3TextEncoder stem with freeze_backbone toggle (egomimic/models/hpt_nets.py).
- Eva/Aria dino_action_expert keymaps + get_dino_ae_transform_list.
  Keymaps respect norm_mode=True (drops camera + annotation keys for the
  norm-stats DataLoader, which uses default_collate and would otherwise
  crash on variable-length annotation lists).
- Action-expert dataset hardening: iterative resample (no recursion),
  last-frame action padding (avoids zero-norm quaternions in scipy),
  EOS clamp to total_frames-1 (handles Python-style exclusive end_idx),
  TYPE_CHECKING import to break the multi <-> action_expert circular cycle.
- Data schematic + data + model (shared head) + top-level train + viz
  configs for the two-stage pipeline. eva_aria_dino_ae.yaml inherits from
  cotrain_pi_base and overrides only the resolver, key_map, transform_list
  and filters.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>