### PR TITLE
Refactor prompt-block flags: proprio/embodiment_label/control_mode

### DIFF
--- a/egomimic/hydra_configs/data/cotrain_pi_base.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_base.yaml
@@ -4,7 +4,7 @@ train_datasets:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets 
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
       key_map:
         _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
         keymap_mode: cartesian
@@ -19,7 +19,7 @@ train_datasets:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
       key_map:
         _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
         keymap_mode: cartesian
@@ -36,7 +36,7 @@ valid_datasets:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
       key_map:
         _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
         keymap_mode: cartesian
@@ -51,7 +51,7 @@ valid_datasets:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
       key_map:
         _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
         keymap_mode: cartesian
@@ -69,36 +69,46 @@ sampling_mode: "random"
 annotation_key: null
 default_prompt: ""
 
-# pi0.5-style proprio-in-prompt. When `discrete_state_input: true`, the
-# canonical concat key produced by each embodiment's transform_list
-# (`observations.state.ee_pose`) is read as the proprio vector, clipped to
-# [-1, 1], discretized into `state_num_bins` bins, and spliced into the
-# prompt before tokenization. Per-arm zarr keys are deleted by ConcatKeys
-# in the transform_list and are NOT available at collate time. The collate
-# defaults to ["observations.state.ee_pose"]; override `proprio_keys` here
-# only if you need a different source (e.g. keypoints mode). State is
-# assumed normalized to [-1, 1] upstream — values outside that range are
-# clipped, so confirm norm_stats is populated before training.
-discrete_state_input: true
+# Three orthogonal inclusion flags govern what gets spliced into the prompt:
+#   proprio          — append "State: <bins>" (pi0.5 discretized proprio)
+#   embodiment_label — append "Embodiment: <name>"
+#   control_mode     — append "Control mode: <descriptor>" (per-embodiment dict
+#                      or null to omit; falls back to "cam frame xyzypr ..."
+#                      defaults if a key isn't matched)
+#
+# If any of these is active, the prompt is rendered as
+#   "Task: {prompt}, <blocks>;\nAction: "
+# Otherwise the raw prompt is tokenized as-is (pre-pi0.5 / language behaviour).
+#
+# Proprio details: when `proprio: true`, the canonical concat key produced by
+# each embodiment's transform_list (`observations.state.ee_pose`) is read as
+# the proprio vector, clipped to [-1, 1], discretized into `state_num_bins`,
+# and spliced. Per-arm zarr keys are deleted by ConcatKeys (delete_old_keys),
+# so override `proprio_keys` only if you need a different source. State is
+# assumed normalized to [-1, 1] upstream — values outside are clipped.
+proprio: false
+embodiment_label: true
 state_num_bins: 256
-# "original" → "Task: ..., State: ...;\nAction: " (openpi pi0.5 default)
-# "specific" → adds "Embodiment: ..." and "Control mode: ..." descriptors;
-#              Aria omits the gripper part of the control-mode string.
-# "language" → no State block, tokenize the raw prompt only (pre-pi0.5
-#              behaviour); takes precedence over discrete_state_input.
-proprio_mode: original
+
+# Per-embodiment "Control mode:" descriptor. Keys are substrings matched
+# against the lowercased embodiment name (first match wins). Default (null)
+# omits the block entirely, matching the cartesian (head/cam-frame) transform
+# pipeline used in this base config. Wristframe pipelines should override this
+# — see cotrain_pi_lang_wrist.yaml.
+control_mode: null
 
 train_dataloader_params:
   eva_bimanual:
-    batch_size: 64
+    batch_size: 32
     num_workers: 6
   aria_bimanual:
-    batch_size: 64
+    batch_size: 32
     num_workers: 6
+
 valid_dataloader_params:
   eva_bimanual:
-    batch_size: 64
+    batch_size: 32
     num_workers: 6
   aria_bimanual:
-    batch_size: 64
+    batch_size: 32
     num_workers: 6

--- a/egomimic/hydra_configs/data/cotrain_pi_lang.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_lang.yaml
@@ -34,3 +34,7 @@ model_name: "google/paligemma-3b-mix-224"
 sampling_mode: "random"
 annotation_key: "annotations"
 default_prompt: "this is a bad action"
