### PR TITLE
Add Aria cartesian_wristframe_ypr mode + viz config

### DIFF
--- a/egomimic/hydra_configs/visualization/cartesian_wrist.yaml
+++ b/egomimic/hydra_configs/visualization/cartesian_wrist.yaml
@@ -1,0 +1,18 @@
+eva_bimanual:
+  _target_: egomimic.rldb.embodiment.eva.Eva.viz_gt_preds
+  _partial_: true
+  image_key: front_img_1
+  action_key: actions_cartesian
+  mode: traj
+  transform_list:
+    _target_: egomimic.rldb.embodiment.eva._build_eva_bimanual_revert_eef_frame_transform_list
+    is_quat: false
+aria_bimanual:
+  _target_: egomimic.rldb.embodiment.human.Aria.viz_gt_preds
+  _partial_: true
+  image_key: front_img_1
+  action_key: actions_cartesian
+  mode: traj
+  transform_list:
+    _target_: egomimic.rldb.embodiment.human._build_aria_cartesian_revert_eef_frame_transform_list
+    is_quat: false

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -124,6 +124,7 @@ class Aria(Human):
         cls,
         mode: Literal[
             "cartesian",
+            "cartesian_wristframe_ypr",
             "keypoints_headframe_ypr",
             "keypoints_headframe_quat",
             "keypoints_wristframe_ypr",
@@ -132,6 +133,10 @@ class Aria(Human):
     ) -> list[Transform]:
         if mode == "cartesian":
             return _build_aria_cartesian_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE
+            )
+        elif mode == "cartesian_wristframe_ypr":
+            return _build_aria_cartesian_eef_frame_transform_list(
                 stride=cls.ACTION_STRIDE
             )
         elif mode == "keypoints_headframe_ypr":
@@ -336,7 +341,7 @@ class Mecka(Human):
             return _build_aria_cartesian_bimanual_transform_list(
                 stride=cls.ACTION_STRIDE
             )
-    
+
     @classmethod
     def get_keymap(
         cls, mode: Literal["cartesian", "keypoints"], annotations: bool = False
@@ -924,6 +929,183 @@ def _build_aria_keypoints_bimanual_transform_list(
                 DeleteKeys(keys_to_delete=keys_to_delete),
             ]
         )
