### PR TITLE
Use AnnotationCutoff resolvers + local dataset paths

### DIFF
--- a/egomimic/hydra_configs/data/cotrain_pi_base.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_base.yaml
@@ -3,8 +3,8 @@ train_datasets:
   eva_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
+      folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
       key_map:
         _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
         keymap_mode: cartesian_pi
@@ -18,8 +18,8 @@ train_datasets:
   aria_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
+      folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
       key_map:
         _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
         keymap_mode: cartesian
@@ -35,8 +35,8 @@ valid_datasets:
   eva_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
+      folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
       key_map:
         _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
         keymap_mode: cartesian_pi
@@ -50,8 +50,8 @@ valid_datasets:
   aria_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
     resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
+      folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
       key_map:
         _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
         keymap_mode: cartesian
@@ -62,11 +62,6 @@ valid_datasets:
     filters: null
     mode: valid
     valid_ratio: 0.05
-
-# Prompt assembly + tokenization config moved to the model side
-# (see hydra_configs/model/pi0.5_base.yaml). Override prompt knobs there
-# (or via `model.robomimic_model.<key>=<value>` on the CLI) when pairing
-# this data config with a non-default prompt configuration.
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/eva_pi.yaml
+++ b/egomimic/hydra_configs/data/eva_pi.yaml
@@ -5,22 +5,24 @@ defaults:
 train_datasets:
   eva_bimanual:
     resolver:
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalAnnotationCutoffEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
     filters:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
-        - "lambda row: row['episode_hash'] == '2025-12-26-18-07-46-296000'"
+        - "lambda row: row.get('embodiment') == 'eva_bimanual'"
     mode: total
   aria_bimanual: null
 
 valid_datasets:
   eva_bimanual:
     resolver:
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalAnnotationCutoffEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
     filters:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
-        - "lambda row: row['episode_hash'] == '2025-12-26-18-07-46-296000'"
+        - "lambda row: row.get('embodiment') == 'eva_bimanual'"
     mode: total
   aria_bimanual: null
 

--- a/egomimic/hydra_configs/model/pi0.5_base.yaml
+++ b/egomimic/hydra_configs/model/pi0.5_base.yaml
@@ -32,9 +32,9 @@ robomimic_model:
   tokenizer_model_name: "google/paligemma-3b-mix-224"
   tokenizer_max_length: 128
   sampling_mode: "random"
-  annotation_key: null
-  default_prompt: ""
-  proprio_in_prompt: false
+  annotation_key: "annotations"
+  default_prompt: "This is a bad action."
+  proprio_in_prompt: true
   embodiment_label: true
   state_num_bins: 256
   control_mode: null

--- a/egomimic/hydra_configs/trainer/default.yaml
+++ b/egomimic/hydra_configs/trainer/default.yaml
@@ -13,7 +13,7 @@ precision: bf16
 limit_train_batches: 100
 limit_val_batches: 80
 # perform a validation loop every N training epochs
-check_val_every_n_epoch: 200
+check_val_every_n_epoch: 100
 
 # set True to to ensure deterministic results
 # makes training slower but gives more reproducibility than just setting seeds


### PR DESCRIPTION
Use AnnotationCutoff resolvers + local dataset paths

Switch cotrain_pi_base and eva_pi data configs to *AnnotationCutoff*
resolver variants so action chunks clamp at annotation boundaries.
Also point at the locally-synced dataset paths.

Tweak PI prompt defaults and run validation more often

- pi0.5_base.yaml: enable proprio-in-prompt, set default annotation_key
  and default_prompt so PI training runs without per-call overrides.
- trainer/default.yaml: validate every 100 epochs instead of 200.