### PR TITLE
Move PI prompt assembly + tokenization from data collate to algo

### DIFF
--- a/egomimic/algo/pi.py
+++ b/egomimic/algo/pi.py
@@ -1,7 +1,10 @@
 import logging
 import os
+import random
 from collections import OrderedDict
+from typing import Literal
 
+import numpy as np
 import openpi
 import openpi.models.pi0_config
 import openpi.models_pytorch.pi0_pytorch
@@ -10,6 +13,7 @@ import torch
 import torch.nn as nn
 from openpi.shared.image_tools import resize_with_pad_torch
 from overrides import override
+from transformers import AutoTokenizer
 
 from egomimic.algo.algo import Algo
 from egomimic.models.preprocess_pi_obs import (
@@ -50,10 +54,45 @@ class PI(Algo):
         # ---------------------------
         ac_keys,
         action_converters,
+        # ---------------------------
+        # Prompt / tokenization (moved from data config). The PI algo owns
+        # the tokenizer because the prompt template is model-specific
+        # (paligemma + pi0.5 anchor). See ``process_batch_for_training`` for
+        # how these knobs assemble the prompt and produce ``tokenized_*``.
+        # ---------------------------
+        tokenizer_model_name: str = "google/paligemma-3b-mix-224",
+        tokenizer_max_length: int = 128,
+        sampling_mode: Literal["first", "random"] = "random",
+        annotation_key: str | None = None,
+        default_prompt: str = "",
+        proprio_in_prompt: bool = False,
+        embodiment_label: bool = False,
+        state_num_bins: int = 256,
+        control_mode: dict[str, str] | None = None,
+        proprio_keys_for_prompt: list[str] | None = None,
         **kwargs,
     ):
         self.nets = nn.ModuleDict()
         self.norm_stats = norm_stats
+
+        # ---- Prompt assembly + tokenization (was in collate_fn) ----
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_model_name)
+        self.tokenizer_max_length = tokenizer_max_length
+        self.sampling_mode = sampling_mode
+        self.annotation_key = annotation_key
+        self.default_prompt = default_prompt
+        self.proprio_in_prompt = proprio_in_prompt
+        self.embodiment_label = embodiment_label
+        self.state_num_bins = state_num_bins
+        self.control_mode = control_mode
+        # Default to the canonical concat key produced by each embodiment's
+        # transform_list (ConcatKeys with delete_old_keys removes per-arm zarr keys).
+        self.proprio_keys_for_prompt = (
+            list(proprio_keys_for_prompt)
+            if proprio_keys_for_prompt is not None
+            else ["observations.state.ee_pose"]
+        )
+        self._state_bin_edges = np.linspace(-1.0, 1.0, state_num_bins + 1)[:-1]
 
         self.camera_transforms = camera_transforms
         self.train_image_augs = train_image_augs
@@ -155,6 +194,103 @@ class PI(Algo):
         self.nets = nn.ModuleDict()
         self.nets["policy"] = self.model
 