+
+control_mode:
+  aria: "cam frame xyzypr per arm"
+  eva: "cam frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/data/cotrain_pi_lang_wrist.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_lang_wrist.yaml
@@ -1,0 +1,32 @@
+defaults:
+  - cotrain_pi_lang
+  - _self_
+
+train_datasets:
+  eva_bimanual:
+    resolver:
+      key_map:
+        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
+        keymap_mode: cartesian_wristframe_ypr # check if this works with the transform list below
+        annotation_key: annotations
+      transform_list:
+        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
+        mode: cartesian_wristframe_ypr
+  aria_bimanual:
+    resolver:
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
+        keymap_mode: cartesian
+        annotation_key: annotations
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
+        mode: cartesian_wristframe_ypr
+
+# Override the cam-frame default in cotrain_pi_base for the wristframe
+# pipeline below. Setting control_mode to a non-null dict activates the
+# "Control mode: ..." block in the prompt (Task: ..., Control mode: ...;
+# \nAction: ). Set the `proprio` / `embodiment_label` flags here too if you
+# also want those blocks; otherwise they inherit `false` from the base.
+control_mode:
+  aria: "wrist frame xyzypr per arm"
+  eva: "wrist frame xyzypr gripper per arm"

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -67,9 +67,10 @@ class MultiDataModuleWrapper(LightningDataModule):
         use_tokenizer=False,
         default_prompt="",
         proprio_keys: list[str] | None = None,
-        discrete_state_input: bool = False,
         state_num_bins: int = 256,
-        proprio_mode: Literal["original", "specific", "language"] = "original",
+        proprio: bool = False,
+        embodiment_label: bool = False,
+        control_mode: dict[str, str] | None = None,
     ):
         """
         Args:
@@ -84,17 +85,28 @@ class MultiDataModuleWrapper(LightningDataModule):
             default_prompt: default prompt to use if the annotation key is not found
             collate_max_length: maximum length of the tokenized prompts
             proprio_keys: union of per-sample state keys to concat for the
-                ``discrete_state_input`` path. Keys missing from a given
-                embodiment's batch are skipped.
-            discrete_state_input: if True, splice discretized proprio into the
-                prompt as ``Task: ..., State: <bins>;\\nAction: `` (pi0.5 style).
+                ``proprio`` path. Keys missing from a given embodiment's
+                batch are skipped.
             state_num_bins: number of bins to discretize each state dim into.
-            proprio_mode: "original" for the upstream pi0.5 template
-                (``Task: ..., State: ...``), "specific" to additionally splice
-                ``Embodiment:`` and ``Control mode:`` descriptors into the
-                prompt, or "language" to tokenize only the raw prompt with no
-                ``State:`` block (pre-pi0.5 behaviour; takes precedence over
-                ``discrete_state_input``).
+            proprio: if True, splice discretized proprio into the prompt as
+                ``..., State: <bins>``. State is clipped to ``[-1, 1]`` and
+                discretized with ``state_num_bins`` (pi0.5 style; assumes
+                upstream normalization).
+            embodiment_label: if True, splice ``..., Embodiment: <name>``
+                into the prompt.
+            control_mode: optional per-embodiment dict; when non-null,
+                splices ``..., Control mode: <descriptor>``. Keys are
+                substrings matched against the (lowercased, ``_``→space)
+                embodiment name; first match wins. Falls back to the
+                built-in ``cam frame xyzypr [gripper] per arm`` strings if
+                no key matches. Example for wristframe pipelines:
+                ``{aria: "wrist frame xyzypr per arm",
+                  eva:  "wrist frame xyzypr gripper per arm"}``.
+
+            If any of ``proprio``, ``embodiment_label``, or ``control_mode``
+            is active, the prompt is rendered as
+            ``"Task: {prompt}, <blocks>;\\nAction: "`` (pi0.5 anchor).
+            Otherwise the raw ``prompt`` is tokenized as-is.
         """
         super().__init__()
         # Drop `None` slots so downstream iteration sites don't need null guards.
@@ -112,9 +124,10 @@ class MultiDataModuleWrapper(LightningDataModule):
                 annotation_key=annotation_key,
                 default_prompt=default_prompt,
                 proprio_keys=proprio_keys,
-                discrete_state_input=discrete_state_input,
                 state_num_bins=state_num_bins,
-                proprio_mode=proprio_mode,
+                proprio=proprio,
+                embodiment_label=embodiment_label,
+                control_mode=control_mode,
             )
         else:
             self.collate_fn = annotation_collate