+    return transform_list
+
+
+def _build_aria_cartesian_revert_eef_frame_transform_list(
+    *,
+    action_key: str = "actions_cartesian",
+    obs_key: str = "observations.state.ee_pose",
+    left_action_wristframe: str = "left.action_ee_pose_wristframe",
+    right_action_wristframe: str = "right.action_ee_pose_wristframe",
+    left_obs_headframe: str = "left.obs_ee_pose_headframe",
+    right_obs_headframe: str = "right.obs_ee_pose_headframe",
+    left_action_headframe: str = "left.action_ee_pose_headframe",
+    right_action_headframe: str = "right.action_ee_pose_headframe",
+    is_quat: bool = False,
+) -> list[Transform]:
+    """Revert wrist-frame ARIA cartesian actions back to head (camera) frame.
+
+    Inverse of ``_build_aria_cartesian_eef_frame_transform_list`` for viz: the
+    action chunks live in each side's wrist frame, the proprio ee-poses live in
+    headframe (= Aria camera frame). Re-composes ``target_headframe @ chunk_wristframe``
+    so action chunks are back in headframe / camera frame.
+    """
+    pose_shape = 7 if is_quat else 6
+    mode = "xyzwxyz" if is_quat else "xyzypr"
+    transform_list = [
+        SplitKeys(
+            input_key=obs_key,
+            output_key_list=[
+                (left_obs_headframe, pose_shape),
+                (right_obs_headframe, pose_shape),
+            ],
+        ),
+        SplitKeys(
+            input_key=action_key,
+            output_key_list=[
+                (left_action_wristframe, pose_shape),
+                (right_action_wristframe, pose_shape),
+            ],
+        ),
+        ActionChunkCoordinateFrameTransform(
+            target_world=left_obs_headframe,
+            chunk_world=left_action_wristframe,
+            transformed_key_name=left_action_headframe,
+            mode=mode,
+            inverse=False,
+        ),
+        ActionChunkCoordinateFrameTransform(
+            target_world=right_obs_headframe,
+            chunk_world=right_action_wristframe,
+            transformed_key_name=right_action_headframe,
+            mode=mode,
+            inverse=False,
+        ),
+        ConcatKeys(
+            key_list=[left_action_headframe, right_action_headframe],
+            new_key_name=action_key,
+            delete_old_keys=True,
+        ),
+    ]
+    return transform_list
+
+
+def _build_aria_cartesian_eef_frame_transform_list(
+    *,
+    target_world: str = "obs_head_pose",
+    target_world_ypr: str = "obs_head_pose_ypr",
+    target_world_is_quat: bool = True,
+    left_action_world: str = "left.action_ee_pose",
+    right_action_world: str = "right.action_ee_pose",
+    left_obs_pose: str = "left.obs_ee_pose",
+    right_obs_pose: str = "right.obs_ee_pose",
+    left_action_headframe: str = "left.action_ee_pose_headframe",
+    right_action_headframe: str = "right.action_ee_pose_headframe",
+    left_obs_headframe: str = "left.obs_ee_pose_headframe",
+    right_obs_headframe: str = "right.obs_ee_pose_headframe",
+    left_action_wristframe: str = "left.action_ee_pose_wristframe",
+    right_action_wristframe: str = "right.action_ee_pose_wristframe",
+    actions_key: str = "actions_cartesian",
+    obs_key: str = "observations.state.ee_pose",
+    chunk_length: int = 100,
+    stride: int = 3,
+    delete_target_world: bool = True,
+) -> list[Transform]:
+    """ARIA bimanual cartesian pipeline expressed in the current wrist frame.
+
+    Action ee-pose chunks are first transformed world → headframe (via
+    ``obs_head_pose``), then headframe → wristframe (via the proprio
+    ``*.obs_ee_pose_headframe`` for each side). Proprio ee-poses remain in
+    headframe (wristframe of the wrist itself is identity). All retained poses
+    are converted to xyz-ypr.
+    """
+    keys_to_delete = list(
+        {
+            left_action_world,
+            right_action_world,
+            left_obs_pose,
+            right_obs_pose,
+            left_action_headframe,
+            right_action_headframe,
+        }
+    )
+    if delete_target_world:
+        keys_to_delete.append(target_world)
+        if target_world_is_quat:
+            keys_to_delete.append(target_world_ypr)
+
+    transform_list: list[Transform] = [
+        ActionChunkCoordinateFrameTransform(
+            target_world=target_world,
+            chunk_world=left_action_world,
+            transformed_key_name=left_action_headframe,
+            mode="xyzwxyz",
+        ),
+        ActionChunkCoordinateFrameTransform(
+            target_world=target_world,
+            chunk_world=right_action_world,
+            transformed_key_name=right_action_headframe,
+            mode="xyzwxyz",
+        ),
+        PoseCoordinateFrameTransform(
+            target_world=target_world,
+            pose_world=left_obs_pose,
+            transformed_key_name=left_obs_headframe,
+            mode="xyzwxyz",
+        ),
+        PoseCoordinateFrameTransform(
+            target_world=target_world,
+            pose_world=right_obs_pose,
+            transformed_key_name=right_obs_headframe,
+            mode="xyzwxyz",
+        ),
+        InterpolatePose(
+            new_chunk_length=chunk_length,
+            action_key=left_action_headframe,
+            output_action_key=left_action_headframe,
+            stride=stride,
+            mode="xyzwxyz",
+        ),
+        InterpolatePose(
+            new_chunk_length=chunk_length,
+            action_key=right_action_headframe,
+            output_action_key=right_action_headframe,
+            stride=stride,
+            mode="xyzwxyz",
+        ),
+        ActionChunkCoordinateFrameTransform(
+            target_world=left_obs_headframe,
+            chunk_world=left_action_headframe,
+            transformed_key_name=left_action_wristframe,
+            mode="xyzwxyz",
+        ),
+        ActionChunkCoordinateFrameTransform(
+            target_world=right_obs_headframe,
+            chunk_world=right_action_headframe,
+            transformed_key_name=right_action_wristframe,
+            mode="xyzwxyz",
+        ),
+        XYZWXYZ_to_XYZYPR(
+            keys=[
+                left_action_wristframe,
+                right_action_wristframe,
+                left_obs_headframe,
+                right_obs_headframe,
+            ]
+        ),
+        ConcatKeys(
+            key_list=[left_action_wristframe, right_action_wristframe],
+            new_key_name=actions_key,
+            delete_old_keys=True,
+        ),
+        ConcatKeys(
+            key_list=[left_obs_headframe, right_obs_headframe],
+            new_key_name=obs_key,
+            delete_old_keys=True,
+        ),
+        DeleteKeys(keys_to_delete=keys_to_delete),
+    ]
     return transform_list
 
 


### PR DESCRIPTION
Adds the cartesian_wristframe_ypr transform mode for Aria, plus the
forward (training) and revert (visualization) transform builders that
re-express bimanual ee-pose action chunks in each side's wrist frame
while keeping proprio in headframe. Wires the new mode into the
visualization config via _build_aria_cartesian_revert_eef_frame_transform_list.