+    def _control_mode_for(self, emb_name: str | None) -> str:
+        if self.control_mode and emb_name is not None:
+            for key, val in self.control_mode.items():
+                if key.lower() in emb_name:
+                    return val
+        if emb_name is not None and "aria" in emb_name:
+            return "cam frame xyzypr per arm"
+        return "cam frame xyzypr gripper per arm"
+
+    def _discretize_state_for_sample(self, _batch, sample_idx: int) -> str | None:
+        """Pick the latest proprio timestep for sample i, clip to [-1, 1],
+        digitize into ``state_num_bins`` bins, and return as a space-joined
+        string. Returns None if no proprio key is present.
+        """
+        parts = []
+        for k in self.proprio_keys_for_prompt:
+            if k not in _batch:
+                continue
+            v = _batch[k]
+            if isinstance(v, torch.Tensor):
+                v = v[sample_idx].detach().cpu().numpy()
+            else:
+                v = np.asarray(v)[sample_idx]
+            v = np.asarray(v, dtype=np.float32)
+            while v.ndim > 1:
+                v = v[-1]
+            parts.append(v.reshape(-1))
+        if not parts:
+            return None
+        state = np.concatenate(parts, axis=-1)
+        state = np.clip(state, -1.0, 1.0)
+        bins = np.digitize(state, bins=self._state_bin_edges) - 1
+        return " ".join(map(str, bins.tolist()))
+
+    def _build_prompts(
+        self, _batch, embodiment_name: str, batch_size: int
+    ) -> list[str]:
+        """Sample one prompt per item from the raw annotation lists and
+        splice in any of the active blocks. Returns ``batch_size`` strings.
+
+        Mirrors the prompt assembly previously done in
+        ``build_tokenized_collate``. Embodiment is known per-batch (one
+        DataLoader per embodiment), so we don't re-derive it per sample.
+        """
+        if self.annotation_key is None or self.annotation_key not in _batch:
+            prompts = [self.default_prompt] * batch_size
+        else:
+            prompts = []
+            for sample in _batch[self.annotation_key]:
+                if not sample:
+                    prompts.append(self.default_prompt)
+                elif self.sampling_mode == "random":
+                    prompts.append(sample[random.randint(0, len(sample) - 1)])
+                else:  # "first"
+                    prompts.append(sample[0])
+
+        any_block_active = (
+            self.proprio_in_prompt or self.embodiment_label or bool(self.control_mode)
+        )
+        if not any_block_active:
+            return prompts
+
+        emb_name = embodiment_name.lower().replace("_", " ")
+        spliced = []
+        for i, prompt in enumerate(prompts):
+            blocks = [f"Task: {prompt}"]
+            if self.embodiment_label:
+                blocks.append(f"Embodiment: {emb_name}")
+            if self.control_mode:
+                blocks.append(f"Control mode: {self._control_mode_for(emb_name)}")
+            if self.proprio_in_prompt:
+                state_str = self._discretize_state_for_sample(_batch, i)
+                if state_str is not None:
+                    blocks.append(f"State: {state_str}")
+            spliced.append(", ".join(blocks) + ";\nAction: ")
+        return spliced
+
+    def _tokenize_prompts(self, prompts: list[str]) -> dict:
+        enc = self.tokenizer(
+            prompts,
+            padding="max_length"
+            if self.tokenizer_max_length is not None
+            else "longest",
+            truncation=True,
+            max_length=self.tokenizer_max_length,
+            return_tensors="pt",
+        )
+        attention_mask = enc["attention_mask"].bool()
+        token_loss_mask = attention_mask.clone()
+        token_loss_mask[:, -1] = False
+        return {
+            "tokenized_prompt": enc["input_ids"].requires_grad_(False),
+            "tokenized_mask": attention_mask.requires_grad_(False),
+            "token_loss_mask": token_loss_mask.requires_grad_(False),
+            "token_ar_mask": attention_mask.clone().requires_grad_(False),
+        }
+
     @override
     def process_batch_for_training(self, batch):
         """
@@ -176,17 +312,6 @@ class PI(Algo):
                 if key_name is not None:
                     processed_batch[embodiment_id][key_name] = value
 
-            # Carry through language tokenization tensors and annotations produced by collate_fn
-            for tk in (
-                "tokenized_prompt",
-                "tokenized_mask",
-                "token_loss_mask",
-                "token_ar_mask",
-                "sampled_prompt",
-            ):
-                if tk in _batch:
-                    processed_batch[embodiment_id][tk] = _batch[tk]
-
             ac_key = self.ac_keys[embodiment_id]
             if ac_key not in processed_batch[embodiment_id]:
                 raise KeyError(
@@ -197,6 +322,13 @@ class PI(Algo):
                 raise ValueError("Action shape in batch is not 2")
 
             B, S, _ = processed_batch[embodiment_id][ac_key].shape
+
+            # Build prompts + tokenize. Reads raw `annotations` (list[list[str]])
+            # left in `_batch` by `annotation_collate`, plus per-sample proprio
+            # tensors from `_batch` for the optional State block.
+            prompts = self._build_prompts(_batch, embodiment_name, B)
+            processed_batch[embodiment_id]["sampled_prompt"] = prompts
+            processed_batch[embodiment_id].update(self._tokenize_prompts(prompts))
             processed_batch[embodiment_id]["pad_mask"] = torch.ones(
                 B, S, 1, device=self.device
             )

--- a/egomimic/hydra_configs/data/cotrain_pi_base.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_base.yaml
@@ -63,39 +63,10 @@ valid_datasets:
     mode: valid
     valid_ratio: 0.05
 
-use_tokenizer: true
-model_name: "google/paligemma-3b-mix-224"
-sampling_mode: "random"
-annotation_key: null
-default_prompt: ""
-
-# Three orthogonal inclusion flags govern what gets spliced into the prompt:
-#   proprio          — append "State: <bins>" (pi0.5 discretized proprio)
-#   embodiment_label — append "Embodiment: <name>"
-#   control_mode     — append "Control mode: <descriptor>" (per-embodiment dict
-#                      or null to omit; falls back to "cam frame xyzypr ..."
-#                      defaults if a key isn't matched)
-#
-# If any of these is active, the prompt is rendered as
-#   "Task: {prompt}, <blocks>;\nAction: "
-# Otherwise the raw prompt is tokenized as-is (pre-pi0.5 / language behaviour).
-#
-# Proprio details: when `proprio: true`, the canonical concat key produced by
-# each embodiment's transform_list (`observations.state.ee_pose`) is read as
-# the proprio vector, clipped to [-1, 1], discretized into `state_num_bins`,
-# and spliced. Per-arm zarr keys are deleted by ConcatKeys (delete_old_keys),
-# so override `proprio_keys` only if you need a different source. State is
-# assumed normalized to [-1, 1] upstream — values outside are clipped.
-proprio: false
-embodiment_label: true
-state_num_bins: 256
-
-# Per-embodiment "Control mode:" descriptor. Keys are substrings matched
-# against the lowercased embodiment name (first match wins). Default (null)
-# omits the block entirely, matching the cartesian (head/cam-frame) transform
-# pipeline used in this base config. Wristframe pipelines should override this
-# — see cotrain_pi_lang_wrist.yaml.
-control_mode: null
+# Prompt assembly + tokenization config moved to the model side
+# (see hydra_configs/model/pi0.5_base.yaml). Override prompt knobs there
+# (or via `model.robomimic_model.<key>=<value>` on the CLI) when pairing
+# this data config with a non-default prompt configuration.
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/cotrain_pi_lang.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_lang.yaml
@@ -29,12 +29,11 @@ valid_datasets:
       filter_lambdas:
         - "lambda row: row['robot_name'] == 'aria_bimanual' and row['task'] == 'pick_place' and row['zarr_processed_path'] != '' and 'alignment' not in (row.get('task_description') or '')"
 
-use_tokenizer: true
-model_name: "google/paligemma-3b-mix-224"
-sampling_mode: "random"
-annotation_key: "annotations"
-default_prompt: "this is a bad action"
-
-control_mode:
-  aria: "cam frame xyzypr per arm"
-  eva: "cam frame xyzypr gripper per arm"
+# Prompt config moved to the model side. To reproduce the previous behaviour
+# of this data config, pair with the following overrides on the model
+# (model.robomimic_model.*):
+#   annotation_key: "annotations"
+#   default_prompt: "this is a bad action"
+#   control_mode:
+#     aria: "cam frame xyzypr per arm"
+#     eva:  "cam frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/data/cotrain_pi_lang_wrist.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_lang_wrist.yaml
@@ -42,11 +42,10 @@ valid_datasets:
         _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
         mode: cartesian_wristframe_ypr
 
-# Override the cam-frame default in cotrain_pi_base for the wristframe
-# pipeline below. Setting control_mode to a non-null dict activates the
-# "Control mode: ..." block in the prompt (Task: ..., Control mode: ...;
-# \nAction: ). Set the `proprio` / `embodiment_label` flags here too if you
-# also want those blocks; otherwise they inherit `false` from the base.
-control_mode:
-  aria: "wrist frame xyzypr per arm"
-  eva: "wrist frame xyzypr gripper per arm"
+# Prompt config moved to the model side. For the wristframe pipeline,
+# pair this data config with model overrides (model.robomimic_model.*):
+#   annotation_key: "annotations"
+#   default_prompt: "this is a bad action"
+#   control_mode:
+#     aria: "wrist frame xyzypr per arm"
+#     eva:  "wrist frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/data/cotrain_pi_no_lang.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_no_lang.yaml
@@ -26,8 +26,7 @@ valid_datasets:
       filter_lambdas:
         - "lambda row: (row['robot_name'] == 'aria_bimanual') & (row['task'] == 'fold_clothes') & (row['zarr_processed_path'] != '')"
 
-use_tokenizer: true
-model_name: "google/paligemma-3b-mix-224"
-sampling_mode: "random"
-annotation_key: null
-default_prompt: "fold the clothes"
+# Prompt config moved to the model side. Pair this data config with model
+# overrides (model.robomimic_model.*):
+#   annotation_key: null
+#   default_prompt: "fold the clothes"

--- a/egomimic/hydra_configs/data/eva_pi.yaml
+++ b/egomimic/hydra_configs/data/eva_pi.yaml
@@ -25,6 +25,7 @@ valid_datasets:
   aria_bimanual: null
 
 
-sampling_mode: "random"
-annotation_key: "annotations"
-default_prompt: "this is a bad action"
+# Prompt config moved to the model side. Pair this data config with model
+# overrides (model.robomimic_model.*):
+#   annotation_key: "annotations"
+#   default_prompt: "this is a bad action"

--- a/egomimic/hydra_configs/data/eva_pi_lang.yaml
+++ b/egomimic/hydra_configs/data/eva_pi_lang.yaml
@@ -20,12 +20,9 @@ valid_datasets:
         - "lambda row: row['robot_name'] == 'eva_bimanual' and row['task'] == 'pick_place' and row['zarr_processed_path'] != '' and 'alignment' not in (row.get('task_description') or '')"
   aria_bimanual: null
 
-use_tokenizer: true
-model_name: "google/paligemma-3b-mix-224"
-sampling_mode: "random"
-annotation_key: "annotations"
-default_prompt: "this is a bad action"
-
-proprio: false
-control_mode:
-  eva: "cam frame xyzypr gripper per arm"
+# Prompt config moved to the model side. Pair this data config with model
+# overrides (model.robomimic_model.*):
+#   annotation_key: "annotations"
+#   default_prompt: "this is a bad action"
+#   control_mode:
+#     eva: "cam frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/model/pi0.5_base.yaml
+++ b/egomimic/hydra_configs/model/pi0.5_base.yaml
@@ -1,7 +1,7 @@
 _target_: egomimic.pl_utils.pl_model.ModelWrapper
 robomimic_model:
   _target_: egomimic.algo.pi.PI
-  config:      
+  config:
     pytorch_training_precision: bfloat16
     pytorch_weight_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/projects/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
     model:
@@ -9,6 +9,35 @@ robomimic_model:
       action_dim: 32
       action_horizon: 100
       max_token_len: 180
+
+  # Prompt assembly + tokenization. The PI algo owns the tokenizer because
+  # the prompt template is model-specific (paligemma + pi0.5 anchor). All
+  # of these were previously in the data config.
+  #
+  # Three orthogonal inclusion flags govern what gets spliced into the prompt:
+  #   proprio_in_prompt — append "State: <bins>" (pi0.5 discretized proprio)
+  #   embodiment_label  — append "Embodiment: <name>"
+  #   control_mode      — append "Control mode: <descriptor>" (per-embodiment dict
+  #                       or null to omit; falls back to "cam frame xyzypr ..."
+  #                       defaults if a key isn't matched)
+  #
+  # If any of these is active, the prompt is rendered as
+  #   "Task: {prompt}, <blocks>;\nAction: "
+  # Otherwise the raw prompt is tokenized as-is (pre-pi0.5 / language behaviour).
+  #
+  # Override per-run for lang / wristframe variants, e.g.
+  #   model.robomimic_model.annotation_key=annotations
+  #   model.robomimic_model.default_prompt="this is a bad action"
+  #   model.robomimic_model.control_mode='{aria: "wrist frame xyzypr per arm", eva: "wrist frame xyzypr gripper per arm"}'
+  tokenizer_model_name: "google/paligemma-3b-mix-224"
+  tokenizer_max_length: 128
+  sampling_mode: "random"
+  annotation_key: null
+  default_prompt: ""
+  proprio_in_prompt: false
+  embodiment_label: true
+  state_num_bins: 256
+  control_mode: null
 
   train_image_augs:
     _target_: torchvision.transforms.Compose

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -60,17 +60,6 @@ class MultiDataModuleWrapper(LightningDataModule):
         valid_datasets: dict,
         train_dataloader_params: dict,
         valid_dataloader_params: dict,
-        collate_max_length=128,
-        model_name="google/paligemma-3b-mix-224",
-        sampling_mode: Literal["first", "random"] = "random",
-        annotation_key=None,
-        use_tokenizer=False,
-        default_prompt="",
-        proprio_keys: list[str] | None = None,
-        state_num_bins: int = 256,
-        proprio: bool = False,
-        embodiment_label: bool = False,
-        control_mode: dict[str, str] | None = None,
     ):
         """
         Args:
@@ -78,35 +67,13 @@ class MultiDataModuleWrapper(LightningDataModule):
             valid_datasets: dictionary of valid datasets
             train_dataloader_params: dictionary of train dataloader parameters
             valid_dataloader_params: dictionary of valid dataloader parameters
-            model_name: name of the model to use for the tokenizer
-            sampling_mode: "first" to sample the first prompt from the list of prompts, "random" to sample a random prompt from the list of prompts
-            annotation_key: key of the annotation to use for the collate function
-            use_tokenizer: whether to use the tokenizer to tokenize the prompts
-            default_prompt: default prompt to use if the annotation key is not found
-            collate_max_length: maximum length of the tokenized prompts
-            proprio_keys: union of per-sample state keys to concat for the
-                ``proprio`` path. Keys missing from a given embodiment's
-                batch are skipped.
-            state_num_bins: number of bins to discretize each state dim into.
-            proprio: if True, splice discretized proprio into the prompt as
-                ``..., State: <bins>``. State is clipped to ``[-1, 1]`` and
-                discretized with ``state_num_bins`` (pi0.5 style; assumes
-                upstream normalization).
-            embodiment_label: if True, splice ``..., Embodiment: <name>``
-                into the prompt.
-            control_mode: optional per-embodiment dict; when non-null,
-                splices ``..., Control mode: <descriptor>``. Keys are
-                substrings matched against the (lowercased, ``_``→space)
-                embodiment name; first match wins. Falls back to the
-                built-in ``cam frame xyzypr [gripper] per arm`` strings if
-                no key matches. Example for wristframe pipelines:
-                ``{aria: "wrist frame xyzypr per arm",
-                  eva:  "wrist frame xyzypr gripper per arm"}``.
 
