### PR TITLE
tshape sim environment

### DIFF
--- a/Tsimulation/README.md
+++ b/Tsimulation/README.md
@@ -45,6 +45,52 @@ Window hotkeys: **SPACE** record/pause, **S** commit + reset, **R** abort
 + reset, **Q** quit. Each committed episode becomes
 `data/pushshapes_demos/episode_NNNNNN.zarr/`.
 
+## Collect scripted demos (headless)
+
+Heuristic auto-collector — useful for bootstrapping data without a mouse
+or display. Approaches a contact point behind the object, then pushes
+toward the goal. Failed attempts (below `--success-threshold` final
+coverage) are discarded.
+
+```bash
+python -m Tsimulation.collect.scripted_collect \
+    --output data/pushshapes_scripted \
+    --object T --pusher circle --obstacles 0 \
+    --num-episodes 50
+```
+
+Works best at `--obstacles 0` with `--pusher circle`. Higher obstacle
+levels and the stick pusher will see a lower success rate.
+
+## Visualize a recorded episode
+
+Pygame viz that plays back the recorded observations alongside the
+actions. Left panel: decoded observation image with overlays (action
+target as a red X, recent action trace, agent/object/goal markers).
+Right panel: numeric state, action, reward, and goal pose.
+
+```bash
+# Interactive
+python -m Tsimulation.examples.visualize_episode \
+    --dataset data/pushshapes_demos --episode 0
+
+# Headless: write an MP4
+python -m Tsimulation.examples.visualize_episode \
+    --dataset data/pushshapes_demos --episode 0 --save ep0.mp4
+```
+
+Hotkeys: **SPACE** play/pause, **←/→** step, **↑/↓** speed, **R** reset,
+**Q** quit.
+
+## Inspect a dataset
+
+```bash
+python -m Tsimulation.examples.dataset_stats --dataset data/pushshapes_demos
+```
+
+Prints episode count, length stats, mean / final coverage, action range,
+and a per-config breakdown over `(object, pusher, obstacle_level)`.
+
 ## Output schema
 
 Per the conventions of
@@ -97,10 +143,14 @@ Tsimulation/
 ├── collect/
 │   ├── __init__.py
 │   ├── mouse_collect.py
+│   ├── scripted_collect.py
 │   └── zarr_writer.py
 ├── examples/
+│   ├── dataset_stats.py
 │   ├── play_random.py
-│   └── replay_zarr.py
+│   ├── replay_zarr.py
+│   └── visualize_episode.py
 └── tests/