@@ -312,38 +325,30 @@ def build_tokenized_collate(
     annotation_key="annotations",
     default_prompt="",
     proprio_keys: list[str] | None = None,
-    discrete_state_input: bool = False,
     state_num_bins: int = 256,
-    proprio_mode: Literal["original", "specific", "language"] = "original",
+    proprio: bool = False,
+    embodiment_label: bool = False,
+    control_mode: dict[str, str] | None = None,
 ):
     """Return a collate_fn closure that tokenizes the annotations field.
 
-    If ``discrete_state_input=True``, the per-sample proprio listed in
-    ``proprio_keys`` is concatenated, clipped to ``[-1, 1]``, discretized into
-    ``state_num_bins`` bins, and spliced into the prompt before tokenization
-    (mirrors openpi's pi05 PaligemmaTokenizer convention). State is assumed to
-    already be normalized to ``[-1, 1]`` upstream; values outside that range
-    are clipped.
+    Three orthogonal inclusion flags govern what gets spliced into the prompt:
 
-    The text template depends on ``proprio_mode``:
-      - ``"original"`` (default, openpi-compatible):
-          ``"Task: {prompt}, State: {b0} {b1} ...;\\nAction: "``
-      - ``"specific"`` (adds embodiment + control-mode descriptors):
-          ``"Task: {prompt}, Embodiment: {emb}, Control mode: {mode}, State: {b0} {b1} ...;\\nAction: "``
-        where the control-mode descriptor is
-        ``"cam frame xyzypr gripper per arm"`` for robot embodiments and
-        ``"cam frame xyzypr per arm"`` for Aria (no gripper).
-      - ``"language"`` (no proprio in prompt; matches the pre-pi0.5 behaviour):
-          the raw ``prompt`` is tokenized as-is, with no ``State:`` block and
-          no ``Action:`` anchor. Useful for ablations or pi0-style models that
-          take state through ``state_proj`` instead of the language stream.
-          Effective regardless of ``discrete_state_input``.
+      - ``proprio`` (bool): if True, append ``State: <bins>``. The per-sample
+        proprio listed in ``proprio_keys`` is concatenated, clipped to
+        ``[-1, 1]``, and discretized into ``state_num_bins`` bins (pi0.5 style;
+        assumes upstream normalization).
+      - ``embodiment_label`` (bool): if True, append ``Embodiment: <name>``.
+      - ``control_mode`` (dict | None): if non-null, append ``Control mode:
+        <descriptor>``. Keys are substrings matched against the (lowercased,
+        ``_``→space) embodiment name; first match wins. Falls back to the
+        built-in ``cam frame xyzypr [gripper] per arm`` defaults if no key
+        matches.
+
+    If any flag is active, the prompt is rendered as
+    ``"Task: {prompt}, <blocks-in-order>;\\nAction: "`` (pi0.5 anchor).
+    Otherwise the raw ``prompt`` is tokenized as-is.
     """
-    if proprio_mode not in ("original", "specific", "language"):
-        raise ValueError(
-            "proprio_mode must be 'original', 'specific', or 'language', "
-            f"got {proprio_mode!r}"
-        )
     from egomimic.rldb.embodiment.embodiment import get_embodiment
 
     tok = AutoTokenizer.from_pretrained(model_name)
@@ -371,6 +376,10 @@ def build_tokenized_collate(
         return name.lower().replace("_", " ")
 
     def _control_mode_for(emb_name):
+        if control_mode and emb_name is not None:
+            for key, val in control_mode.items():
+                if key.lower() in emb_name:
+                    return val
         if emb_name is not None and "aria" in emb_name:
             return "cam frame xyzypr per arm"
         return "cam frame xyzypr gripper per arm"
@@ -417,23 +426,25 @@ def build_tokenized_collate(
                     sampled_prompt = sample[0]
                 prompts.append(sampled_prompt)
 
-        if discrete_state_input and proprio_mode != "language":
+        any_block_active = proprio or embodiment_label or bool(control_mode)
+        if any_block_active:
             spliced = []
             for i, prompt in enumerate(prompts):
-                state_str = _discretize_sample_state(batch[i])
-                if state_str is None:
-                    spliced.append(prompt)
-                    continue
-                if proprio_mode == "original":
-                    spliced.append(f"Task: {prompt}, State: {state_str};\nAction: ")
-                else:  # "specific"
-                    emb_name = _embodiment_name(batch[i])
-                    control_mode = _control_mode_for(emb_name)
-                    emb_part = f", Embodiment: {emb_name}" if emb_name else ""
-                    spliced.append(
-                        f"Task: {prompt}{emb_part}, Control mode: {control_mode}, "
-                        f"State: {state_str};\nAction: "
-                    )
+                emb_name = (
+                    _embodiment_name(batch[i])
+                    if (embodiment_label or control_mode)
+                    else None
+                )
+                blocks = [f"Task: {prompt}"]
+                if embodiment_label and emb_name:
+                    blocks.append(f"Embodiment: {emb_name}")
+                if control_mode:
+                    blocks.append(f"Control mode: {_control_mode_for(emb_name)}")
+                if proprio:
+                    state_str = _discretize_sample_state(batch[i])
+                    if state_str is not None:
+                        blocks.append(f"State: {state_str}")
+                spliced.append(", ".join(blocks) + ";\nAction: ")
             prompts = spliced
 
         list_keys = _extract_list_keys(batch)


### PR DESCRIPTION
Replaces the discrete_state_input + proprio_mode enum with three
orthogonal inclusion flags. The collate fn now composes the prompt as
'Task: {prompt}, <blocks>;\nAction: ' when any block is active, and
tokenizes the raw prompt otherwise. control_mode is a per-embodiment
dict (substring keys, first match wins) that lets wristframe pipelines
override the cam-frame default without code changes.

Updates cotrain_pi_base/lang to the new keys, and adds cotrain_pi_lang_wrist
which combines the new control_mode override with the cartesian_wristframe_ypr
Aria mode.