-            If any of ``proprio``, ``embodiment_label``, or ``control_mode``
-            is active, the prompt is rendered as
-            ``"Task: {prompt}, <blocks>;\\nAction: "`` (pi0.5 anchor).
-            Otherwise the raw ``prompt`` is tokenized as-is.
+        Tokenization (sampling a prompt from per-sample annotation lists,
+        splicing in embodiment / control-mode / proprio blocks, and running
+        the HF tokenizer) lives on the algo side now — see
+        ``PI.process_batch_for_training``. The collate here only stacks
+        tensors and preserves variable-length list-valued keys (e.g. raw
+        ``annotations``) so the algo can consume them downstream.
         """
         super().__init__()
         # Drop `None` slots so downstream iteration sites don't need null guards.
@@ -116,21 +83,7 @@ class MultiDataModuleWrapper(LightningDataModule):
         self.valid_datasets = {k: v for k, v in valid_datasets.items() if v is not None}
         self.train_dataloader_params = train_dataloader_params
         self.valid_dataloader_params = valid_dataloader_params
-        if use_tokenizer:
-            self.collate_fn = build_tokenized_collate(
-                max_length=collate_max_length,
-                model_name=model_name,
-                sampling_mode=sampling_mode,
-                annotation_key=annotation_key,
-                default_prompt=default_prompt,
-                proprio_keys=proprio_keys,
-                state_num_bins=state_num_bins,
-                proprio=proprio,
-                embodiment_label=embodiment_label,
-                control_mode=control_mode,
-            )
-        else:
-            self.collate_fn = annotation_collate
+        self.collate_fn = annotation_collate
 
     def train_dataloader(self):
         iterables = dict()


### PR DESCRIPTION
The data layer no longer needs paligemma/control-mode/proprio knowledge.
MultiDataModuleWrapper now only stacks tensors and preserves list-valued
keys; PI.process_batch_for_training samples a prompt per item from the
raw annotation lists, splices in the optional Embodiment/Control-mode/
State blocks, and tokenizes. All prompt knobs moved to pi0.5_base.yaml
(override per-run via model.robomimic_model.*); 6 data configs lost
their prompt blocks (would otherwise crash on the new __init__).

build_tokenized_collate is kept in pl_data_utils for rollout.py and the
deprecated wrappers that still call it.