+    ├── test_features.py
     └── test_smoke.py
 ```

--- a/Tsimulation/collect/scripted_collect.py
+++ b/Tsimulation/collect/scripted_collect.py
@@ -1,0 +1,241 @@
+"""Headless scripted demonstration collection for PushShapesEnv.
+
+Uses a simple two-phase heuristic so we can bootstrap a demo set without a
+mouse — handy while the physics is being tuned and human mouse demos are
+finicky to record.
+
+Heuristic per step:
+
+1. Compute the unit vector from the object's center toward the goal center.
+2. Pick an "approach point" a fixed offset behind the object along the
+   anti-push direction.
+3. If the pusher is far from that approach point, the action target is the
+   approach point (move into contact).
+4. Otherwise the action target is past the goal along the push direction
+   (push the object toward the goal).
+
+Episodes that don't reach a configurable coverage threshold are discarded
+so we don't pollute the dataset with failed attempts. Obstacle-heavy
+levels will see a lower success rate.
+
+Usage::
+
+    python -m Tsimulation.collect.scripted_collect \\
+        --output data/pushshapes_scripted \\
+        --object T --pusher circle --obstacles 0 \\
+        --num-episodes 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+
+from Tsimulation.collect.zarr_writer import ZarrDemoWriter
+from Tsimulation.pushshapes.env import PushShapesEnv
+
+APPROACH_OFFSET = 60.0
+PUSH_LOOKAHEAD = 80.0
+CONTACT_RADIUS = 25.0
+
+
+def scripted_action(
+    *,
+    agent_xy: np.ndarray,
+    object_xy: np.ndarray,
+    goal_xy: np.ndarray,
+    world_size: float,
+) -> np.ndarray:
+    """Return a (2,) float32 action target in world coords."""
+    push_vec = goal_xy - object_xy
+    push_dist = float(np.linalg.norm(push_vec))
+    if push_dist < 1e-3:
+        return object_xy.astype(np.float32)
+    push_dir = push_vec / push_dist
+    approach_point = object_xy - push_dir * APPROACH_OFFSET
+    if float(np.linalg.norm(agent_xy - approach_point)) > CONTACT_RADIUS:
+        target = approach_point
+    else:
+        target = object_xy + push_dir * PUSH_LOOKAHEAD
+    return np.clip(target, 0.0, world_size).astype(np.float32)
+
+
+def run_episode(
+    env: PushShapesEnv,
+    writer: ZarrDemoWriter,
+    *,
+    max_steps: int,
+    success_threshold: float,
+    rng: np.random.Generator,
+    jitter: float,
+    seed: int | None,
+) -> tuple[bool, float, int]:
+    """Roll out one scripted episode. Returns (committed, final_coverage, steps)."""
+    obs, info = env.reset(seed=seed)
+    writer.start_episode()
+    coverage = float(info.get("coverage", 0.0))
+    final_coverage = coverage
+    steps = 0
+    for _ in range(max_steps):
+        agent_xy = np.asarray(obs["agent_pos"], dtype=np.float32)
+        object_xy = np.asarray(obs["object_pose"][:2], dtype=np.float32)
+        goal_xy = np.asarray(obs["goal_pose"][:2], dtype=np.float32)
+        action = scripted_action(
+            agent_xy=agent_xy,
+            object_xy=object_xy,
+            goal_xy=goal_xy,
+            world_size=float(env.WORLD_SIZE),
+        )
+        if jitter > 0.0:
+            action = action + rng.normal(0.0, jitter, size=(2,)).astype(np.float32)
+            action = np.clip(action, 0.0, float(env.WORLD_SIZE)).astype(np.float32)
+
+        next_obs, reward, terminated, truncated, info = env.step(action)
+        coverage = float(info.get("coverage", 0.0))
+
+        state = np.concatenate([obs["agent_pos"], obs["object_pose"]], dtype=np.float32)
+        writer.add_step(
+            image=obs["image"],
+            state=state,
+            action=action,
+            reward=float(reward),
+            goal_pose=obs["goal_pose"],
+        )
+
+        obs = next_obs
+        steps += 1
+        final_coverage = coverage
+        if terminated or truncated:
+            break
+
+    committed = False
+    if final_coverage >= success_threshold and writer.steps_in_episode > 0:
+        idx = writer.commit_episode()
+        committed = idx >= 0
+    else:
+        writer.abort_episode()
+    return committed, final_coverage, steps
+
+
+def run(args: argparse.Namespace) -> int:
+    if args.headless:
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+    env = PushShapesEnv(
+        object_shape=args.object,
+        pusher_shape=args.pusher,
+        obstacle_level=args.obstacles,
+        image_size=args.image_size,
+        seed=args.seed,
+    )
+    # --max-steps stays on the CLI / collector loop only — it's not passed
+    # to the env (which no longer truncates by step count).
+    env_args = {
+        "object_shape": args.object,
+        "pusher_shape": args.pusher,
+        "obstacle_level": args.obstacles,
+        "image_size": args.image_size,
+        "fps": args.fps,
+        "max_episode_steps": args.max_steps,
+        "collector": "scripted",
+    }
+    writer = ZarrDemoWriter(
+        path=args.output,
+        env_args=env_args,
+        image_size=args.image_size,
+        fps=args.fps,
+    )
+    rng = np.random.default_rng(args.seed)
+
+    saved = 0
+    attempts = 0
+    max_attempts = args.num_episodes * args.max_tries
+    while saved < args.num_episodes and attempts < max_attempts:
+        attempts += 1
+        ep_seed = (args.seed + attempts) if args.seed is not None else None
+        committed, coverage, steps = run_episode(
+            env,
+            writer,
+            max_steps=args.max_steps,
+            success_threshold=args.success_threshold,
+            rng=rng,
+            jitter=args.jitter,
+            seed=ep_seed,
+        )
+        if committed:
+            saved += 1
+            print(
+                f"saved ep {saved:03d}/{args.num_episodes}  "
+                f"steps={steps:3d}  coverage={coverage:.3f}  (attempt {attempts})"
+            )
+        elif args.verbose:
+            print(
+                f"discard       attempt {attempts:3d}  "
+                f"steps={steps:3d}  coverage={coverage:.3f}"
+            )
+
+    writer.close()
+    env.close()
+    print(
+        f"done. saved {saved}/{args.num_episodes} in {attempts} attempts "
+        f"-> {args.output}"
+    )
+    return 0 if saved == args.num_episodes else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output", required=True, help="directory for episode_*.zarr stores"
+    )
+    parser.add_argument("--object", default="T", choices=["T", "U", "Z"])
+    parser.add_argument("--pusher", default="circle", choices=["circle", "stick"])
+    parser.add_argument("--obstacles", type=int, default=0, choices=[0, 1, 2, 3])
+    parser.add_argument("--num-episodes", type=int, default=20)
+    parser.add_argument("--image-size", type=int, default=96)
+    parser.add_argument("--max-steps", type=int, default=300)
+    parser.add_argument("--fps", type=int, default=30)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--success-threshold",
+        type=float,
+        default=0.6,
+        help="minimum final coverage to count an episode as a success",
+    )
+    parser.add_argument(
+        "--max-tries",
+        type=int,
+        default=4,
+        help="give up after num_episodes * max_tries attempts",
+    )
+    parser.add_argument(
+        "--jitter",
+        type=float,
+        default=4.0,
+        help="zero-mean Gaussian noise (stddev, in world coords) added to actions",
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        default=True,
+        help="force SDL dummy driver so no display is required (default: True)",
+    )
+    parser.add_argument(
+        "--no-headless",
+        dest="headless",
+        action="store_false",
+        help="render to a real display (requires a windowed environment)",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tsimulation/collect/zarr_writer.py
+++ b/Tsimulation/collect/zarr_writer.py
@@ -50,7 +50,7 @@ class ZarrDemoWriter:
         self.embodiment = embodiment
         self.chunk_timesteps = chunk_timesteps
         self.task_description = json.dumps(
-            {"env_args": env_args, "version": "0.1"}, separators=(",", ":")
+            {"env_args": env_args, "version": "0.3"}, separators=(",", ":")
         )
         self._buffer: dict[str, list[np.ndarray]] | None = None
         self._episode_idx = self._find_next_index()

--- a/Tsimulation/examples/dataset_stats.py
+++ b/Tsimulation/examples/dataset_stats.py
@@ -1,0 +1,236 @@
+"""Aggregate stats over a directory of PushShapes episode_*.zarr stores.
+
+Reports episode count, length stats, final / mean coverage, action ranges,
+and per-config breakdown (object × pusher × obstacle_level). Useful for
+sanity-checking a collected dataset at a glance.
+
+Usage::
+
+    python -m Tsimulation.examples.dataset_stats --dataset data/pushshapes_demos
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import zarr
+
+from Tsimulation.collect.zarr_writer import ACTION_KEY, REWARD_KEY
+
+_EPISODE_RE = re.compile(r"^episode_(\d+)\.zarr$")
+
+# (object_shape, pusher_shape, obstacle_level)
+Config = tuple[str, str, object]
+
+
+# ---------------------------------------------------------------------- #
+# Types
+# ---------------------------------------------------------------------- #
+
+
+@dataclass
+class _ConfigBucket:
+    """Per-(object, pusher, obstacles) accumulator filled while iterating."""
+
+    lengths: list[int] = field(default_factory=list)
+    final_cov: list[float] = field(default_factory=list)
+
+    def add(self, length: int, final_coverage: float) -> None:
+        self.lengths.append(length)
+        self.final_cov.append(final_coverage)
+
+    @property
+    def count(self) -> int:
+        return len(self.lengths)
+
+
+@dataclass
+class DatasetStats:
+    """Aggregate stats for a directory of episode_*.zarr stores."""
+
+    dataset: Path
+    n_episodes: int
+    n_with_data: int
+    total_frames: int
+    length_min: int
+    length_max: int
+    length_mean: float
+    length_median: float
+    final_cov_min: float
+    final_cov_max: float
+    final_cov_mean: float
+    mean_cov_mean: float
+    action_lo: list[float]
+    action_hi: list[float]
+    fps_seen: list[int]
+    per_config: dict[Config, _ConfigBucket]
+
+
+# ---------------------------------------------------------------------- #
+# Episode iteration
+# ---------------------------------------------------------------------- #
+
+
+def _list_episodes(dataset: Path) -> list[Path]:
+    """Subdirectories matching `episode_NNNNNN.zarr/` in `dataset`."""
+    return [
+        entry
+        for entry in sorted(dataset.iterdir())
+        if entry.is_dir() and _EPISODE_RE.match(entry.name)
+    ]
+
+
+def _parse_env_args(metadata: dict) -> dict:
+    try:
+        return json.loads(metadata.get("task_description", "{}")).get("env_args", {})
+    except json.JSONDecodeError:
+        return {}
+
+
+def _config_of(env_args: dict) -> Config:
+    return (
+        env_args.get("object_shape", "?"),
+        env_args.get("pusher_shape", "?"),
+        env_args.get("obstacle_level", "?"),
+    )
+
+
+@dataclass
+class _EpisodeRecord:
+    """One episode's flattened stats — folded into the global summary."""
+
+    length: int
+    final_coverage: float
+    mean_coverage: float
+    action_min: np.ndarray
+    action_max: np.ndarray
+    fps: int
+    config: Config
+
+
+def _load_one(ep_path: Path) -> _EpisodeRecord | None:
+    """Return None for empty / unreadable episodes (skipped in the summary)."""
+    store = zarr.open_group(str(ep_path), mode="r")
+    attrs = dict(store.attrs)
+    total = int(attrs.get("total_frames", 0))
+    if total <= 0:
+        return None
+    actions = np.asarray(store[ACTION_KEY][:total])
+    rewards = np.asarray(store[REWARD_KEY][:total]).reshape(-1)
+    return _EpisodeRecord(
+        length=total,
+        final_coverage=float(rewards[-1]),
+        mean_coverage=float(rewards.mean()),
+        action_min=actions.min(axis=0),
+        action_max=actions.max(axis=0),
+        fps=int(attrs.get("fps", 0)),
+        config=_config_of(_parse_env_args(attrs)),
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Summarize
+# ---------------------------------------------------------------------- #
+
+
+def _summarize(dataset: Path) -> DatasetStats:
+    ep_paths = _list_episodes(dataset)
+    if not ep_paths:
+        raise SystemExit(f"no episode_*.zarr stores in {dataset}")
+
+    records = [r for r in (_load_one(p) for p in ep_paths) if r is not None]
+    if not records:
+        raise SystemExit(f"all episodes in {dataset} are empty")
+
+    lengths = np.asarray([r.length for r in records])
+    final_cov = np.asarray([r.final_coverage for r in records])
+    mean_cov = np.asarray([r.mean_coverage for r in records])
+    action_lo = np.stack([r.action_min for r in records]).min(axis=0)
+    action_hi = np.stack([r.action_max for r in records]).max(axis=0)
+
+    per_config: dict[Config, _ConfigBucket] = {}
+    for r in records:
+        per_config.setdefault(r.config, _ConfigBucket()).add(r.length, r.final_coverage)
+
+    return DatasetStats(
+        dataset=dataset,
+        n_episodes=len(ep_paths),
+        n_with_data=len(records),
+        total_frames=int(lengths.sum()),
+        length_min=int(lengths.min()),
+        length_max=int(lengths.max()),
+        length_mean=float(lengths.mean()),
+        length_median=float(np.median(lengths)),
+        final_cov_min=float(final_cov.min()),
+        final_cov_max=float(final_cov.max()),
+        final_cov_mean=float(final_cov.mean()),
+        mean_cov_mean=float(mean_cov.mean()),
+        action_lo=action_lo.tolist(),
+        action_hi=action_hi.tolist(),
+        fps_seen=sorted({r.fps for r in records}),
+        per_config=per_config,
+    )
+
+
+def _print(stats: DatasetStats, success_threshold: float) -> None:
+    print(f"dataset: {stats.dataset}")
+    print(f"  episodes: {stats.n_episodes}  (with data: {stats.n_with_data})")
+    print(f"  total frames: {stats.total_frames}")
+    print(
+        f"  length: min={stats.length_min}  median={stats.length_median:.0f}  "
+        f"max={stats.length_max}  mean={stats.length_mean:.1f}"
+    )
+    print(
+        f"  final coverage: min={stats.final_cov_min:.3f}  "
+        f"mean={stats.final_cov_mean:.3f}  max={stats.final_cov_max:.3f}"
+    )
+    print(f"  mean coverage (per-ep average over frames): {stats.mean_cov_mean:.3f}")
+    print(
+        f"  action range:  x in [{stats.action_lo[0]:.1f}, {stats.action_hi[0]:.1f}]   "
+        f"y in [{stats.action_lo[1]:.1f}, {stats.action_hi[1]:.1f}]"
+    )
+    print(f"  fps values: {stats.fps_seen}")
+    print("  per-config breakdown  (object, pusher, obstacle_level):")
+    for cfg, bucket in sorted(stats.per_config.items()):
+        finals = np.asarray(bucket.final_cov)
+        successes = int((finals >= success_threshold).sum())
+        print(
+            f"    {cfg}: n={bucket.count:4d}  "
+            f"len mean={float(np.mean(bucket.lengths)):5.1f}  "
+            f"final_cov mean={finals.mean():.3f}  "
+            f"success(@{success_threshold:.2f})={successes}/{bucket.count}"
+        )
+
+
+# ---------------------------------------------------------------------- #
+# Entry point
+# ---------------------------------------------------------------------- #
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", required=True, help="directory of episode_*.zarr")
+    parser.add_argument(
+        "--success-threshold",
+        type=float,
+        default=0.6,
+        help="threshold on final coverage used to count successes (default: 0.6)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    stats = _summarize(Path(args.dataset))
+    _print(stats, success_threshold=args.success_threshold)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tsimulation/examples/visualize_episode.py
+++ b/Tsimulation/examples/visualize_episode.py
@@ -1,0 +1,501 @@
+"""Visualize a recorded PushShapes episode (observations + actions).
+
+Renders, frame-by-frame, the recorded observation image alongside a panel
+showing the proprioceptive state, the action target, current reward, and a
+short trace of the last few action targets overlaid on the scene.
+
+Usage::
+
+    # Interactive (window pops up)
+    python -m Tsimulation.examples.visualize_episode \\
+        --dataset data/pushshapes_demos --episode 0
+
+    # Headless: dump an MP4 of the episode (no display needed)
+    python -m Tsimulation.examples.visualize_episode \\
+        --dataset data/pushshapes_demos --episode 0 --save out.mp4
+
+Window hotkeys: SPACE play/pause, LEFT/RIGHT step, UP/DOWN speed,
+R restart, Q quit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import cv2
+import numpy as np
+import pygame
+import simplejpeg
+import zarr
+
+from Tsimulation.collect.zarr_writer import (
+    ACTION_KEY,
+    GOAL_KEY,
+    IMAGE_KEY,
+    REWARD_KEY,
+    STATE_KEY,
+)
+
+# Layout
+WORLD_SIZE = 512
+IMAGE_PANEL = 480
+RIGHT_PANEL_W = 320
+WINDOW_W = IMAGE_PANEL + RIGHT_PANEL_W
+WINDOW_H = IMAGE_PANEL
+TRACE_LEN = 30
+
+# Palette
+BG = (245, 245, 245)
+PANEL_BG = (255, 255, 255)
+TEXT = (25, 25, 25)
+DIM = (110, 110, 110)
+ACTION_MARK = (220, 40, 40)
+TRACE_LINE = (220, 40, 40)
+GOAL_MARK = (40, 160, 80)
+AGENT_MARK = (200, 60, 60)
+OBJECT_MARK = (60, 100, 200)
+
+
+# ---------------------------------------------------------------------- #
+# Data
+# ---------------------------------------------------------------------- #
+
+
+@dataclass
+class Episode:
+    """Decoded episode buffers + metadata."""
+
+    images: np.ndarray  # (T, H, W, 3) uint8
+    states: np.ndarray  # (T, 5)
+    actions: np.ndarray  # (T, 2)
+    rewards: np.ndarray  # (T,)
+    goal_pose: np.ndarray  # (3,) — constant across the episode
+    metadata: dict
+    path: Path
+
+    @property
+    def total(self) -> int:
+        return int(self.images.shape[0])
+
+
+@dataclass
+class RenderResources:
+    """pygame Surface + fonts; shared across interactive and headless paths."""
+
+    surface: pygame.Surface
+    font: pygame.font.Font
+    font_small: pygame.font.Font
+
+
+def _load_episode(ep_path: Path) -> Episode:
+    if not ep_path.exists():
+        raise FileNotFoundError(f"no such episode store: {ep_path}")
+    store = zarr.open_group(str(ep_path), mode="r")
+    attrs = dict(store.attrs)
+    total = int(attrs["total_frames"])
+    images_raw = store[IMAGE_KEY][:total]
+    return Episode(
+        images=np.stack(
+            [simplejpeg.decode_jpeg(bytes(b), colorspace="RGB") for b in images_raw],
+            axis=0,
+        ),
+        states=np.asarray(store[STATE_KEY][:total]),
+        actions=np.asarray(store[ACTION_KEY][:total]),
+        rewards=np.asarray(store[REWARD_KEY][:total]).reshape(-1),
+        goal_pose=np.asarray(store[GOAL_KEY][0]),
+        metadata=attrs,
+        path=ep_path,
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Rendering
+# ---------------------------------------------------------------------- #
+
+
+def _world_to_image(xy: Sequence[float], panel: int = IMAGE_PANEL) -> tuple[int, int]:
+    """Map (x, y) in 512-px world coords to pixel coords inside the image panel."""
+    s = panel / WORLD_SIZE
+    return int(round(xy[0] * s)), int(round(xy[1] * s))
+
+
+def _make_render_resources(headless: bool = False) -> RenderResources:
+    if headless:
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    pygame.init()
+    pygame.font.init()
+    return RenderResources(
+        surface=pygame.Surface((WINDOW_W, WINDOW_H)),
+        font=pygame.font.Font(None, 22),
+        font_small=pygame.font.Font(None, 18),
+    )
+
+
+def _blit_observation(surface: pygame.Surface, image_rgb: np.ndarray) -> None:
+    """Upscale the (low-res) recorded observation into the left panel."""
+    h, w = image_rgb.shape[:2]
+    img = pygame.image.frombuffer(
+        np.ascontiguousarray(image_rgb).tobytes(), (w, h), "RGB"
+    )
+    surface.blit(pygame.transform.smoothscale(img, (IMAGE_PANEL, IMAGE_PANEL)), (0, 0))
+
+
+def _draw_overlay_markers(
+    surface: pygame.Surface,
+    *,
+    state: np.ndarray,
+    action: np.ndarray,
+    goal_pose: np.ndarray,
+    recent_actions: Sequence[np.ndarray],
+) -> None:
+    """Trace of recent actions + current-action marker + agent/object/goal pins."""
+    if len(recent_actions) >= 2:
+        pygame.draw.lines(
+            surface, TRACE_LINE, False, [_world_to_image(a) for a in recent_actions], 2
+        )
+    # Action target — red X.
+    ax, ay = _world_to_image(action)
+    pygame.draw.line(surface, ACTION_MARK, (ax - 6, ay - 6), (ax + 6, ay + 6), 2)
+    pygame.draw.line(surface, ACTION_MARK, (ax - 6, ay + 6), (ax + 6, ay - 6), 2)
+    # Agent — red circle outline.
+    pgx, pgy = _world_to_image(state[0:2])
+    pygame.draw.circle(surface, AGENT_MARK, (pgx, pgy), 4, 1)
+    # Object center — blue square outline.
+    ox, oy = _world_to_image(state[2:4])
+    pygame.draw.rect(surface, OBJECT_MARK, (ox - 4, oy - 4, 8, 8), 1)
+    # Goal — green diamond outline.
+    gx, gy = _world_to_image(goal_pose[0:2])
+    pygame.draw.polygon(
+        surface,
+        GOAL_MARK,
+        [(gx, gy - 6), (gx + 6, gy), (gx, gy + 6), (gx - 6, gy)],
+        1,
+    )
+
+
+class _StatsPanel:
+    """Small helper for laying out a column of label/value rows on the right
+    panel. Internal y-cursor avoids the `nonlocal y` closure dance."""
+
+    PANEL_X = IMAGE_PANEL
+
+    def __init__(self, res: RenderResources):
+        self.surface = res.surface
+        self.font = res.font
+        self.font_small = res.font_small
+        self.y = 12
+
+    def background(self) -> None:
+        pygame.draw.rect(
+            self.surface,
+            PANEL_BG,
+            pygame.Rect(self.PANEL_X, 0, RIGHT_PANEL_W, WINDOW_H),
+        )
+        self.y = 12
+
+    def header(self, lines: Sequence[str]) -> None:
+        for line in lines:
+            self.surface.blit(
+                self.font_small.render(line, True, DIM), (self.PANEL_X + 12, self.y)
+            )
+            self.y += 18
+        self.y += 6
+        pygame.draw.line(
+            self.surface,
+            DIM,
+            (self.PANEL_X + 12, self.y),
+            (self.PANEL_X + RIGHT_PANEL_W - 12, self.y),
+            1,
+        )
+        self.y += 10
+
+    def section(self, title: str, rows: Sequence[tuple[str, str]]) -> None:
+        self.surface.blit(
+            self.font.render(title, True, TEXT), (self.PANEL_X + 12, self.y)
+        )
+        self.y += 22
+        for label, value in rows:
+            self.surface.blit(
+                self.font_small.render(label, True, DIM), (self.PANEL_X + 18, self.y)
+            )
+            self.surface.blit(
+                self.font_small.render(value, True, TEXT), (self.PANEL_X + 130, self.y)
+            )
+            self.y += 17
+        self.y += 8
+
+    def legend(self, items: Sequence[tuple[str, str]]) -> None:
+        self.surface.blit(
+            self.font.render("legend", True, TEXT), (self.PANEL_X + 12, self.y)
+        )
+        self.y += 22
+        for label, desc in items:
+            self.surface.blit(
+                self.font_small.render(label, True, DIM), (self.PANEL_X + 18, self.y)
+            )
+            self.surface.blit(
+                self.font_small.render(desc, True, TEXT), (self.PANEL_X + 110, self.y)
+            )
+            self.y += 17
+
+
+def _env_args_from_metadata(metadata: dict) -> dict:
+    try:
+        return json.loads(metadata.get("task_description", "{}")).get("env_args", {})
+    except json.JSONDecodeError:
+        return {}
+
+
+def _render_frame(
+    episode: Episode,
+    frame_idx: int,
+    recent_actions: Sequence[np.ndarray],
+    res: RenderResources,
+) -> None:
+    """Composite one frame onto `res.surface` in place."""
+    state = episode.states[frame_idx]
+    action = episode.actions[frame_idx]
+    reward = float(episode.rewards[frame_idx])
+
+    res.surface.fill(BG)
+    _blit_observation(res.surface, episode.images[frame_idx])
+    _draw_overlay_markers(
+        res.surface,
+        state=state,
+        action=action,
+        goal_pose=episode.goal_pose,
+        recent_actions=recent_actions,
+    )
+
+    panel = _StatsPanel(res)
+    panel.background()
+    env_args = _env_args_from_metadata(episode.metadata)
+    panel.header(
+        [
+            f"{episode.metadata.get('task_name', '?')}  "
+            f"frame {frame_idx + 1:>4}/{episode.total}",
+            f"fps={episode.metadata.get('fps', '?')}  "
+            f"embodiment={episode.metadata.get('embodiment', '?')}",
+            f"object={env_args.get('object_shape', '?')}  "
+            f"pusher={env_args.get('pusher_shape', '?')}  "
+            f"obs={env_args.get('obstacle_level', '?')}",
+        ]
+    )
+    panel.section(
+        "observations.state",
+        [
+            ("agent xy", f"{state[0]:7.1f}, {state[1]:7.1f}"),
+            ("object xy", f"{state[2]:7.1f}, {state[3]:7.1f}"),
+            ("object θ", f"{float(np.rad2deg(state[4])):+7.1f}°"),
+        ],
+    )
+    panel.section(
+        "actions  (target xy)",
+        [
+            ("target xy", f"{action[0]:7.1f}, {action[1]:7.1f}"),
+            (
+                "Δ to agent",
+                f"{action[0] - state[0]:+7.1f}, {action[1] - state[1]:+7.1f}",
+            ),
+        ],
+    )
+    panel.section(
+        "reward / goal",
+        [
+            ("reward (IoU)", f"{reward:6.3f}"),
+            ("goal xy", f"{episode.goal_pose[0]:7.1f}, {episode.goal_pose[1]:7.1f}"),
+            ("goal θ", f"{float(np.rad2deg(episode.goal_pose[2])):+7.1f}°"),
+        ],
+    )
+    panel.legend(
+        [
+            ("red x", "action target"),
+            ("red trail", "recent actions"),
+            ("red ○", "agent"),
+            ("blue □", "object"),
+            ("green ◆", "goal"),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------- #
+# Trace rolling buffer
+# ---------------------------------------------------------------------- #
+
+
+@dataclass
+class TraceBuffer:
+    """Fixed-length tail of recent action targets — used for the red trail."""
+
+    maxlen: int = TRACE_LEN
+    points: list[np.ndarray] = field(default_factory=list)
+
+    def push(self, action: np.ndarray) -> None:
+        self.points.append(action.copy())
+        if len(self.points) > self.maxlen:
+            self.points.pop(0)
+
+    def rebuild_for(self, episode: Episode, up_to: int) -> None:
+        start = max(0, up_to - self.maxlen + 1)
+        self.points = [episode.actions[k].copy() for k in range(start, up_to + 1)]
+
+
+# ---------------------------------------------------------------------- #
+# Output paths: MP4 dump + interactive playback
+# ---------------------------------------------------------------------- #
+
+
+def _save_mp4(episode: Episode, out_path: Path, fps: int) -> None:
+    res = _make_render_resources(headless=True)
+    writer = cv2.VideoWriter(
+        str(out_path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (WINDOW_W, WINDOW_H)
+    )
+    if not writer.isOpened():
+        raise RuntimeError(f"cv2.VideoWriter failed to open: {out_path}")
+
+    trace = TraceBuffer()
+    try:
+        for i in range(episode.total):
+            trace.push(episode.actions[i])
+            _render_frame(episode, i, trace.points, res)
+            # pygame surfarray gives (W, H, 3); cv2 wants (H, W, 3) BGR.
+            frame = np.transpose(pygame.surfarray.array3d(res.surface), (1, 0, 2))
+            writer.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
+    finally:
+        writer.release()
+        pygame.quit()
+    print(f"wrote {episode.total} frames -> {out_path}")
+
+
+def _run_interactive(episode: Episode, fps: int) -> None:
+    pygame.init()
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((WINDOW_W, WINDOW_H))
+    pygame.display.set_caption(f"PushShapes viz — {episode.path.name}")
+    clock = pygame.time.Clock()
+    res = RenderResources(
+        surface=screen,
+        font=pygame.font.Font(None, 22),
+        font_small=pygame.font.Font(None, 18),
+    )
+
+    trace = TraceBuffer()
+    trace.rebuild_for(episode, 0)
+    idx = 0
+    playing = True
+    speed = 1.0
+    last_advance_ms = pygame.time.get_ticks()
+    running = True
+
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+                continue
+            if event.type != pygame.KEYDOWN:
+                continue
+            if event.key in (pygame.K_q, pygame.K_x, pygame.K_ESCAPE):
+                running = False
+            elif event.key == pygame.K_SPACE:
+                playing = not playing
+            elif event.key == pygame.K_LEFT:
+                idx = max(0, idx - 1)
+                playing = False
+                trace.rebuild_for(episode, idx)
+            elif event.key == pygame.K_RIGHT:
+                idx = min(episode.total - 1, idx + 1)
+                playing = False
+                trace.rebuild_for(episode, idx)
+            elif event.key == pygame.K_UP:
+                speed = min(8.0, speed * 1.5)
+            elif event.key == pygame.K_DOWN:
+                speed = max(0.1, speed / 1.5)
+            elif event.key == pygame.K_r:
+                idx = 0
+                trace.rebuild_for(episode, idx)
+                playing = True
+
+        # Advance index based on playback speed.
+        if playing and episode.total > 1:
+            now = pygame.time.get_ticks()
+            step_ms = max(1, int(1000.0 / (fps * speed)))
+            if now - last_advance_ms >= step_ms:
+                last_advance_ms = now
+                if idx + 1 < episode.total:
+                    idx += 1
+                    trace.push(episode.actions[idx])
+                else:
+                    playing = False  # hold on the final frame
+
+        _render_frame(episode, idx, trace.points, res)
+        status = "PLAY" if playing else "PAUSE"
+        footer = res.font_small.render(
+            f"{status}  speed x{speed:.2f}   "
+            "[SPACE]play  [←/→]step  [↑/↓]speed  [R]reset  [Q]quit",
+            True,
+            DIM,
+        )
+        screen.blit(footer, (8, WINDOW_H - 20))
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.display.quit()
+    pygame.quit()
+
+
+# ---------------------------------------------------------------------- #
+# Entry point
+# ---------------------------------------------------------------------- #
+
+
+def _resolve_episode_path(args: argparse.Namespace) -> Path:
+    if args.path is not None:
+        return Path(args.path)
+    if args.dataset is None:
+        raise SystemExit("must provide either --dataset/--episode or --path")
+    return Path(args.dataset) / f"episode_{args.episode:06d}.zarr"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    src = parser.add_argument_group("episode source")
+    src.add_argument("--dataset", help="directory containing episode_*.zarr stores")
+    src.add_argument(
+        "--episode", type=int, default=0, help="episode index inside --dataset"
+    )
+    src.add_argument(
+        "--path",
+        help="path to a single episode_*.zarr store (overrides --dataset/--episode)",
+    )
+    parser.add_argument(
+        "--save", help="if set, render headlessly and save an MP4 to this path"
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=None,
+        help="override playback fps (default: stored fps)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    episode = _load_episode(_resolve_episode_path(args))
+    fps = args.fps or int(episode.metadata.get("fps", 30))
+    if args.save:
+        _save_mp4(episode, Path(args.save), fps=fps)
+    else:
+        _run_interactive(episode, fps=fps)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tsimulation/pushshapes/env.py
+++ b/Tsimulation/pushshapes/env.py
@@ -51,11 +51,12 @@ class PushShapesEnv(gym.Env):
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 30}
 
     WORLD_SIZE: float = 512.0
-    PUSHER_SPEED: float = 200.0  # px/sec cap on commanded velocity
-    DT: float = 1.0 / 30.0  # outer step is 1/30s; subdivided for contacts
-    SUBSTEPS: int = 10
-    DAMPING: float = 0.85  # global linear damping → object drifts to rest
-    SUCCESS_THRESHOLD: float = 0.95  # IoU(object, goal) needed to terminate
+    PUSHER_SPEED: float = 200.0
+    DT: float = 1.0 / 30.0
+    SUBSTEPS: int = 20
+    DAMPING: float = 0
+    STICK_TURN_RATE: float = 4.0  # rad/s — max kinematic rotation of stick pusher
+    SUCCESS_THRESHOLD: float = 0.95
     SPAWN_MARGIN: float = 60.0
 
     def __init__(
@@ -200,9 +201,10 @@ class PushShapesEnv(gym.Env):
             self._drive_pusher_toward(tx, ty, dt_sub)
             self._space.step(dt_sub)
 
-        # Zero pusher velocity between outer steps so a stale velocity
-        # doesn't drift contacts when no new action comes in.
+        # Zero pusher velocity (and angular velocity) between outer steps so
+        # stale motion doesn't drift contacts when no new action comes in.
         self._pusher_body.velocity = (0.0, 0.0)
+        self._pusher_body.angular_velocity = 0.0
         self._step_count += 1
 
         coverage = float(self._coverage())
@@ -282,22 +284,38 @@ class PushShapesEnv(gym.Env):
     # ------------------------------------------------------------------ #
 
     def _drive_pusher_toward(self, tx: float, ty: float, dt_sub: float) -> None:
-        """Single-substep velocity command toward (tx, ty) in world coords."""
-        pos = self._pusher_body.position
+        """Single-substep velocity command toward (tx, ty) in world coords.
+
+        For the stick pusher we set `angular_velocity` (rather than snapping
+        `angle`) so contact impulses on the object stay smooth — the
+        kinematic body integrates the spin over the substep.
+        """
+        body = self._pusher_body
+        pos = body.position
         dx, dy = tx - pos.x, ty - pos.y
         dist = math.hypot(dx, dy)
         if dist < _MIN_TARGET_DIST:
-            self._pusher_body.velocity = (0.0, 0.0)
+            body.velocity = (0.0, 0.0)
+            body.angular_velocity = 0.0
             return
+
         # Cap by PUSHER_SPEED but also by distance-remaining-per-substep so
         # we don't overshoot the target inside a single substep.
         speed = min(self.PUSHER_SPEED, dist / dt_sub)
         ux, uy = dx / dist, dy / dist
-        self._pusher_body.velocity = (ux * speed, uy * speed)
+        body.velocity = (ux * speed, uy * speed)
+
         if self.pusher_shape == "stick" and dist > _MIN_STICK_TURN_DIST:
-            # KINEMATIC body — angle can be set directly without disturbing
-            # the physics solver.
-            self._pusher_body.angle = math.atan2(uy, ux)
+            # Shortest signed angle diff to the velocity direction, capped at
+            # STICK_TURN_RATE so the stick eases into its new heading rather
+            # than rotating instantly through contacts.
+            desired = math.atan2(uy, ux)
+            diff = (desired - float(body.angle) + math.pi) % (2 * math.pi) - math.pi
+            body.angular_velocity = max(
+                -self.STICK_TURN_RATE, min(self.STICK_TURN_RATE, diff / dt_sub)
+            )
+        else:
+            body.angular_velocity = 0.0
 
     def _build_boundary_walls(self) -> None:
         """Four static segments enclosing the 512x512 arena."""

--- a/Tsimulation/pushshapes/shapes.py
+++ b/Tsimulation/pushshapes/shapes.py
@@ -53,8 +53,8 @@ SHAPES: dict[str, list[tuple[float, float, float, float]]] = {
     ],
 }
 
-OBJECT_DENSITY = 0.01
-OBJECT_FRICTION = 15.0
+OBJECT_DENSITY = 0.30
+OBJECT_FRICTION = 0.6
 PUSHER_RADIUS = 15.0
 STICK_HALF_LEN = 30.0
 STICK_HALF_THICK = 5.0

--- a/Tsimulation/tests/test_features.py
+++ b/Tsimulation/tests/test_features.py
@@ -1,0 +1,192 @@
+"""Smoke tests for the non-physics features:
+
+- scripted_action heuristic returns valid targets
+- scripted_collect runs an end-to-end attempt without raising
+- dataset_stats aggregates a synthesized dataset
+- visualize_episode renders frames headlessly to an MP4
+
+Run with::
+
+    SDL_VIDEODRIVER=dummy pytest Tsimulation/tests/test_features.py -q
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+from Tsimulation.collect.scripted_collect import (
+    APPROACH_OFFSET,
+    scripted_action,
+)
+from Tsimulation.collect.zarr_writer import ZarrDemoWriter
+
+
+def test_scripted_action_clipped_and_finite():
+    action = scripted_action(
+        agent_xy=np.array([100.0, 100.0], dtype=np.float32),
+        object_xy=np.array([200.0, 200.0], dtype=np.float32),
+        goal_xy=np.array([400.0, 200.0], dtype=np.float32),
+        world_size=512.0,
+    )
+    assert action.shape == (2,)
+    assert action.dtype == np.float32
+    assert np.all(action >= 0.0)
+    assert np.all(action <= 512.0)
+    assert np.all(np.isfinite(action))
+
+
+def test_scripted_action_approaches_when_far():
+    """When the pusher is far from the contact point, target is roughly the
+    approach point behind the object (opposite the goal direction)."""
+    agent_xy = np.array([10.0, 10.0], dtype=np.float32)
+    object_xy = np.array([256.0, 256.0], dtype=np.float32)
+    goal_xy = np.array([456.0, 256.0], dtype=np.float32)
+    action = scripted_action(
+        agent_xy=agent_xy, object_xy=object_xy, goal_xy=goal_xy, world_size=512.0
+    )
+    expected = object_xy - np.array([1.0, 0.0], dtype=np.float32) * APPROACH_OFFSET
+    assert float(np.linalg.norm(action - expected)) < 1e-3
+
+
+def test_scripted_action_pushes_when_close():
+    """When the pusher is already at the contact point, action target is past
+    the goal in the push direction."""
+    object_xy = np.array([200.0, 200.0], dtype=np.float32)
+    goal_xy = np.array([400.0, 200.0], dtype=np.float32)
+    push_dir = np.array([1.0, 0.0], dtype=np.float32)
+    agent_xy = object_xy - push_dir * APPROACH_OFFSET  # exactly on approach point
+    action = scripted_action(
+        agent_xy=agent_xy, object_xy=object_xy, goal_xy=goal_xy, world_size=512.0
+    )
+    # Action target should be in the +x direction from the object.
+    assert action[0] > object_xy[0]
+
+
+def test_scripted_action_handles_zero_distance():
+    xy = np.array([256.0, 256.0], dtype=np.float32)
+    action = scripted_action(agent_xy=xy, object_xy=xy, goal_xy=xy, world_size=512.0)
+    assert np.all(np.isfinite(action))
+
+
+def test_scripted_collector_runs_end_to_end():
+    """We don't assert success — physics can be sticky — but the collector
+    must run a few attempts without raising and report a saved count >= 0."""
+    from Tsimulation.collect import scripted_collect
+
+    with tempfile.TemporaryDirectory() as tmp:
+        parser = scripted_collect.build_parser()
+        args = parser.parse_args(
+            [
+                "--output",
+                tmp,
+                "--object",
+                "T",
+                "--pusher",
+                "circle",
+                "--obstacles",
+                "0",
+                "--num-episodes",
+                "1",
+                "--image-size",
+                "32",
+                "--max-steps",
+                "60",
+                "--max-tries",
+                "2",
+                "--success-threshold",
+                "0.0",  # commit any non-empty attempt — we only care that it runs
+                "--seed",
+                "7",
+                "--jitter",
+                "0.0",
+                "--headless",
+            ]
+        )
+        # rc may be 0 or 1; we only assert it didn't raise.
+        scripted_collect.run(args)
+
+
+def test_dataset_stats_on_synthesized_dataset():
+    """Synthesize two short episodes via the writer, then run stats."""
+    from Tsimulation.examples import dataset_stats
+
+    with tempfile.TemporaryDirectory() as tmp:
+        env_args = {
+            "object_shape": "T",
+            "pusher_shape": "circle",
+            "obstacle_level": 0,
+        }
+        writer = ZarrDemoWriter(path=tmp, env_args=env_args, image_size=8)
+        rng = np.random.default_rng(0)
+        for ep_len in (3, 5):
+            writer.start_episode()
+            for k in range(ep_len):
+                writer.add_step(
+                    image=rng.integers(0, 255, size=(8, 8, 3), dtype=np.uint8),
+                    state=rng.standard_normal(5).astype(np.float32),
+                    action=rng.uniform(0, 512, size=2).astype(np.float32),
+                    reward=float(k) / ep_len,  # rising reward
+                    goal_pose=rng.standard_normal(3).astype(np.float32),
+                )
+            writer.commit_episode()
+        writer.close()
+
+        stats = dataset_stats._summarize(Path(tmp))
+        assert stats.n_episodes == 2
+        assert stats.n_with_data == 2
+        assert stats.total_frames == 3 + 5
+        assert stats.length_min == 3
+        assert stats.length_max == 5
+        assert ("T", "circle", 0) in stats.per_config
+        assert stats.per_config[("T", "circle", 0)].count == 2
+        # printing should not raise
+        dataset_stats._print(stats, success_threshold=0.5)
+
+
+def test_visualize_episode_save_mp4(tmp_path):
+    """Headless render: save a short MP4 from a synthesized 4-frame episode."""
+    from Tsimulation.examples import visualize_episode
+
+    dataset_dir = tmp_path / "ds"
+    dataset_dir.mkdir()
+    env_args = {
+        "object_shape": "T",
+        "pusher_shape": "circle",
+        "obstacle_level": 0,
+    }
+    writer = ZarrDemoWriter(path=dataset_dir, env_args=env_args, image_size=32)
+    rng = np.random.default_rng(123)
+    writer.start_episode()
+    for k in range(4):
+        writer.add_step(
+            image=rng.integers(0, 255, size=(32, 32, 3), dtype=np.uint8),
+            state=np.array(
+                [100.0 + k, 100.0 + k, 200.0, 200.0, 0.1 * k], dtype=np.float32
+            ),
+            action=np.array([150.0 + k * 10, 150.0], dtype=np.float32),
+            reward=0.1 * k,
+            goal_pose=np.array([400.0, 300.0, 0.5], dtype=np.float32),
+        )
+    writer.commit_episode()
+    writer.close()
+
+    out_mp4 = tmp_path / "out.mp4"
+    rc = visualize_episode.main(
+        [
+            "--dataset",
+            str(dataset_dir),
+            "--episode",
+            "0",
+            "--save",
+            str(out_mp4),
+        ]
+    )
+    assert rc == 0
+    assert out_mp4.exists()
+    assert out_mp4.stat().st_size > 0


### PR DESCRIPTION
tshape sim environment

Add Tsimulation viz/scripted/stats tools + physics tuning

- New tools: visualize_episode (replay obs+action), scripted_collect
  (headless heuristic), dataset_stats (per-config summary).
- Physics: smoother kinematic pusher (angular_velocity-driven stick
  rotation), retuned damping/friction/density for less twitchy contact.
- zarr_writer: bump episode metadata version 0.1 -> 0.3.
- 7 new smoke tests in tests/test_features.py (all 34 tests pass).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>