### PR TITLE
Flexible H-Net stage refactor

### DIFF
--- a/egomimic/algo/hnet.py
+++ b/egomimic/algo/hnet.py
@@ -1,0 +1,287 @@
+"""
+H-Net policy for EgoVerse — stage-based architecture.
+
+The policy treats the action sequence as the input modality (autoregressive,
+causal). Observations are encoded by a ``CondEncoderModule`` into a
+``cond_dict`` carried by an ``HNetContext`` that is threaded through the
+stage tree. Each stage reads whichever cond key it wants (or ignores cond
+entirely).
+
+Loss = action MSE (next-action prediction) +
+       sum_over_chunkers( weight * ratio_loss(boundary_predictions) ).
+
+The per-chunker ratio-loss weights live inside the chunker stages themselves;
+this algo just calls ``ratio_loss_from_aux(ctx.aux)`` after forward.
+"""
+from collections import OrderedDict
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from overrides import override
+
+from egomimic.algo.algo import Algo
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
+from egomimic.models.hnet_nets.context import HNetContext
+from egomimic.models.hnet_nets.hnet import HNet as HNetCore
+from egomimic.models.hnet_nets.hnet import ratio_loss_from_aux
+from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+
+
+class HNetPolicy(nn.Module):
+    """
+    action-tokenizer → stage-based H-Net → action-detokenizer.
+
+    Owns action_in / action_out projections, BOS token, positional embedding,
+    the ``CondEncoderModule``, and the ``HNetCore`` (stage tree).
+    """
+
+    def __init__(
+        self,
+        action_dim: int,
+        action_horizon: int,
+        d_model: int,
+        cond_encoder: CondEncoderModule,
+        hnet: HNetCore,
+    ):
+        super().__init__()
+        self.action_dim = action_dim
+        self.action_horizon = action_horizon
+        self.d_model = d_model
+
+        self.action_in = nn.Linear(action_dim, d_model)
+        self.action_out = nn.Linear(d_model, action_dim)
+        self.bos = nn.Parameter(torch.zeros(1, 1, d_model))
+        nn.init.normal_(self.bos, std=0.02)
+        self.pos_emb = nn.Parameter(torch.zeros(1, action_horizon, d_model))
+        nn.init.normal_(self.pos_emb, std=0.02)
+
+        self.cond_encoder = cond_encoder
+        self.hnet = hnet
+
+        # Sanity-check that the stage tree's outer hidden dim matches d_model.
+        if self.hnet.input_hidden_dim != d_model:
+            raise ValueError(
+                f"hnet.input_hidden_dim ({self.hnet.input_hidden_dim}) "
+                f"must equal d_model ({d_model})."
+            )
+        if self.hnet.output_hidden_dim != d_model:
+            raise ValueError(
+                f"hnet.output_hidden_dim ({self.hnet.output_hidden_dim}) "
+                f"must equal d_model ({d_model})."
+            )
+
+    def _build_ctx(self, obs: dict) -> HNetContext:
+        cond_dict = self.cond_encoder.encode(obs, self.action_horizon)
+        return HNetContext(cond_dict=cond_dict, aux=[], inference_params=None)
+
+    def forward(self, actions: torch.Tensor, obs: dict):
+        """
+        actions: (B, T, action_dim) ground-truth actions for teacher-forcing.
+        obs:     dict of (B, ...) obs tensors.
+
+        Returns: (pred_actions (B, T, action_dim), aux list).
+        """
+        B, T, _ = actions.shape
+        x = self.action_in(actions)
+        x = torch.cat([self.bos.expand(B, -1, -1), x[:, :-1]], dim=1)
+        x = x + self.pos_emb[:, :T]
+
+        ctx = self._build_ctx(obs)
+        h = self.hnet(x, ctx)
+        return self.action_out(h), ctx.aux
+
+    @torch.no_grad()
+    def generate(self, obs: dict, batch_size: int, device) -> torch.Tensor:
+        """Autoregressive rollout from BOS for ``action_horizon`` steps."""
+        T = self.action_horizon
+        cond_dict = self.cond_encoder.encode(obs, T)
+        actions = torch.zeros(batch_size, T, self.action_dim, device=device)
+        dtype = next(self.parameters()).dtype
+
+        inference_params = self.hnet.allocate_inference_cache(
+            batch_size=batch_size, max_seqlen=T, device=device, dtype=dtype,
+        )
+
+        # Per-step cond_dict slice (B, d_cond) — AdaLN broadcasts over the
+        # single-token sequence dim inside the encoder.
+        def slice_cond(t: int) -> dict:
+            return {k: v[:, t] if v.dim() == 3 else v for k, v in cond_dict.items()}
+
+        cur = self.bos.expand(batch_size, -1, -1) + self.pos_emb[:, 0:1]
+        for t in range(T):
+            ctx = HNetContext(
+                cond_dict=slice_cond(t), aux=[], inference_params=inference_params,
+            )
+            h = self.hnet.step(cur, ctx)
+            a_t = self.action_out(h)
+            actions[:, t : t + 1] = a_t
+            if t < T - 1:
+                cur = self.action_in(a_t) + self.pos_emb[:, t + 1 : t + 2]
+        return actions
+
+
+class HNet(Algo):
+    """
+    H-Net policy Algo. Single-domain action-sequence model with per-frame
+    obs conditioning -- each action token sees the obs at its own timestep.
+    """
+
+    def __init__(
+        self,
+        data_schematic,
+        action_dim: int,
+        action_horizon: int,
+        d_model: int,
+        d_cond: int,
+        cond_encoder: CondEncoderModule,
+        hnet: HNetCore,
+        domains: list = None,
+        ac_keys: dict = None,
+        device=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.data_schematic = data_schematic
+        self.domains = list(domains or [])
+        self.ac_keys = dict(ac_keys or {})
+        self.action_horizon = action_horizon
+        self.d_cond = d_cond
+        self.device = device or torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+
+        policy = HNetPolicy(
+            action_dim=action_dim,
+            action_horizon=action_horizon,
+            d_model=d_model,
+            cond_encoder=cond_encoder,
+            hnet=hnet,
+        )
+        self.nets = nn.ModuleDict({"policy": policy})
+        self.nets = self.nets.float().to(self.device)
+
+        # Resolve per-embodiment keys via data_schematic (like HPT).
+        self.embodiment_ids = {}
+        self.proprio_keys = {}
+        self.lang_keys = {}
+        self.camera_keys = {}
+        self.resolved_ac_keys = {}
+        for emb in self.domains:
+            emb_id = get_embodiment_id(emb)
+            self.embodiment_ids[emb] = emb_id
+            self.proprio_keys[emb_id] = []
+            self.lang_keys[emb_id] = []
+            self.camera_keys[emb_id] = []
+            for key in data_schematic.keys_of_type("action_keys", emb_id):
+                if (
+                    data_schematic.is_key_with_embodiment(key, emb_id)
+                    and key == self.ac_keys[emb]
+                ):
+                    self.resolved_ac_keys[emb_id] = key
+            for key in data_schematic.keys_of_type("proprio_keys", emb_id):
+                if data_schematic.is_key_with_embodiment(key, emb_id):
+                    self.proprio_keys[emb_id].append(key)
+            for key in data_schematic.keys_of_type("lang_keys", emb_id):
+                if data_schematic.is_key_with_embodiment(key, emb_id):
+                    self.lang_keys[emb_id].append(key)
+            for key in data_schematic.keys_of_type("camera_keys", emb_id):
+                if data_schematic.is_key_with_embodiment(key, emb_id):
+                    self.camera_keys[emb_id].append(key)
+
+    # ---- Algo API --------------------------------------------------------
+
+    @override
+    def process_batch_for_training(self, batch):
+        processed = {}
+        for emb_name, _batch in batch.items():
+            emb_id = get_embodiment_id(emb_name)
+            processed[emb_id] = {}
+            for key, value in _batch.items():
+                key_name = self.data_schematic.zarr_key_to_keyname(key, emb_id)
+                if key is not None:
+                    processed[emb_id][key_name] = value
+
+            ac_key = self.resolved_ac_keys[emb_id]
+            B, S, _ = processed[emb_id][ac_key].shape
+            processed[emb_id]["pad_mask"] = torch.ones(
+                B, S, 1, device=processed[emb_id][ac_key].device
+            )
+            processed[emb_id] = self.data_schematic.normalize_data(processed[emb_id], emb_id)
+            processed[emb_id]["embodiment"] = torch.tensor(
+                [emb_id], device=self.device, dtype=torch.int64
+            )
+            for key, value in processed[emb_id].items():
+                if isinstance(value, torch.Tensor):
+                    value = value.to(self.device)
+                    if value.is_floating_point():
+                        value = value.float()
+                    processed[emb_id][key] = value
+        return processed
+
+    def _build_obs(self, _batch, emb_id):
+        obs = {}
+        for key in (
+            self.proprio_keys[emb_id]
+            + self.lang_keys[emb_id]
+            + self.camera_keys[emb_id]
+        ):
+            if key in _batch:
+                obs[key] = _batch[key]
+        return obs
+
+    @override
+    def forward_training(self, batch):
+        predictions = OrderedDict()
+        policy = self.nets["policy"]
+        for emb_id, _batch in batch.items():
+            ac_key = self.resolved_ac_keys[emb_id]
+            actions = _batch[ac_key]
+            obs = self._build_obs(_batch, emb_id)
+
+            pred, aux = policy(actions, obs)
+            mse = nn.functional.mse_loss(pred, actions)
+            rloss = ratio_loss_from_aux(aux, device=mse.device)
+            predictions[f"{emb_id}_pred"] = pred
+            predictions[f"{emb_id}_action_loss"] = mse
+            predictions[f"{emb_id}_ratio_loss"] = rloss
+        return predictions
+
+    @override
+    def forward_eval(self, batch):
+        unnorm = {}
+        policy = self.nets["policy"]
+        for emb_id, _batch in batch.items():
+            ac_key = self.resolved_ac_keys[emb_id]
+            obs = self._build_obs(_batch, emb_id)
+            B = next(iter(obs.values())).shape[0] if obs else _batch[ac_key].shape[0]
+            actions = policy.generate(obs, batch_size=B, device=self.device)
+            preds = OrderedDict()
+            preds[ac_key] = actions
+            unnorm_actions = self.data_schematic.unnormalize_data(preds, emb_id)
+            for key, val in unnorm_actions.items():
+                unnorm[f"emb{emb_id}_{key}"] = val
+        return unnorm
+
+    @override
+    def compute_losses(self, predictions, batch):
+        total = torch.tensor(0.0, device=self.device)
+        loss_dict = OrderedDict()
+        for emb_id in batch.keys():
+            a = predictions[f"{emb_id}_action_loss"]
+            r = predictions[f"{emb_id}_ratio_loss"]
+            loss_dict[f"emb{emb_id}_action_loss"] = a
+            loss_dict[f"emb{emb_id}_ratio_loss"] = r
+            # Ratio-loss weights are baked into each chunker stage, so r
+            # is already a properly-weighted sum.
+            total = total + a + r
+        loss_dict["action_loss"] = total / max(len(batch), 1)
+        return loss_dict
+
+    @override
+    def log_info(self, info):
+        log = OrderedDict()
+        log["Loss"] = info["losses"]["action_loss"].item()
+        for k, v in info["losses"].items():
+            log[k] = v.item()
+        return log

--- a/egomimic/hydra_configs/model/hnet_pushshapes.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes.yaml
@@ -1,0 +1,100 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.HNet
+  data_schematic: _${data.dataset.data_schematic}
+
+  # ---- core dims ----
+  action_dim: 2
+  action_horizon: 32
+  d_model: 128
+  d_cond: 128
+
+  # ---- conditioning encoder ----
+  # Produces a cond_dict consumed by stages via their cond_key. The default
+  # "fused_cond" entry is per-token (B, T, d_cond) from concatenated obs
+  # encodings projected by an MLP. Per-obs un-fused embeddings are also
+  # exposed when per_obs_keys=True.
+  cond_encoder:
+    _target_: egomimic.models.hnet_nets.cond_encoders.CondEncoderModule
+    d_cond: 128
+    output_key: "fused_cond"
+    cond_proj_widths: [128, 128]
+    obs_specs:
+      state_agent_obj:
+        input_dim: 5
+        embed_dim: 64
+        widths: [128]
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv
+        in_channels: 3
+        channels: [32, 64, 128, 256]
+        kernel_size: 3
+        stride: 2
+        embed_dim: 128
+        norm_groups: 8
+
+  # ---- stage-based H-Net ----
+  # The list below is wired into a chain at construction:
+  #   stages[0] (outer encoder/decoder)
+  #     └─ stages[1] (chunker, compression ratio 8)
+  #           └─ stages[2] (inner compute, terminal)
+  # Each stage declares its input_hidden_dim / output_hidden_dim explicitly;
+  # ChunkerStage handles the outer→inner dim bridge via explicit Linear
+  # projections (NO padding-based dim bridging).
+  hnet:
+    _target_: egomimic.models.hnet_nets.hnet.HNet
+    stages:
+      - _target_: egomimic.models.hnet_nets.stages.EncoderDecoderStage
+        input_hidden_dim: 128
+        output_hidden_dim: 128
+        cond_key: "fused_cond"
+        d_cond: 128
+        causal: true
+        encoder:
+          arch_layout: "T4"
+          d_model: 128
+          d_intermediate: 512
+          num_heads: 4
+          cond: true
+        decoder:
+          arch_layout: "T4"
+          d_model: 128
+          d_intermediate: 512
+          num_heads: 4
+          cond: true
+      - _target_: egomimic.models.hnet_nets.stages.ChunkerStage
+        input_hidden_dim: 128
+        output_hidden_dim: 192
+        target_compression_ratio: 8.0
+        ratio_loss_weight: 0.03
+        cond_key: "fused_cond"
+      - _target_: egomimic.models.hnet_nets.stages.ComputeStage
+        input_hidden_dim: 192
+        output_hidden_dim: 192
+        cond_key: "fused_cond"
+        d_cond: 128
+        causal: true
+        main_network:
+          arch_layout: "T4"
+          d_model: 192
+          d_intermediate: 768
+          num_heads: 4
+          cond: false        # inner compute does not run AdaLN
+
+  # ---- domain / action key wiring (mirrors HPT) ----
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/models/hnet_nets/__init__.py
+++ b/egomimic/models/hnet_nets/__init__.py
@@ -1,0 +1,8 @@
+from egomimic.models.hnet_nets.context import HNetContext
+from egomimic.models.hnet_nets.hnet import HNet, ratio_loss_from_aux
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
+from egomimic.models.hnet_nets.stages import (
+    EncoderDecoderStage,
+    ChunkerStage,
+    ComputeStage,
+)

--- a/egomimic/models/hnet_nets/_smoke_stages.py
+++ b/egomimic/models/hnet_nets/_smoke_stages.py
@@ -1,0 +1,124 @@
+"""
+Dev smoke test for the stage-based H-Net.
+
+Run via:
+
+    python -m egomimic.models.hnet_nets._smoke_stages
+
+Builds a tiny 3-stage tree (EncoderDecoder → Chunker → Compute), runs a
+forward pass with dummy actions + cond_dict, verifies output shape and that
+the chunker registered its bpred entry into ctx.aux, then runs step() across
+all T tokens and compares to the cached forward output.
+"""
+import math
+
+import torch
+
+from egomimic.models.hnet_nets.context import HNetContext
+from egomimic.models.hnet_nets.hnet import HNet, ratio_loss_from_aux
+from egomimic.models.hnet_nets.stages import (
+    ChunkerStage,
+    ComputeStage,
+    EncoderDecoderStage,
+)
+
+
+def build_tiny_hnet(d_model: int = 64, d_inner: int = 64, d_cond: int = 64) -> HNet:
+    stages = [
+        EncoderDecoderStage(
+            input_hidden_dim=d_model,
+            output_hidden_dim=d_model,
+            encoder=dict(
+                arch_layout="T2", d_model=d_model, d_intermediate=128,
+                num_heads=4, cond=True,
+            ),
+            decoder=dict(
+                arch_layout="T2", d_model=d_model, d_intermediate=128,
+                num_heads=4, cond=True,
+            ),
+            cond_key="fused_cond",
+            d_cond=d_cond,
+            causal=True,
+        ),
+        ChunkerStage(
+            input_hidden_dim=d_model,
+            output_hidden_dim=d_inner,
+            target_compression_ratio=4.0,
+            ratio_loss_weight=0.03,
+            cond_key="fused_cond",
+        ),
+        ComputeStage(
+            input_hidden_dim=d_inner,
+            output_hidden_dim=d_inner,
+            main_network=dict(
+                arch_layout="T2", d_model=d_inner, d_intermediate=128,
+                num_heads=4, cond=False,
+            ),
+            cond_key="fused_cond",
+            d_cond=0,            # inner stage has no AdaLN
+            causal=True,
+        ),
+    ]
+    return HNet(stages)
+
+
+def main():
+    torch.manual_seed(0)
+    B, T, d_model, d_cond = 2, 32, 64, 64
+
+    hnet = build_tiny_hnet(d_model=d_model, d_inner=d_model, d_cond=d_cond).eval()
+
+    x_full = torch.randn(B, T, d_model)
+    cond = torch.randn(B, T, d_cond)
+
+    ctx = HNetContext(cond_dict={"fused_cond": cond}, aux=[])
+    with torch.no_grad():
+        y_full = hnet(x_full, ctx)
+    print(f"forward output shape: {tuple(y_full.shape)}")
+    assert y_full.shape == (B, T, d_model), y_full.shape
+
+    print(f"ctx.aux entries: {len(ctx.aux)}")
+    assert len(ctx.aux) == 1, "exactly one chunker should register aux"
+    entry = ctx.aux[0]
+    assert "bpred" in entry and "target_ratio" in entry and "weight" in entry
+    bpred = entry["bpred"]
+    print(
+        f"  bpred.boundary_mask shape: {tuple(bpred.boundary_mask.shape)} "
+        f"(expected ({B},{T}))"
+    )
+    assert bpred.boundary_mask.shape == (B, T)
+
+    rloss = ratio_loss_from_aux(ctx.aux)
+    print(f"ratio_loss: {rloss.item():.6f}")
+
+    # --- step parity ---
+    state = hnet.allocate_inference_cache(
+        batch_size=B, max_seqlen=T, device=x_full.device, dtype=torch.float32,
+    )
+    y_step = torch.zeros_like(y_full)
+    with torch.no_grad():
+        for t in range(T):
+            cond_t = cond[:, t]
+            step_ctx = HNetContext(
+                cond_dict={"fused_cond": cond_t}, aux=[], inference_params=state,
+            )
+            y_t = hnet.step(x_full[:, t : t + 1], step_ctx)
+            y_step[:, t : t + 1] = y_t
+
+    diff = (y_full - y_step).abs().max().item()
+    print(f"max |forward - step|: {diff:.3e}")
+
+    tol = 5e-4
+    if diff > tol:
+        print(f"WARN: step/forward divergence above tol={tol}. "
+              f"This can happen when chunker boundary patterns differ between "
+              f"the padded full-context path and the per-token step path "
+              f"(known difference inherited from the original H-Net design).")
+    else:
+        print(f"OK: step/forward agree within {tol}.")
+
+    print("smoke test complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/egomimic/models/hnet_nets/blocks.py
+++ b/egomimic/models/hnet_nets/blocks.py
@@ -1,0 +1,527 @@
+"""
+Transformer + Mamba2 blocks for the vendored HNet.
+
+Arch types (matching upstream layout-string vocabulary):
+    't' : attention-only block (no MLP)
+    'T' : attention + SwiGLU MLP block
+    'm' : Mamba2-only block (no MLP)        -- requires `mamba_ssm`
+    'M' : Mamba2 + SwiGLU MLP block         -- requires `mamba_ssm`
+
+Optional kernels (auto-detected, fallback if absent):
+    flash_attn:  packed-mode attention uses `flash_attn_varlen_func`,
+                 else SDPA + block-diagonal mask.
+    mamba_ssm:   'm'/'M' arch blocks (Mamba2 mixer). Without mamba_ssm,
+                 only 't'/'T' arch is supported.
+
+Tensor shape conventions (match upstream):
+    Padded mode: (B, L, D) with mask: (B, L).
+    Packed mode: (T_total, D) with cu_seqlens: (B+1,) + max_seqlen: int.
+"""
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from egomimic.models.hnet_nets.config import HNetConfig, get_stage_cfg
+
+# Optional flash-attn varlen kernel.
+try:
+    from flash_attn import flash_attn_varlen_func  # type: ignore
+    _HAS_FLASH_ATTN = True
+except Exception:
+    flash_attn_varlen_func = None  # type: ignore
+    _HAS_FLASH_ATTN = False
+
+# Optional Mamba2 SSM block.
+try:
+    from mamba_ssm.modules.mamba2 import Mamba2 as _Mamba2  # type: ignore
+    _HAS_MAMBA = True
+except Exception:
+    _Mamba2 = None  # type: ignore
+    _HAS_MAMBA = False
+
+
+def has_flash_attn() -> bool:
+    return _HAS_FLASH_ATTN
+
+
+def has_mamba() -> bool:
+    return _HAS_MAMBA
+
+
+@dataclass
+class KVCache:
+    """Per-attention-layer K/V cache with per-batch-element fill counters."""
+    k: torch.Tensor          # (B, num_heads, max_seqlen, head_dim)
+    v: torch.Tensor          # (B, num_heads, max_seqlen, head_dim)
+    offsets: torch.Tensor    # (B,) long
+
+    def reset(self):
+        self.k.zero_()
+        self.v.zero_()
+        self.offsets.zero_()
+
+
+@dataclass
+class MambaCache:
+    """Per-SSM-layer state for Mamba2 step inference."""
+    conv_state: torch.Tensor   # (B, conv_dim, d_conv - 1)
+    ssm_state: torch.Tensor    # (B, nheads, headdim, d_state)
+
+    def reset(self):
+        self.conv_state.zero_()
+        self.ssm_state.zero_()
+
+
+LayerCache = Union[KVCache, MambaCache]
+
+
+@dataclass
+class IsotropicInferenceParams:
+    """One per-layer cache (KV or Mamba) per layer index."""
+    layer_caches: Dict[int, Any] = field(default_factory=dict)
+    max_seqlen: int = 0
+    batch_size: int = 0
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(d_model))
+        self.eps = eps
+
+    def forward(self, x):
+        var = x.float().pow(2).mean(dim=-1, keepdim=True)
+        x_normed = (x.float() * torch.rsqrt(var + self.eps)).to(x.dtype)
+        return x_normed * self.weight
+
+
+class AdaLNModulation(nn.Module):
+    """Maps a conditioning vector to per-block (scale, shift) for AdaLN."""
+
+    def __init__(self, d_cond, d_model):
+        super().__init__()
+        self.proj = nn.Linear(d_cond, 2 * d_model)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+        self.proj.weight._no_reinit = True
+
+    def forward(self, cond):
+        scale, shift = self.proj(cond).chunk(2, dim=-1)
+        return scale, shift
+
+
+def _adaln(x, scale, shift):
+    """Apply AdaLN modulation with shape-flexible broadcasting.
+
+    Padded mode: ``x`` is (B, L, D), ``scale/shift`` are (B, D)  → unsqueeze dim 1.
+    Packed mode: ``x`` is (T_total, D), ``scale/shift`` are (T_total, D) → direct.
+    """
+    if scale.dim() < x.dim():
+        scale = scale.unsqueeze(-2)
+        shift = shift.unsqueeze(-2)
+    return x * (1 + scale) + shift
+
+
+class MultiHeadAttention(nn.Module):
+    def __init__(self, d_model, num_heads, causal=False, dropout=0.0):
+        super().__init__()
+        assert d_model % num_heads == 0
+        self.d_model = d_model
+        self.num_heads = num_heads
+        self.head_dim = d_model // num_heads
+        self.causal = causal
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=True)
+        self.out_proj = nn.Linear(d_model, d_model, bias=True)
+        self.dropout = dropout
+
+    def forward(
+        self,
+        x,
+        mask=None,
+        cu_seqlens=None,
+        max_seqlen: Optional[int] = None,
+    ):
+        """
+        Padded mode: x (B, L, D), mask (B, L). Uses SDPA.
+        Packed mode: x (T_total, D), cu_seqlens (B+1,), max_seqlen int.
+            Uses flash_attn_varlen_func when available; otherwise SDPA with a
+            block-diagonal causal mask.
+        """
+        if cu_seqlens is not None:
+            return self._forward_packed(x, cu_seqlens, max_seqlen)
+        return self._forward_padded(x, mask)
+
+    def _forward_padded(self, x, mask):
+        B, L, D = x.shape
+        qkv = self.qkv(x).reshape(B, L, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=2)
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        attn_mask = None
+        if mask is not None:
+            attn_mask = mask[:, None, None, :].to(dtype=torch.bool)
+            attn_mask = attn_mask & attn_mask.transpose(-1, -2)
+
+        out = F.scaled_dot_product_attention(
+            q, k, v,
+            attn_mask=attn_mask,
+            dropout_p=self.dropout if self.training else 0.0,
+            is_causal=self.causal,
+        )
+        out = out.transpose(1, 2).reshape(B, L, D)
+        return self.out_proj(out)
+
+    def _forward_packed(self, x, cu_seqlens, max_seqlen):
+        # x: (T_total, D)
+        T_total, D = x.shape
+        qkv = self.qkv(x).reshape(T_total, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=1)  # each (T_total, H, Dh)
+
+        if _HAS_FLASH_ATTN and x.is_cuda:
+            cu_q = cu_seqlens.to(torch.int32)
+            ms = int(max_seqlen) if max_seqlen is not None else int(
+                (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
+            )
+            out = flash_attn_varlen_func(
+                q, k, v,
+                cu_seqlens_q=cu_q, cu_seqlens_k=cu_q,
+                max_seqlen_q=ms, max_seqlen_k=ms,
+                dropout_p=self.dropout if self.training else 0.0,
+                causal=self.causal,
+            )
+            # flash_attn returns (T_total, H, Dh)
+            out = out.reshape(T_total, D)
+            return self.out_proj(out)
+
+        # Fallback: SDPA with block-diagonal (+ optional causal) mask.
+        # (T_total, H, Dh) -> (1, H, T_total, Dh)
+        q_ = q.transpose(0, 1).unsqueeze(0)
+        k_ = k.transpose(0, 1).unsqueeze(0)
+        v_ = v.transpose(0, 1).unsqueeze(0)
+
+        pos = torch.arange(T_total, device=x.device)
+        seq_idx = (pos[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)
+        same_seq = seq_idx[:, None] == seq_idx[None, :]
+        if self.causal:
+            causal_mask = pos[:, None] >= pos[None, :]
+            attn_mask = (same_seq & causal_mask)[None, None]
+        else:
+            attn_mask = same_seq[None, None]
+
+        out = F.scaled_dot_product_attention(
+            q_, k_, v_, attn_mask=attn_mask,
+            dropout_p=self.dropout if self.training else 0.0,
+            is_causal=False,
+        )
+        # (1, H, T_total, Dh) -> (T_total, D)
+        out = out.squeeze(0).transpose(0, 1).reshape(T_total, D)
+        return self.out_proj(out)
+
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
+        return KVCache(
+            k=torch.zeros(batch_size, self.num_heads, max_seqlen, self.head_dim,
+                          device=device, dtype=dtype),
+            v=torch.zeros(batch_size, self.num_heads, max_seqlen, self.head_dim,
+                          device=device, dtype=dtype),
+            offsets=torch.zeros(batch_size, device=device, dtype=torch.long),
+        )
+
+    def step(self, x, cache: KVCache):
+        # x: (B, 1, D). Per-batch K/V scatter + attn against valid prior slots.
+        B, _, D = x.shape
+        qkv = self.qkv(x).reshape(B, 1, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=2)
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        batch_idx = torch.arange(B, device=x.device)
+        cache.k[batch_idx, :, cache.offsets] = k.squeeze(2).to(cache.k.dtype)
+        cache.v[batch_idx, :, cache.offsets] = v.squeeze(2).to(cache.v.dtype)
+        cache.offsets = cache.offsets + 1
+
+        max_T = cache.k.shape[2]
+        pos = torch.arange(max_T, device=x.device)
+        attn_mask = pos[None, :] < cache.offsets[:, None]
+        attn_mask = attn_mask[:, None, None, :]
+
+        out = F.scaled_dot_product_attention(
+            q, cache.k, cache.v, attn_mask=attn_mask
+        )
+        out = out.transpose(1, 2).reshape(B, 1, D)
+        return self.out_proj(out)
+
+
+class SwiGLU(nn.Module):
+    def __init__(self, d_model, d_intermediate):
+        super().__init__()
+        self.fc1 = nn.Linear(d_model, 2 * d_intermediate, bias=False)
+        self.fc2 = nn.Linear(d_intermediate, d_model, bias=False)
+
+    def forward(self, x):
+        a, b = self.fc1(x).chunk(2, dim=-1)
+        return self.fc2(F.silu(a) * b)
+
+
+class TransformerBlock(nn.Module):
+    """Pre-norm transformer block with optional MLP and optional AdaLN cond."""
+
+    def __init__(self, d_model, num_heads, d_intermediate=0, causal=False, d_cond=0):
+        super().__init__()
+        self.has_mlp = d_intermediate > 0
+        self.has_cond = d_cond > 0
+        self.causal = causal
+        self.norm1 = RMSNorm(d_model)
+        self.mixer = MultiHeadAttention(d_model, num_heads, causal=causal)
+        if self.has_mlp:
+            self.norm2 = RMSNorm(d_model)
+            self.mlp = SwiGLU(d_model, d_intermediate)
+        if self.has_cond:
+            self.adaln1 = AdaLNModulation(d_cond, d_model)
+            if self.has_mlp:
+                self.adaln2 = AdaLNModulation(d_cond, d_model)
+
+    def forward(self, x, mask=None, cond=None, cu_seqlens=None, max_seqlen=None):
+        h = self.norm1(x)
+        if self.has_cond and cond is not None:
+            s, b = self.adaln1(cond)
+            h = _adaln(h, s, b)
+        x = x + self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+
+        if self.has_mlp:
+            h = self.norm2(x)
+            if self.has_cond and cond is not None:
+                s, b = self.adaln2(cond)
+                h = _adaln(h, s, b)
+            x = x + self.mlp(h)
+        return x
+
+    def step(self, x, cache: KVCache, cond: Optional[torch.Tensor] = None):
+        h = self.norm1(x)
+        if self.has_cond and cond is not None:
+            s, b = self.adaln1(cond)
+            h = _adaln(h, s, b)
+        x = x + self.mixer.step(h, cache)
+
+        if self.has_mlp:
+            h = self.norm2(x)
+            if self.has_cond and cond is not None:
+                s, b = self.adaln2(cond)
+                h = _adaln(h, s, b)
+            x = x + self.mlp(h)
+        return x
+
+
+class Mamba2Mixer(nn.Module):
+    """Adapter around mamba_ssm's Mamba2 with our (forward, step, allocate) interface.
+
+    Mamba2 is inherently causal; the `causal` flag on TransformerBlock has no
+    equivalent here.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        layer_idx: int,
+        ssm_cfg: Optional[dict] = None,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        if not _HAS_MAMBA:
+            raise ImportError(
+                "mamba_ssm is not installed but an 'm'/'M' arch block was requested. "
+                "Install mamba_ssm or change the arch_layout to use only 't'/'T'."
+            )
+        ssm_cfg = dict(ssm_cfg or {})
+        self.mamba = _Mamba2(
+            d_model=d_model, layer_idx=layer_idx, device=device, dtype=dtype, **ssm_cfg
+        )
+        self.layer_idx = layer_idx
+        self.d_model = d_model
+
+    def forward(self, x, mask=None, cu_seqlens=None, max_seqlen=None):
+        """
+        Padded mode: x (B, L, D). Mamba2 processes the full sequence (padding
+            tokens at the end don't pollute earlier outputs since it's causal).
+        Packed mode: x (T_total, D). We unsqueeze to (1, T_total, D) and pass
+            seq_idx so the inner scan resets at sub-sequence boundaries.
+        """
+        if cu_seqlens is not None:
+            x3 = x.unsqueeze(0)
+            pos = torch.arange(x3.shape[1], device=x.device)
+            seq_idx = (pos[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1).to(torch.int32)
+            seq_idx = seq_idx.unsqueeze(0)  # (1, T_total)
+            out = self.mamba(x3, seq_idx=seq_idx)
+            return out.squeeze(0)
+        return self.mamba(x)
+
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
+        conv_state, ssm_state = self.mamba.allocate_inference_cache(
+            batch_size, max_seqlen, dtype=dtype
+        )
+        return MambaCache(conv_state=conv_state, ssm_state=ssm_state)
+
+    def step(self, x, cache: MambaCache):
+        # x: (B, 1, D). Mamba2.step returns (out, conv_state, ssm_state).
+        out, conv_state, ssm_state = self.mamba.step(x, cache.conv_state, cache.ssm_state)
+        cache.conv_state.copy_(conv_state)
+        cache.ssm_state.copy_(ssm_state)
+        return out
+
+
+class MambaBlock(nn.Module):
+    """Pre-norm block with Mamba2 mixer + optional MLP + optional AdaLN cond.
+
+    Mirrors TransformerBlock; same forward/step signature so Isotropic can
+    treat them interchangeably.
+    """
+
+    def __init__(
+        self,
+        d_model,
+        layer_idx: int,
+        d_intermediate: int = 0,
+        d_cond: int = 0,
+        ssm_cfg: Optional[dict] = None,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        self.has_mlp = d_intermediate > 0
+        self.has_cond = d_cond > 0
+        self.norm1 = RMSNorm(d_model)
+        self.mixer = Mamba2Mixer(d_model, layer_idx=layer_idx, ssm_cfg=ssm_cfg,
+                                  device=device, dtype=dtype)
+        if self.has_mlp:
+            self.norm2 = RMSNorm(d_model)
+            self.mlp = SwiGLU(d_model, d_intermediate)
+        if self.has_cond:
+            self.adaln1 = AdaLNModulation(d_cond, d_model)
+            if self.has_mlp:
+                self.adaln2 = AdaLNModulation(d_cond, d_model)
+
+    def forward(self, x, mask=None, cond=None, cu_seqlens=None, max_seqlen=None):
+        h = self.norm1(x)
+        if self.has_cond and cond is not None:
+            s, b = self.adaln1(cond)
+            h = _adaln(h, s, b)
+        x = x + self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+
+        if self.has_mlp:
+            h = self.norm2(x)
+            if self.has_cond and cond is not None:
+                s, b = self.adaln2(cond)
+                h = _adaln(h, s, b)
+            x = x + self.mlp(h)
+        return x
+
+    def step(self, x, cache: MambaCache, cond: Optional[torch.Tensor] = None):
+        h = self.norm1(x)
+        if self.has_cond and cond is not None:
+            s, b = self.adaln1(cond)
+            h = _adaln(h, s, b)
+        x = x + self.mixer.step(h, cache)
+
+        if self.has_mlp:
+            h = self.norm2(x)
+            if self.has_cond and cond is not None:
+                s, b = self.adaln2(cond)
+                h = _adaln(h, s, b)
+            x = x + self.mlp(h)
+        return x
+
+
+class Isotropic(nn.Module):
+    """A stack of transformer and/or Mamba2 blocks for one stage / position."""
+
+    def __init__(
+        self,
+        config: HNetConfig,
+        pos_idx: int,
+        stage_idx: int,
+        d_cond: int = 0,
+        cond_here: bool = False,
+        causal: bool = False,
+    ):
+        super().__init__()
+        self.stage_idx = stage_idx
+        self.d_model = config.d_model[stage_idx]
+        attn_cfg = get_stage_cfg(config.attn_cfg, stage_idx)
+        num_heads = attn_cfg.get("num_heads", 8)
+        ssm_cfg = get_stage_cfg(config.ssm_cfg, stage_idx) if hasattr(config, "ssm_cfg") else {}
+
+        layout = config.arch_layout
+        for _ in range(stage_idx):
+            layout = layout[1]
+        layout = layout[pos_idx]
+        layout_parse = re.findall(r"([mMtT])(\d+)", layout)
+        if not layout_parse:
+            raise ValueError(
+                f"Empty / unsupported arch_layout entry '{layout}'. Use t/T/m/M tokens."
+            )
+
+        blocks = []
+        self.arch_full = []
+        self.height = 0
+        layer_idx = 0
+        for arch, n_layer_str in layout_parse:
+            n = int(n_layer_str)
+            d_int = config.d_intermediate[stage_idx] if arch.isupper() else 0
+            for _ in range(n):
+                if arch in ("t", "T"):
+                    blk = TransformerBlock(
+                        d_model=self.d_model,
+                        num_heads=num_heads,
+                        d_intermediate=d_int,
+                        causal=causal,
+                        d_cond=d_cond if cond_here else 0,
+                    )
+                else:  # 'm' or 'M'
+                    blk = MambaBlock(
+                        d_model=self.d_model,
+                        layer_idx=layer_idx,
+                        d_intermediate=d_int,
+                        d_cond=d_cond if cond_here else 0,
+                        ssm_cfg=ssm_cfg or None,
+                    )
+                blocks.append(blk)
+                self.arch_full.append(arch)
+                layer_idx += 1
+            self.height += (2 if arch.isupper() else 1) * n
+
+        self.layers = nn.ModuleList(blocks)
+        self.final_norm = RMSNorm(self.d_model)
+
+    def forward(
+        self,
+        x,
+        mask=None,
+        cond: Optional[torch.Tensor] = None,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[int] = None,
+    ):
+        for blk in self.layers:
+            x = blk(x, mask=mask, cond=cond, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        return self.final_norm(x)
+
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
+        params = IsotropicInferenceParams(
+            layer_caches={}, max_seqlen=max_seqlen, batch_size=batch_size,
+        )
+        for i, blk in enumerate(self.layers):
+            params.layer_caches[i] = blk.mixer.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            )
+        return params
+
+    def step(self, x, params: IsotropicInferenceParams, cond: Optional[torch.Tensor] = None):
+        for i, blk in enumerate(self.layers):
+            x = blk.step(x, params.layer_caches[i], cond=cond)
+        return self.final_norm(x)

--- a/egomimic/models/hnet_nets/cond_encoders.py
+++ b/egomimic/models/hnet_nets/cond_encoders.py
@@ -1,0 +1,125 @@
+"""
+CondEncoderModule: build the per-token conditioning tensor for the H-Net
+from a raw obs dict.
+
+Replaces the inline obs_encoders / img_encoders / cond_proj fusion that
+previously lived on ``HNetPolicy``. The algo now holds a single
+``CondEncoderModule`` instance and calls ``encode(obs, T)`` to produce a
+``cond_dict`` it can hand to ``HNetContext``.
+
+Output:
+    cond_dict[output_key] = (B, T, d_cond)  — fused per-token cond.
+    optionally per-obs raw embeddings keyed by their obs name when
+    ``per_obs_keys=True`` (useful if a stage wants un-fused cond).
+"""
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+
+def _mlp(in_dim: int, out_dim: int, widths: Optional[List[int]] = None) -> nn.Sequential:
+    widths = widths or []
+    layers: List[nn.Module] = []
+    prev = in_dim
+    for w in widths:
+        layers += [nn.Linear(prev, w), nn.GELU()]
+        prev = w
+    layers.append(nn.Linear(prev, out_dim))
+    return nn.Sequential(*layers)
+
+
+class CondEncoderModule(nn.Module):
+    """
+    Args:
+        obs_specs:        dict of obs_key -> {input_dim, embed_dim, widths}.
+        img_encoders:     dict of img_key -> nn.Module with .embed_dim.
+        d_cond:           output cond width per token.
+        cond_proj_widths: hidden widths for the fusion MLP. If None, defaults
+                          to ``[max(d_cond, fused_in_dim)]``.
+        output_key:       key under which the fused cond is exposed.
+        per_obs_keys:     when True, also expose each obs's individual embedding
+                          under its own obs_key in the output dict (useful for
+                          stages that want un-fused cond).
+    """
+
+    def __init__(
+        self,
+        d_cond: int,
+        obs_specs: Optional[Dict[str, dict]] = None,
+        img_encoders: Optional[Dict[str, nn.Module]] = None,
+        cond_proj_widths: Optional[List[int]] = None,
+        output_key: str = "fused_cond",
+        per_obs_keys: bool = False,
+    ):
+        super().__init__()
+        self.d_cond = int(d_cond)
+        self.output_key = output_key
+        self.per_obs_keys = per_obs_keys
+
+        obs_specs = obs_specs or {}
+        self.obs_keys = sorted(obs_specs.keys())
+        self.obs_encoders = nn.ModuleDict()
+        fused_dim = 0
+        for key in self.obs_keys:
+            spec = obs_specs[key]
+            self.obs_encoders[key] = _mlp(
+                spec["input_dim"], spec["embed_dim"], spec.get("widths", [])
+            )
+            fused_dim += spec["embed_dim"]
+
+        img_encoders = img_encoders or {}
+        self.img_keys = sorted(img_encoders.keys())
+        self.img_encoders = nn.ModuleDict({k: img_encoders[k] for k in self.img_keys})
+        for key in self.img_keys:
+            enc = self.img_encoders[key]
+            if not hasattr(enc, "embed_dim"):
+                raise AttributeError(
+                    f"img_encoders['{key}'] must expose `.embed_dim` (got "
+                    f"{type(enc).__name__})."
+                )
+            fused_dim += enc.embed_dim
+
+        if fused_dim == 0:
+            self.cond_proj = None
+        else:
+            widths = cond_proj_widths
+            if widths is None:
+                widths = [max(self.d_cond, fused_dim)]
+            self.cond_proj = _mlp(fused_dim, self.d_cond, widths=list(widths))
+
+    def encode(self, obs: Dict[str, torch.Tensor], T_action: int) -> Dict[str, torch.Tensor]:
+        """Returns a cond_dict. Single-frame obs are broadcast across T_action."""
+        if self.cond_proj is None:
+            return {}
+
+        out: Dict[str, torch.Tensor] = {}
+        feats: List[torch.Tensor] = []
+
+        for key in self.obs_keys:
+            if key not in obs:
+                continue
+            x = obs[key]
+            if x.dim() == 2:                       # (B, D) -> (B, T, D)
+                x = x.unsqueeze(1).expand(-1, T_action, -1)
+            emb = self.obs_encoders[key](x)         # (B, T, embed_dim)
+            feats.append(emb)
+            if self.per_obs_keys:
+                out[key] = emb
+
+        for key in self.img_keys:
+            if key not in obs:
+                continue
+            x = obs[key]
+            if x.dim() == 4:                       # (B, C, H, W) -> (B, T, ...)
+                x = x.unsqueeze(1).expand(-1, T_action, -1, -1, -1)
+            emb = self.img_encoders[key](x)         # (B, T, embed_dim)
+            feats.append(emb)
+            if self.per_obs_keys:
+                out[key] = emb
+
+        if not feats:
+            return out
+        fused = torch.cat(feats, dim=-1)
+        out[self.output_key] = self.cond_proj(fused)
+        return out

--- a/egomimic/models/hnet_nets/config.py
+++ b/egomimic/models/hnet_nets/config.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass, field
+from typing import List, Union, Any
+
+
+@dataclass
+class AttnConfig:
+    num_heads: List[int] = field(default_factory=list)
+    rotary_emb_dim: List[int] = field(default_factory=list)
+    window_size: List[int] = field(default_factory=list)
+
+
+@dataclass
+class SSMConfig:
+    """Per-stage Mamba2 kwargs. Each list is indexed by stage_idx."""
+    d_conv: List[int] = field(default_factory=list)
+    expand: List[int] = field(default_factory=list)
+    d_state: List[int] = field(default_factory=list)
+    chunk_size: List[int] = field(default_factory=list)
+    headdim: List[int] = field(default_factory=list)
+
+
+@dataclass
+class HNetConfig:
+    """
+    Flexible config for the vendored HNet.
+
+    arch_layout: nested list describing the hierarchy. At each level either
+        [encoder_str, sub_layout, decoder_str] (3 elements) or [innermost_str] (1).
+        Strings use HNet's notation but here we only support 't'/'T' (transformer
+        without/with MLP). Mamba ('m'/'M') is not vendored.
+    d_model:        per-stage list of hidden dims
+    d_intermediate: per-stage list of FFN intermediate dims (0 = no MLP within block)
+    attn_cfg:       dict-like (num_heads / window_size lists, indexed per stage)
+    target_compression_ratios: per non-innermost stage, used by the ratio loss
+    """
+
+    arch_layout: List[Union[str, List]] = field(default_factory=list)
+    d_model: List[int] = field(default_factory=list)
+    d_intermediate: List[int] = field(default_factory=list)
+    attn_cfg: Any = field(default_factory=AttnConfig)
+    ssm_cfg: Any = field(default_factory=SSMConfig)
+    target_compression_ratios: List[float] = field(default_factory=list)
+    # AdaLN conditioning placement. Each list holds the stage indices that
+    # should receive cond at that position. Defaults: outer encoder only.
+    cond_encoder_stages: List[int] = field(default_factory=lambda: [0])
+    cond_decoder_stages: List[int] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, cfg: dict) -> "HNetConfig":
+        attn_cfg = cfg.get("attn_cfg", {})
+        if isinstance(attn_cfg, dict):
+            attn_cfg = AttnConfig(**attn_cfg)
+        ssm_cfg = cfg.get("ssm_cfg", {})
+        if isinstance(ssm_cfg, dict):
+            ssm_cfg = SSMConfig(**ssm_cfg)
+        return cls(
+            arch_layout=cfg["arch_layout"],
+            d_model=cfg["d_model"],
+            d_intermediate=cfg.get("d_intermediate", [0] * len(cfg["d_model"])),
+            attn_cfg=attn_cfg,
+            ssm_cfg=ssm_cfg,
+            target_compression_ratios=cfg.get(
+                "target_compression_ratios",
+                [2.0] * max(0, len(cfg["d_model"]) - 1),
+            ),
+            cond_encoder_stages=list(cfg.get("cond_encoder_stages", [0])),
+            cond_decoder_stages=list(cfg.get("cond_decoder_stages", [])),
+        )
+
+
+def get_stage_cfg(cfg: AttnConfig, stage_idx: int) -> dict:
+    """Slice the per-stage AttnConfig into a flat dict for a given stage."""
+    out = {}
+    for k, v in cfg.__dict__.items():
+        if isinstance(v, list) and len(v) > stage_idx:
+            out[k] = v[stage_idx]
+    return out

--- a/egomimic/models/hnet_nets/context.py
+++ b/egomimic/models/hnet_nets/context.py
@@ -1,0 +1,40 @@
+"""
+Conditioning + aux context object threaded through all H-Net stages.
+
+Built by the algo (HNetPolicy) at the top of forward / generate, then handed
+to the stage tree. Stages read named tensors from ``cond_dict`` and append
+auxiliary information (e.g. boundary predictions for the ratio loss) via
+``register_aux``. ``inference_params`` carries per-stage step-time state when
+running autoregressively; it is left None during teacher-forced forward.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import torch
+
+
+@dataclass
+class HNetContext:
+    """Per-call context for a stage tree.
+
+    Attributes:
+        cond_dict: named conditioning tensors. The default "fused_cond" entry
+            (per-token cond of shape (B, T, d_cond)) is produced by
+            ``CondEncoderModule``; user-defined keys may be added alongside.
+        aux: each chunker stage's forward / step appends a dict here with at
+            least ``{"bpred": RoutingModuleOutput, "target_ratio": float,
+            "weight": float}``. The algo iterates this to compute the ratio
+            loss after forward returns.
+        inference_params: per-stage state list during step inference, or None
+            during teacher-forced forward.
+        extras: free-form scratch dict for callers that want to pass extra
+            information down (and back up) through the stage tree.
+    """
+
+    cond_dict: Dict[str, torch.Tensor] = field(default_factory=dict)
+    aux: List[Dict[str, Any]] = field(default_factory=list)
+    inference_params: Optional[List[Any]] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    def register_aux(self, item: Dict[str, Any]) -> None:
+        self.aux.append(item)

--- a/egomimic/models/hnet_nets/hnet.py
+++ b/egomimic/models/hnet_nets/hnet.py
@@ -1,0 +1,139 @@
+"""
+Top-level H-Net wrapper for the stage-based architecture.
+
+The YAML provides a *flat* list of stages. At construction time we walk the
+list and set ``stages[i].inner_stage = stages[i+1]`` so the runtime tree is
+recursive even though the config is flat. The terminal stage's ``inner_stage``
+remains None.
+
+The wrapper itself owns no learned modules — all parameters live inside the
+individual stages. It exists to:
+
+  * thread the ``HNetContext`` into the root stage on forward / step;
+  * collect per-stage inference-state objects for autoregressive rollout;
+  * expose the ratio_loss helper at the module level for the algo.
+
+action_in / action_out / BOS / pos_emb / cond encoders live on the algo
+class (``HNetPolicy``), not here.
+"""
+from typing import List
+
+import torch
+import torch.nn as nn
+
+from egomimic.models.hnet_nets.context import HNetContext
+from egomimic.models.hnet_nets.stages import _BaseStage
+
+
+class HNet(nn.Module):
+    def __init__(self, stages: List[_BaseStage]):
+        super().__init__()
+        if not stages:
+            raise ValueError("HNet requires at least one stage.")
+        # The flat list is wired into a chain. Assert each stage was constructed
+        # with inner_stage=None so the user can't accidentally double-specify.
+        for i, st in enumerate(stages):
+            if not isinstance(st, _BaseStage):
+                raise TypeError(
+                    f"stages[{i}] is not a Stage instance (got {type(st).__name__})."
+                )
+            if st.inner_stage is not None:
+                raise ValueError(
+                    f"stages[{i}] already has inner_stage set; pass a flat list "
+                    f"and let HNet wire the chain."
+                )
+        for i in range(len(stages) - 1):
+            # Sanity-check dim handoff into the nested inner_stage. For
+            # EncoderDecoderStage/ComputeStage the inner stage runs at the
+            # outer working dim (== input_hidden_dim). For ChunkerStage the
+            # inner stage runs in the chunked space at output_hidden_dim
+            # (after the explicit proj_in).
+            from egomimic.models.hnet_nets.stages import ChunkerStage as _CS
+            expected = (
+                stages[i].output_hidden_dim
+                if isinstance(stages[i], _CS)
+                else stages[i].input_hidden_dim
+            )
+            if stages[i + 1].input_hidden_dim != expected:
+                raise ValueError(
+                    f"Hidden-dim mismatch: stages[{i+1}].input_hidden_dim "
+                    f"({stages[i + 1].input_hidden_dim}) does not match the "
+                    f"inner working dim of stages[{i}] ({expected})."
+                )
+            stages[i].inner_stage = stages[i + 1]
+
+        self.stages = nn.ModuleList(stages)
+        # The root stage is stages[0]; deeper stages are only referenced via
+        # inner_stage. We still keep them in the ModuleList so nn.Module sees
+        # all params (the inner_stage attribute is set above which also makes
+        # them children of the parent stage, but ModuleList is the canonical
+        # registration). To avoid double-registration we detach inner_stage
+        # from the parent's submodules and rely on ModuleList alone — but
+        # detach is awkward; instead we leave both registered (PyTorch
+        # deduplicates by parameter identity, but module-level it would double
+        # count submodule names). Simplest robust choice: do NOT register
+        # inner_stage via setattr; use object.__setattr__ to bypass the
+        # automatic child registration in nn.Module.
+        for i in range(len(stages) - 1):
+            # Re-bind inner_stage as a *non-submodule* attribute to avoid
+            # duplicate registration; ModuleList keeps the actual parameters.
+            object.__setattr__(stages[i], "inner_stage", stages[i + 1])
+
+    @property
+    def root(self) -> _BaseStage:
+        return self.stages[0]
+
+    @property
+    def input_hidden_dim(self) -> int:
+        return self.stages[0].input_hidden_dim
+
+    @property
+    def output_hidden_dim(self) -> int:
+        # Chain is recursive (stages[i].inner_stage = stages[i+1]) so the
+        # end-to-end output dim is the outermost stage's output dim, not the
+        # innermost. EncoderDecoder/Compute/Chunker stages each guarantee that
+        # they return to their own output_hidden_dim before their forward ends.
+        return self.stages[0].output_hidden_dim
+
+    def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        return self.root(x, ctx)
+
+    def step(self, x: torch.Tensor, ctx: HNetContext):
+        """Single-token step. ``ctx.inference_params[0]`` is the root state."""
+        assert ctx.inference_params is not None, "Call allocate_inference_cache first."
+        return self.root.step(x, ctx, ctx.inference_params[0])
+
+    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, device, dtype=torch.float32):
+        """Returns a list with a single entry: the root stage's nested state."""
+        return [self.root._allocate(batch_size, max_seqlen, dtype, device)]
+
+
+def ratio_loss_from_aux(aux: List[dict], device=None) -> torch.Tensor:
+    """Compute the H-Net auxiliary ratio loss from a list of aux entries.
+
+    Each entry is::
+
+        {"bpred": RoutingModuleOutput, "target_ratio": float, "weight": float}
+
+    Loss (per chunker, summed):
+        N = target_ratio
+        F = fraction of tokens selected as boundaries
+        G = mean boundary probability
+        L = weight * N/(N-1) * ((N-1)*F*G + (1-F)*(1-G))
+    """
+    if not aux:
+        return torch.zeros((), device=device or "cpu")
+    losses = []
+    for entry in aux:
+        bpred = entry["bpred"]
+        N = float(entry["target_ratio"])
+        w = float(entry["weight"])
+        bm = bpred.boundary_mask.float()
+        bp = bpred.boundary_prob[..., -1]
+        # We treat all positions as valid (no padding mask).
+        denom = max(bm.numel(), 1)
+        F_ = bm.sum() / denom
+        G_ = bp.sum() / denom
+        loss_i = w * (N / (N - 1)) * ((N - 1) * F_ * G_ + (1 - F_) * (1 - G_))
+        losses.append(loss_i)
+    return torch.stack(losses).sum()

--- a/egomimic/models/hnet_nets/image_encoders.py
+++ b/egomimic/models/hnet_nets/image_encoders.py
@@ -1,0 +1,66 @@
+"""
+Image encoders for HNetPolicy conditioning.
+
+Designed to be instantiated via Hydra `_target_:`:
+
+    img_encoders:
+      front_cam:
+        _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv
+        in_channels: 3
+        channels: [32, 64, 128]
+        embed_dim: 256
+
+Each encoder must expose an `embed_dim` attribute so `HNetPolicy` can size
+the fusion MLP without inspecting weights.
+
+Shape contract: accept any tensor of shape `(..., C, H, W)` and return
+`(..., embed_dim)`. Leading dims are flattened for the conv stack then
+unflattened on output — so `(B, T, C, H, W) -> (B, T, embed_dim)` works
+out of the box.
+"""
+from typing import Sequence
+
+import torch
+import torch.nn as nn
+
+
+class SimpleConv(nn.Module):
+    """A small convnet for per-frame image conditioning.
+
+    Architecture (configurable via YAML):
+        for c_out in channels:
+            Conv2d(stride) -> GroupNorm -> GELU
+        AdaptiveAvgPool2d(1) -> Flatten -> Linear -> embed_dim
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        channels: Sequence[int] = (32, 64, 128),
+        kernel_size: int = 3,
+        stride: int = 2,
+        embed_dim: int = 256,
+        norm_groups: int = 8,
+    ):
+        super().__init__()
+        layers = []
+        c = in_channels
+        for c_out in channels:
+            layers += [
+                nn.Conv2d(c, c_out, kernel_size, stride=stride, padding=kernel_size // 2),
+                nn.GroupNorm(min(norm_groups, c_out), c_out),
+                nn.GELU(),
+            ]
+            c = c_out
+        layers.append(nn.AdaptiveAvgPool2d(1))
+        self.conv = nn.Sequential(*layers)
+        self.head = nn.Linear(c, embed_dim)
+        self.embed_dim = embed_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (..., C, H, W) -> (..., embed_dim)
+        leading = x.shape[:-3]
+        x = x.reshape(-1, *x.shape[-3:])
+        feat = self.conv(x).flatten(1)         # (N, C_last)
+        feat = self.head(feat)                 # (N, embed_dim)
+        return feat.reshape(*leading, self.embed_dim)

--- a/egomimic/models/hnet_nets/install_kernels.sh
+++ b/egomimic/models/hnet_nets/install_kernels.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Optional kernel deps for egomimic/models/hnet_nets.
+#
+# The H-Net code runs without these (pure-PyTorch fallbacks), but installing
+# them unlocks:
+#   - flash_attn       -> packed-mode attention via flash_attn_varlen_func
+#                         (otherwise SDPA + block-diagonal mask)
+#   - causal-conv1d    -> required by mamba_ssm
+#   - mamba-ssm        -> 'm'/'M' arch blocks (Mamba2 mixer) AND parallel
+#                         selective-scan kernel inside DeChunkLayer
+#                         (otherwise pure-Python EMA recurrence)
+#   - einops           -> tensor rearrange used by the mamba scan path
+#
+# Requirements:
+#   - CUDA-capable GPU + matching CUDA toolkit
+#   - PyTorch already installed (these wheels are torch-ABI specific)
+#   - ninja (for fused build)
+#
+# Usage:
+#   bash egomimic/models/hnet_nets/install_kernels.sh
+#
+# Pinned versions reflect the upstream H-Net repo's known-good combo. Bump
+# them only if you've validated against your CUDA / PyTorch combo.
+
+set -euo pipefail
+
+# ---- sanity check: torch + CUDA ----
+python - <<'PY'
+import sys, torch
+print(f"torch {torch.__version__} | cuda {torch.version.cuda} | available={torch.cuda.is_available()}")
+if not torch.cuda.is_available():
+    print("WARNING: torch.cuda.is_available() is False. These kernels are CUDA-only.", file=sys.stderr)
+PY
+
+# ---- 1) build helpers ----
+pip install --upgrade pip setuptools wheel
+pip install ninja packaging einops
+
+# ---- 2) causal-conv1d (mamba_ssm dep) ----
+pip install --no-build-isolation "causal-conv1d>=1.4.0"
+
+# ---- 3) mamba-ssm (selective-scan kernel + Mamba2 block) ----
+pip install --no-build-isolation "mamba-ssm>=2.2.2"
+
+# ---- 4) flash-attn (varlen packed attention) ----
+# --no-build-isolation matches flash-attn's documented install path.
+pip install --no-build-isolation "flash-attn>=2.6.0"
+
+# ---- 5) verify ----
+python - <<'PY'
+def check(name, expr):
+    try:
+        exec(expr, {})
+        print(f"  ok   {name}")
+    except Exception as e:
+        print(f"  FAIL {name}: {e}")
+
+print("Verifying imports:")
+check("einops",             "import einops")
+check("causal_conv1d",      "from causal_conv1d import causal_conv1d_fn")
+check("mamba_ssm.Mamba2",   "from mamba_ssm.modules.mamba2 import Mamba2")
+check("mamba_chunk_scan",   "from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined")
+check("flash_attn_varlen",  "from flash_attn import flash_attn_varlen_func")
+
+import torch
+from egomimic.models.hnet_nets.blocks  import has_flash_attn, has_mamba
+from egomimic.models.hnet_nets.routing import has_mamba_scan
+print(f"\nRuntime detection:")
+print(f"  has_flash_attn  = {has_flash_attn()}")
+print(f"  has_mamba       = {has_mamba()}")
+print(f"  has_mamba_scan  = {has_mamba_scan()}")
+PY

--- a/egomimic/models/hnet_nets/isotropic_builder.py
+++ b/egomimic/models/hnet_nets/isotropic_builder.py
@@ -1,0 +1,58 @@
+"""
+Build an ``Isotropic`` stack from a self-contained spec dict.
+
+The vendored ``Isotropic`` constructor expects an ``HNetConfig`` indexed by a
+``stage_idx`` / ``pos_idx`` pair. In the new stage-based architecture each
+stage owns its own Isotropic(s) directly, so we synthesise a single-stage
+``HNetConfig`` on the fly.
+
+A spec dict looks like::
+
+    {
+      "arch_layout": "T4",       # str — passed verbatim to Isotropic
+      "d_model": 128,
+      "d_intermediate": 512,
+      "num_heads": 4,
+      "cond": true,              # whether AdaLN should be wired in this stack
+      "ssm_cfg": {...},          # optional, only used for m/M arch
+    }
+"""
+from typing import Any, Dict, Optional
+
+from egomimic.models.hnet_nets.blocks import Isotropic
+from egomimic.models.hnet_nets.config import AttnConfig, HNetConfig, SSMConfig
+
+
+def build_isotropic(
+    spec: Dict[str, Any],
+    d_cond: int = 0,
+    causal: bool = True,
+) -> Isotropic:
+    """Construct an Isotropic stack from a flat spec dict.
+
+    ``d_cond`` is the algo-level conditioning width; AdaLN is wired only when
+    ``spec.get("cond", False)`` is True AND ``d_cond > 0``.
+    """
+    arch_layout = spec["arch_layout"]
+    d_model = int(spec["d_model"])
+    d_intermediate = int(spec.get("d_intermediate", 0))
+    num_heads = int(spec.get("num_heads", 8))
+    cond_here = bool(spec.get("cond", False))
+    ssm_kwargs = spec.get("ssm_cfg", {}) or {}
+
+    # Wrap the per-stage scalars into the list-indexed config Isotropic expects.
+    cfg = HNetConfig(
+        arch_layout=[arch_layout],  # 1-level nesting; pos_idx=0 selects it
+        d_model=[d_model],
+        d_intermediate=[d_intermediate],
+        attn_cfg=AttnConfig(num_heads=[num_heads]),
+        ssm_cfg=SSMConfig(**{k: [v] for k, v in ssm_kwargs.items()}),
+    )
+    return Isotropic(
+        cfg,
+        pos_idx=0,
+        stage_idx=0,
+        d_cond=d_cond if cond_here else 0,
+        cond_here=cond_here,
+        causal=causal,
+    )

--- a/egomimic/models/hnet_nets/routing.py
+++ b/egomimic/models/hnet_nets/routing.py
@@ -1,0 +1,416 @@
+"""
+RoutingModule / ChunkLayer / DeChunkLayer with both padded (mask-based) and
+packed (cu_seqlens-based) training paths, plus single-token `step` inference.
+
+Padded mode:
+    hidden_states: (B, L, D)
+    mask:          (B, L) bool — True = valid token
+    cu_seqlens:    None
+
+Packed mode (matches upstream's 2D convention so flash_attn varlen plugs in):
+    hidden_states: (T_total, D)
+    cu_seqlens:    (num_subseqs + 1,) long — cumulative subseq lengths
+    max_seqlen:    int — longest subseq length (passed to attention modules)
+    mask:          None
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Optional Mamba2 selective-scan kernel for the DeChunkLayer EMA.
+try:
+    from einops import rearrange, repeat  # type: ignore
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined  # type: ignore
+    _HAS_MAMBA_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None  # type: ignore
+    rearrange = repeat = None  # type: ignore
+    _HAS_MAMBA_SCAN = False
+
+
+def has_mamba_scan() -> bool:
+    return _HAS_MAMBA_SCAN
+
+
+@dataclass
+class RoutingModuleOutput:
+    boundary_prob: torch.Tensor   # padded: (B, L, 2); packed: (T_total, 2); step: (B, 2)
+    boundary_mask: torch.Tensor   # padded: (B, L);    packed: (T_total,);   step: (B,)
+    selected_probs: torch.Tensor  # padded: (B, L, 1); packed: (T_total, 1); step: (B, 1)
+
+
+@dataclass
+class RoutingModuleState:
+    has_seen_tokens: torch.Tensor   # (B,) bool
+    last_hidden_state: torch.Tensor # (B, D)
+
+
+@dataclass
+class DeChunkState:
+    last_value: torch.Tensor  # (B, D)
+
+
+def get_seq_idx(cu_seqlens: torch.Tensor) -> torch.Tensor:
+    """(B+1,) cu_seqlens -> (T_total,) seq_idx mapping each packed position to its subseq id."""
+    T_total = int(cu_seqlens[-1].item())
+    pos = torch.arange(T_total, device=cu_seqlens.device)
+    return (pos[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)
+
+
+class RoutingModule(nn.Module):
+    def __init__(self, d_model, device=None, dtype=None):
+        super().__init__()
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.d_model = d_model
+        self.q_proj_layer = nn.Linear(d_model, d_model, bias=False, **factory_kwargs)
+        self.k_proj_layer = nn.Linear(d_model, d_model, bias=False, **factory_kwargs)
+        with torch.no_grad():
+            self.q_proj_layer.weight.copy_(torch.eye(d_model))
+            self.k_proj_layer.weight.copy_(torch.eye(d_model))
+        self.q_proj_layer.weight._no_reinit = True
+        self.k_proj_layer.weight._no_reinit = True
+
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype=None):
+        # max_seqlen kept for upstream signature parity (unused here).
+        return RoutingModuleState(
+            has_seen_tokens=torch.zeros(batch_size, device=device, dtype=torch.bool),
+            last_hidden_state=torch.zeros(batch_size, self.d_model, device=device, dtype=dtype),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        inference_params: Optional[RoutingModuleState] = None,
+    ) -> RoutingModuleOutput:
+        assert (mask is not None) or (cu_seqlens is not None), \
+            "Either mask (padded) or cu_seqlens (packed) must be provided"
+        if cu_seqlens is not None:
+            assert inference_params is None, "Packed mode does not support inference_params"
+            return self._forward_packed(hidden_states, cu_seqlens)
+        return self._forward_padded(hidden_states, mask, inference_params)
+
+    def _forward_padded(
+        self,
+        hidden_states: torch.Tensor,
+        mask: torch.Tensor,
+        inference_params: Optional[RoutingModuleState],
+    ) -> RoutingModuleOutput:
+        cos_sim = torch.einsum(
+            "b l d, b l d -> b l",
+            F.normalize(self.q_proj_layer(hidden_states[:, :-1]), dim=-1),
+            F.normalize(self.k_proj_layer(hidden_states[:, 1:]), dim=-1),
+        )
+        boundary_prob = torch.clamp(((1 - cos_sim) / 2), min=0.0, max=1.0)
+        boundary_prob = F.pad(boundary_prob, (1, 0), "constant", 1.0) # PAD Prob 1.0
+        boundary_prob = torch.stack(((1 - boundary_prob), boundary_prob), dim=-1)
+
+        selected_idx = torch.argmax(boundary_prob, dim=-1) 
+        boundary_mask = (selected_idx == 1) & mask # selected boundary not in valid token range is not chosen
+        selected_probs = boundary_prob.gather(dim=-1, index=selected_idx.unsqueeze(-1)) # equivalent confidence mentioned in the paper
+
+        # Prefill update: stash last valid token per batch so subsequent step()s
+        # continue from this prefix.
+        if inference_params is not None:
+            has_mask = mask.any(dim=-1)
+            inference_params.has_seen_tokens.copy_(
+                has_mask | inference_params.has_seen_tokens
+            )
+            last_idx = torch.clamp(mask.sum(dim=-1) - 1, min=0)
+            B = hidden_states.shape[0]
+            last_h = hidden_states[torch.arange(B, device=hidden_states.device), last_idx]
+            inference_params.last_hidden_state.copy_(
+                torch.where(
+                    has_mask.unsqueeze(-1),
+                    last_h.to(inference_params.last_hidden_state.dtype),
+                    inference_params.last_hidden_state,
+                )
+            )
+
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_mask,
+            selected_probs=selected_probs,
+        )
+
+    def _forward_packed(
+        self, hidden_states: torch.Tensor, cu_seqlens: torch.Tensor
+    ) -> RoutingModuleOutput:
+        # hidden_states: (T_total, D)
+        # Pairwise cos sim across consecutive positions, then re-pad to length T_total
+        cos_sim = (
+            F.normalize(self.q_proj_layer(hidden_states[:-1]), dim=-1)
+            * F.normalize(self.k_proj_layer(hidden_states[1:]), dim=-1)
+        ).sum(dim=-1)
+        boundary_prob = torch.clamp(((1 - cos_sim) / 2), min=0.0, max=1.0)
+        boundary_prob = F.pad(boundary_prob, (1, 0), "constant", 1.0)
+        # Force boundary at the first token of every subseq
+        boundary_prob = boundary_prob.clone()
+        boundary_prob[cu_seqlens[:-1]] = 1.0 # PAD Prob 1.0 at subseq starts
+
+        boundary_prob = torch.stack(((1 - boundary_prob), boundary_prob), dim=-1)  # (T_total, 2)
+        selected_idx = torch.argmax(boundary_prob, dim=-1)
+        boundary_mask = selected_idx == 1  # (T_total,)
+        selected_probs = boundary_prob.gather(dim=-1, index=selected_idx.unsqueeze(-1)) # equivalent to confidence mentioned in the paper, (T_total, 1)
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_mask,
+            selected_probs=selected_probs,
+        )
+
+    def step(self, hidden_states, inference_params: RoutingModuleState) -> RoutingModuleOutput:
+        hidden_states = hidden_states.squeeze(1)
+        cos_sim = torch.einsum(
+            "b d, b d -> b",
+            F.normalize(self.q_proj_layer(inference_params.last_hidden_state), dim=-1),
+            F.normalize(self.k_proj_layer(hidden_states), dim=-1),
+        )
+        boundary_prob = torch.clamp(((1 - cos_sim) / 2), min=0.0, max=1.0)
+        inference_params.last_hidden_state.copy_(hidden_states.to(inference_params.last_hidden_state.dtype))
+        boundary_prob = torch.where(
+            inference_params.has_seen_tokens, boundary_prob, torch.ones_like(boundary_prob)
+        )
+        boundary_prob = torch.stack(((1 - boundary_prob), boundary_prob), dim=-1)
+        inference_params.has_seen_tokens.fill_(True)
+
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_prob[..., 1] > 0.5,
+            selected_probs=boundary_prob.max(dim=-1).values.unsqueeze(-1),
+        )
+
+
+class ChunkLayer(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        boundary_mask: torch.Tensor,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+    ):
+        """
+        Returns: (next_hidden_states, next_cu_seqlens, next_max_seqlen, next_mask)
+            Padded mode: next_cu_seqlens / next_max_seqlen are None.
+            Packed mode: next_mask is None.
+        """
+        if cu_seqlens is not None:
+            return self._forward_packed(hidden_states, boundary_mask, cu_seqlens)
+        return self._forward_padded(hidden_states, boundary_mask)
+
+    def _forward_padded(self, hidden_states, boundary_mask):
+        _, L, D = hidden_states.shape
+        num_tokens = boundary_mask.sum(dim=-1)
+        next_max_seqlen = int(num_tokens.max())
+
+        device = hidden_states.device
+        token_idx = torch.arange(L, device=device)[None, :] + (~boundary_mask).long() * L
+        seq_sorted_indices = torch.argsort(token_idx, dim=1)
+        next_hidden_states = torch.gather(
+            hidden_states,
+            dim=1,
+            index=seq_sorted_indices[:, :next_max_seqlen, None].expand(-1, -1, D),
+        )
+        next_mask = torch.arange(next_max_seqlen, device=device)[None, :] < num_tokens[:, None]
+        # Upstream discards next_max_seqlen at the end of the padded path — the
+        # downstream Isotropic uses next_mask instead.
+        next_max_seqlen = None
+        return next_hidden_states, None, next_max_seqlen, next_mask
+
+    def _forward_packed(self, hidden_states, boundary_mask, cu_seqlens):
+        # hidden_states: (T_total, D), boundary_mask: (T_total,)
+        next_hidden_states = hidden_states[boundary_mask]  # (M_total, D)
+        next_cu_seqlens = F.pad(
+            boundary_mask.cumsum(dim=0)[cu_seqlens[1:] - 1], (1, 0)
+        )  # (B+1,)
+        next_max_seqlen = int((next_cu_seqlens[1:] - next_cu_seqlens[:-1]).max())
+        return next_hidden_states, next_cu_seqlens, next_max_seqlen, None
+
+    def step(self, hidden_states, boundary_mask):
+        return hidden_states[boundary_mask]
+
+
+class DeChunkLayer(nn.Module):
+    """
+    Maps chunked representations back to the original sequence length via an
+    EMA along the chunked axis followed by index-gather plug-back.
+
+    EMA backend (auto-selected):
+        - mamba_chunk_scan_combined when mamba_ssm is installed (parallel
+          selective-scan kernel; same recurrence as the Python loop).
+        - Pure-PyTorch sequential recurrence otherwise.
+
+    `dtype`, `block_size`, `headdim` are kernel knobs (mirror upstream defaults).
+    """
+
+    def __init__(self, d_model, dtype=torch.bfloat16, block_size=256, headdim=32):
+        super().__init__()
+        self.d_model = d_model
+        self.dtype = dtype
+        self.block_size = block_size
+        self.headdim = headdim
+        assert d_model % self.headdim == 0, (
+            f"d_model ({d_model}) must be divisible by headdim ({self.headdim})."
+        )
+        self.nheads = d_model // self.headdim
+
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype=None):
+        # max_seqlen kept for upstream signature parity (unused here).
+        return DeChunkState(
+            last_value=torch.zeros(batch_size, self.d_model, device=device, dtype=dtype),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        boundary_mask: torch.Tensor,
+        boundary_prob: torch.Tensor,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        inference_params: Optional[DeChunkState] = None,
+        mask: Optional[torch.Tensor] = None,
+    ):
+        """
+        Padded mode:
+            hidden_states (B, M, D), boundary_mask (B, L), boundary_prob (B, L, 2).
+        Packed mode:
+            hidden_states (M_total, D), boundary_mask (T_total,), boundary_prob (T_total, 2),
+            cu_seqlens is **chunked-space** cu_seqlens (matches upstream API).
+        """
+        if cu_seqlens is not None:
+            assert inference_params is None, "Packed mode does not support inference_params"
+            return self._forward_packed(hidden_states, boundary_mask, boundary_prob, cu_seqlens)
+        return self._forward_padded(hidden_states, boundary_mask, boundary_prob, inference_params)
+
+    # -------------- EMA backends --------------
+
+    def _ema_kernel(self, x_3d: torch.Tensor, p_2d: torch.Tensor,
+                    seq_idx: Optional[torch.Tensor]) -> torch.Tensor:
+        """Parallel EMA via mamba_chunk_scan_combined.
+
+        x_3d: (B, M, D), p_2d: (B, M), seq_idx: (B, M) int32 or None.
+        Returns (B, M, D), dtype = x_3d.dtype.
+        """
+        original_dtype = x_3d.dtype
+        dt = torch.log(1 / (1 - p_2d)).to(self.dtype)
+        x = (x_3d / dt[..., None]).to(self.dtype)
+        A = -torch.ones((self.nheads,), device=x_3d.device, dtype=torch.float32)
+        b = p_2d.to(self.dtype)
+        c = torch.ones_like(b)
+        out = mamba_chunk_scan_combined(
+            rearrange(x, "b l (h p) -> b l h p", p=self.headdim),
+            repeat(dt, "b l -> b l h", h=self.nheads),
+            A,
+            rearrange(b, "b l -> b l 1 1"),
+            rearrange(c, "b l -> b l 1 1"),
+            chunk_size=self.block_size,
+            seq_idx=seq_idx,
+        )
+        out = rearrange(out, "b l h p -> b l (h p)")
+        return out.to(original_dtype)
+
+    def _ema_loop(self, x_3d: torch.Tensor, p_2d: torch.Tensor,
+                  seq_starts: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Sequential EMA fallback.
+
+        x_3d: (B, M, D), p_2d: (B, M). When seq_starts is provided (1D long
+        tensor of chunked-space subseq starts), reset prev at those indices.
+        """
+        B, M, D = x_3d.shape
+        if M == 0:
+            return x_3d
+        starts_set: set = set()
+        if seq_starts is not None:
+            starts_set = set(int(s) for s in seq_starts.tolist())
+        out = []
+        prev = torch.zeros(B, D, device=x_3d.device, dtype=x_3d.dtype)
+        for t in range(M):
+            if t in starts_set:
+                prev = torch.zeros(B, D, device=x_3d.device, dtype=x_3d.dtype)
+            pt = p_2d[:, t:t + 1]
+            prev = pt * x_3d[:, t] + (1 - pt) * prev
+            out.append(prev)
+        return torch.stack(out, dim=1)
+
+    # -------------- Mode-specific forwards --------------
+
+    def _forward_padded(self, hidden_states, boundary_mask, boundary_prob, inference_params=None):
+        _, L = boundary_mask.shape
+        D = hidden_states.shape[-1]
+        device = hidden_states.device
+        M = hidden_states.shape[1]
+
+        # Gather boundary probs in chunked order (boundaries first within each row).
+        p_full = torch.clamp(boundary_prob[..., -1], min=1e-4, max=1 - 1e-4)
+        token_idx = torch.arange(L, device=device)[None, :] + (~boundary_mask).long() * L
+        sorted_idx = torch.argsort(token_idx, dim=1)[:, :M]
+        p = torch.gather(p_full, dim=1, index=sorted_idx)  # (B, M)
+
+        if _HAS_MAMBA_SCAN and hidden_states.is_cuda and M > 0:
+            ema = self._ema_kernel(hidden_states, p, seq_idx=None)
+        else:
+            ema = self._ema_loop(hidden_states, p)
+
+        plug_back_idx = torch.clamp(torch.cumsum(boundary_mask, dim=1) - 1, min=0)
+        full = torch.gather(
+            ema, dim=1, index=plug_back_idx.unsqueeze(-1).expand(-1, -1, D)
+        )
+
+        if inference_params is not None:
+            inference_params.last_value.copy_(
+                full[:, -1].to(inference_params.last_value.dtype)
+            )
+        return full
+
+    def _forward_packed(self, hidden_states, boundary_mask, boundary_prob, cu_seqlens):
+        """`cu_seqlens` is the **chunked-space** cu_seqlens (size B+1)."""
+        _, D = hidden_states.shape
+        device = hidden_states.device
+
+        # Chunked-space boundary probs.
+        p_packed = torch.clamp(
+            boundary_prob[..., -1][boundary_mask], min=1e-4, max=1 - 1e-4
+        )  # (M_total,)
+
+        M_total = hidden_states.shape[0]
+        if _HAS_MAMBA_SCAN and hidden_states.is_cuda and M_total > 0:
+            # Build chunked-space seq_idx for the scan reset.
+            pos = torch.arange(M_total, device=device)
+            seq_idx = (pos[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1).to(torch.int32)
+            ema = self._ema_kernel(
+                hidden_states.unsqueeze(0),
+                p_packed.unsqueeze(0),
+                seq_idx=seq_idx.unsqueeze(0),
+            ).squeeze(0)
+        else:
+            # Fallback: per-subseq EMA with reset at each subseq start.
+            ema = self._ema_loop(
+                hidden_states.unsqueeze(0),
+                p_packed.unsqueeze(0),
+                seq_starts=cu_seqlens[1:-1] if cu_seqlens.numel() > 2 else None,
+            ).squeeze(0)
+
+        # Plug back: chunked stream is monotonic in subseq order, so the global
+        # cumsum aligns indices correctly.
+        plug_back_idx = torch.clamp(boundary_mask.cumsum(dim=0) - 1, min=0)
+        full = torch.gather(ema, dim=0, index=plug_back_idx.unsqueeze(-1).expand(-1, D))
+        return full  # (T_total, D)
+
+    def step(self, hidden_states, boundary_mask, boundary_prob, inference_params: DeChunkState):
+        B = boundary_mask.shape[0]
+        D = inference_params.last_value.shape[-1]
+        device = inference_params.last_value.device
+
+        p = torch.zeros(B, device=device, dtype=inference_params.last_value.dtype)
+        p[boundary_mask] = boundary_prob[boundary_mask, -1].clamp(min=1e-4, max=1 - 1e-4)
+
+        new_vals = torch.zeros(B, D, device=device, dtype=inference_params.last_value.dtype)
+        if hidden_states.numel() > 0:
+            new_vals[boundary_mask] = hidden_states.squeeze(1).to(inference_params.last_value.dtype)
+
+        p_b = p.unsqueeze(-1)
+        result = p_b * new_vals + (1 - p_b) * inference_params.last_value
+        inference_params.last_value.copy_(result)
+        return result.unsqueeze(1)

--- a/egomimic/models/hnet_nets/stages.py
+++ b/egomimic/models/hnet_nets/stages.py
@@ -1,0 +1,537 @@
+"""
+Stage classes for the stage-based H-Net.
+
+A *stage* is a self-contained nn.Module that owns its own sub-modules
+(encoders / chunkers / main networks) and exposes a uniform interface:
+
+    forward(x, ctx) -> y
+    step(x_step, ctx, state) -> (y_step, state)
+    allocate_inference_cache(batch_size, dtype, device) -> state
+
+Stages nest recursively: each stage carries an optional ``inner_stage``. The
+top-level ``HNet`` wrapper wires the flat YAML list into a chain by setting
+``stages[i].inner_stage = stages[i+1]``. The last stage's ``inner_stage``
+stays None (terminal stage).
+
+Three stage types are provided:
+
+* ``EncoderDecoderStage`` — encoder Isotropic + (optional) inner_stage +
+  decoder Isotropic with an encoder→decoder residual.
+* ``ChunkerStage`` — RoutingModule + ChunkLayer + (optional) inner_stage +
+  DeChunkLayer, with STE residual gating. Registers boundary predictions
+  into ``ctx.aux`` for the ratio loss.
+* ``ComputeStage`` — a single Isotropic main_network. Terminal by default but
+  may also carry an inner_stage if the user wants further nesting.
+
+Dimension bridging between consecutive stages is **explicit**: each stage
+declares its ``input_hidden_dim`` and ``output_hidden_dim``. When the inner
+stage's expected input dim differs from this stage's working dim, the stage
+inserts a minimal ``nn.Linear`` projection. No padding-based bridging.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+from egomimic.models.hnet_nets.blocks import (
+    IsotropicInferenceParams,
+    KVCache,
+    MambaCache,
+)
+from egomimic.models.hnet_nets.context import HNetContext
+from egomimic.models.hnet_nets.isotropic_builder import build_isotropic
+from egomimic.models.hnet_nets.routing import (
+    ChunkLayer,
+    DeChunkLayer,
+    DeChunkState,
+    RoutingModule,
+    RoutingModuleState,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Inference-state dataclasses (one per stage type).
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class EncoderDecoderStageState:
+    encoder_state: Optional[IsotropicInferenceParams] = None
+    inner_state: Optional[Any] = None
+    decoder_state: Optional[IsotropicInferenceParams] = None
+    # closure-pattern residual carry between encoder.step and decoder.step
+    # within a single step() call is handled as a local variable; no field.
+
+
+@dataclass
+class ChunkerStageState:
+    routing_state: Optional[RoutingModuleState] = None
+    inner_state: Optional[Any] = None
+    dechunk_state: Optional[DeChunkState] = None
+
+
+@dataclass
+class ComputeStageState:
+    main_state: Optional[IsotropicInferenceParams] = None
+    inner_state: Optional[Any] = None
+
+
+# --------------------------------------------------------------------------- #
+# Straight-through estimator for the boundary mask (matches upstream HNet).
+# --------------------------------------------------------------------------- #
+
+class _STE(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        return torch.ones_like(x)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output
+
+
+def _ste(x):
+    return _STE.apply(x)
+
+
+# --------------------------------------------------------------------------- #
+# Per-batch slice/scatter helpers for nested inference state during step().
+# Reused (and slightly simplified) from the previous monolithic HNet.
+# --------------------------------------------------------------------------- #
+
+def _slice_iso_params(params: Optional[IsotropicInferenceParams], mask: torch.Tensor):
+    if params is None:
+        return None
+    new = IsotropicInferenceParams(
+        layer_caches={}, max_seqlen=params.max_seqlen, batch_size=int(mask.sum().item()),
+    )
+    for k, c in params.layer_caches.items():
+        if isinstance(c, KVCache):
+            new.layer_caches[k] = KVCache(
+                k=c.k[mask].clone(),
+                v=c.v[mask].clone(),
+                offsets=c.offsets[mask].clone(),
+            )
+        elif isinstance(c, MambaCache):
+            new.layer_caches[k] = MambaCache(
+                conv_state=c.conv_state[mask].clone(),
+                ssm_state=c.ssm_state[mask].clone(),
+            )
+        else:
+            raise TypeError(f"Unknown layer cache type: {type(c)}")
+    return new
+
+
+def _scatter_iso_params(
+    params: Optional[IsotropicInferenceParams],
+    sub: Optional[IsotropicInferenceParams],
+    mask: torch.Tensor,
+):
+    if params is None or sub is None:
+        return
+    for k, c in params.layer_caches.items():
+        s = sub.layer_caches[k]
+        if isinstance(c, KVCache):
+            c.k[mask] = s.k.to(c.k.dtype)
+            c.v[mask] = s.v.to(c.v.dtype)
+            c.offsets[mask] = s.offsets
+        elif isinstance(c, MambaCache):
+            c.conv_state[mask] = s.conv_state.to(c.conv_state.dtype)
+            c.ssm_state[mask] = s.ssm_state.to(c.ssm_state.dtype)
+        else:
+            raise TypeError(f"Unknown layer cache type: {type(c)}")
+
+
+def _slice_state(state: Any, mask: torch.Tensor):
+    """Generic batch-dim slice for any stage state dataclass."""
+    if state is None:
+        return None
+    if isinstance(state, IsotropicInferenceParams):
+        return _slice_iso_params(state, mask)
+    if isinstance(state, EncoderDecoderStageState):
+        return EncoderDecoderStageState(
+            encoder_state=_slice_iso_params(state.encoder_state, mask),
+            inner_state=_slice_state(state.inner_state, mask),
+            decoder_state=_slice_iso_params(state.decoder_state, mask),
+        )
+    if isinstance(state, ChunkerStageState):
+        rs = state.routing_state
+        if rs is not None:
+            rs = RoutingModuleState(
+                has_seen_tokens=rs.has_seen_tokens[mask].clone(),
+                last_hidden_state=rs.last_hidden_state[mask].clone(),
+            )
+        ds = state.dechunk_state
+        if ds is not None:
+            ds = DeChunkState(last_value=ds.last_value[mask].clone())
+        return ChunkerStageState(
+            routing_state=rs,
+            inner_state=_slice_state(state.inner_state, mask),
+            dechunk_state=ds,
+        )
+    if isinstance(state, ComputeStageState):
+        return ComputeStageState(
+            main_state=_slice_iso_params(state.main_state, mask),
+            inner_state=_slice_state(state.inner_state, mask),
+        )
+    raise TypeError(f"Unknown stage state type: {type(state)}")
+
+
+def _scatter_state(state: Any, sub: Any, mask: torch.Tensor):
+    if state is None or sub is None:
+        return
+    if isinstance(state, IsotropicInferenceParams):
+        _scatter_iso_params(state, sub, mask)
+        return
+    if isinstance(state, EncoderDecoderStageState):
+        _scatter_iso_params(state.encoder_state, sub.encoder_state, mask)
+        _scatter_state(state.inner_state, sub.inner_state, mask)
+        _scatter_iso_params(state.decoder_state, sub.decoder_state, mask)
+        return
+    if isinstance(state, ChunkerStageState):
+        if state.routing_state is not None and sub.routing_state is not None:
+            state.routing_state.has_seen_tokens[mask] = sub.routing_state.has_seen_tokens
+            state.routing_state.last_hidden_state[mask] = (
+                sub.routing_state.last_hidden_state.to(state.routing_state.last_hidden_state.dtype)
+            )
+        _scatter_state(state.inner_state, sub.inner_state, mask)
+        if state.dechunk_state is not None and sub.dechunk_state is not None:
+            state.dechunk_state.last_value[mask] = (
+                sub.dechunk_state.last_value.to(state.dechunk_state.last_value.dtype)
+            )
+        return
+    if isinstance(state, ComputeStageState):
+        _scatter_iso_params(state.main_state, sub.main_state, mask)
+        _scatter_state(state.inner_state, sub.inner_state, mask)
+        return
+    raise TypeError(f"Unknown stage state type: {type(state)}")
+
+
+# --------------------------------------------------------------------------- #
+# Shared base — handles inner_stage wiring assertion and the optional
+# input/output projections triggered only when input_hidden_dim != working dim.
+# --------------------------------------------------------------------------- #
+
+class _BaseStage(nn.Module):
+    """Common scaffolding for stage classes."""
+
+    def __init__(
+        self,
+        input_hidden_dim: int,
+        output_hidden_dim: int,
+        cond_key: str = "fused_cond",
+    ):
+        super().__init__()
+        self.input_hidden_dim = int(input_hidden_dim)
+        self.output_hidden_dim = int(output_hidden_dim)
+        self.cond_key = cond_key
+        # Filled in by HNet.__init__ when chaining stages.
+        self.inner_stage: Optional["_BaseStage"] = None
+
+    def _get_cond(self, ctx: HNetContext) -> Optional[torch.Tensor]:
+        if self.cond_key is None:
+            return None
+        return ctx.cond_dict.get(self.cond_key)
+
+    # Subclasses implement these.
+    def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:  # noqa: D401
+        raise NotImplementedError
+
+    def step(self, x: torch.Tensor, ctx: HNetContext, state: Any):
+        raise NotImplementedError
+
+    def allocate_inference_cache(self, batch_size: int, dtype, device):
+        raise NotImplementedError
+
+
+# --------------------------------------------------------------------------- #
+# EncoderDecoderStage
+# --------------------------------------------------------------------------- #
+
+class EncoderDecoderStage(_BaseStage):
+    """encoder → (optional inner_stage) → +encoder-residual → decoder.
+
+    The residual is a *local* variable inside forward / step (option C closure
+    pattern): no ``self.residual`` slot is mutated across calls.
+
+    Hidden-dim contract:
+        x_in.shape[-1] == input_hidden_dim == output_hidden_dim
+    (EncoderDecoderStages do not change hidden dim themselves; if the inner
+    stage uses a different working dim, the inner stage handles its own
+    projections.)
+    """
+
+    def __init__(
+        self,
+        input_hidden_dim: int,
+        output_hidden_dim: int,
+        encoder: Dict[str, Any],
+        decoder: Dict[str, Any],
+        cond_key: str = "fused_cond",
+        d_cond: int = 0,
+        causal: bool = True,
+    ):
+        super().__init__(input_hidden_dim, output_hidden_dim, cond_key=cond_key)
+        if input_hidden_dim != output_hidden_dim:
+            raise ValueError(
+                f"EncoderDecoderStage requires input_hidden_dim==output_hidden_dim "
+                f"(got {input_hidden_dim} vs {output_hidden_dim}). Use a "
+                f"ChunkerStage or ComputeStage to change hidden dim."
+            )
+        if int(encoder["d_model"]) != input_hidden_dim:
+            raise ValueError(
+                f"encoder.d_model ({encoder['d_model']}) must equal stage "
+                f"input_hidden_dim ({input_hidden_dim})."
+            )
+        if int(decoder["d_model"]) != output_hidden_dim:
+            raise ValueError(
+                f"decoder.d_model ({decoder['d_model']}) must equal stage "
+                f"output_hidden_dim ({output_hidden_dim})."
+            )
+
+        self.causal = causal
+        self.encoder = build_isotropic(encoder, d_cond=d_cond, causal=causal)
+        self.decoder = build_isotropic(decoder, d_cond=d_cond, causal=causal)
+
+    def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        cond = self._get_cond(ctx)
+        # Padded mode: build an all-ones mask along T (causal already wired
+        # into the Isotropic). This matches the algo's BOS-prefixed teacher-
+        # forced input.
+        mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
+
+        x = self.encoder(x, mask=mask, cond=cond)
+        residual = x
+        if self.inner_stage is not None:
+            x = self.inner_stage(x, ctx)
+        x = x + residual
+        x = self.decoder(x, mask=mask, cond=cond)
+        return x
+
+    def step(self, x: torch.Tensor, ctx: HNetContext, state: EncoderDecoderStageState):
+        cond = self._get_cond(ctx)
+        x = self.encoder.step(x, state.encoder_state, cond=cond)
+        residual = x
+        if self.inner_stage is not None:
+            x = self.inner_stage.step(x, ctx, state.inner_state)
+        x = x + residual
+        x = self.decoder.step(x, state.decoder_state, cond=cond)
+        return x
+
+    def allocate_inference_cache(self, batch_size, dtype, device):
+        max_seqlen = 1024  # generous: KVCache size; actual seqlen comes from algo
+        # The algo will call HNet.allocate_inference_cache(batch_size, max_seqlen, ...)
+        # which forwards max_seqlen through; for simplicity we keep a separate path.
+        raise NotImplementedError("Use _allocate(batch_size, max_seqlen, dtype, device).")
+
+    def _allocate(self, batch_size, max_seqlen, dtype, device):
+        return EncoderDecoderStageState(
+            encoder_state=self.encoder.allocate_inference_cache(batch_size, max_seqlen, device, dtype),
+            inner_state=(
+                self.inner_stage._allocate(batch_size, max_seqlen, dtype, device)
+                if self.inner_stage is not None else None
+            ),
+            decoder_state=self.decoder.allocate_inference_cache(batch_size, max_seqlen, device, dtype),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# ChunkerStage
+# --------------------------------------------------------------------------- #
+
+class ChunkerStage(_BaseStage):
+    """RoutingModule → ChunkLayer → (optional inner_stage) → DeChunkLayer.
+
+    Includes the STE residual gating from the upstream H-Net so the dechunked
+    signal can fall back to a learned residual when no boundary fires.
+
+    Hidden-dim contract:
+        Working dim outside the chunker = ``input_hidden_dim``.
+        Working dim of the inner stage  = ``output_hidden_dim``.
+        If they differ, the stage inserts an explicit Linear pre-chunk and a
+        matching Linear post-chunk so dechunk operates back at the outer dim.
+    """
+
+    def __init__(
+        self,
+        input_hidden_dim: int,
+        output_hidden_dim: int,
+        target_compression_ratio: float = 2.0,
+        ratio_loss_weight: float = 0.03,
+        cond_key: str = "fused_cond",
+    ):
+        super().__init__(input_hidden_dim, output_hidden_dim, cond_key=cond_key)
+        self.target_compression_ratio = float(target_compression_ratio)
+        self.ratio_loss_weight = float(ratio_loss_weight)
+
+        # Routing / chunk / dechunk operate at the *outer* (input) hidden dim.
+        self.routing_module = RoutingModule(self.input_hidden_dim)
+        self.chunk_layer = ChunkLayer()
+        self.dechunk_layer = DeChunkLayer(self.input_hidden_dim)
+
+        # Explicit projections to/from the inner-stage working dim when it
+        # differs from the outer dim. Created only when needed.
+        if self.input_hidden_dim != self.output_hidden_dim:
+            self.proj_in = nn.Linear(self.input_hidden_dim, self.output_hidden_dim)
+            self.proj_out = nn.Linear(self.output_hidden_dim, self.input_hidden_dim)
+        else:
+            self.proj_in = None
+            self.proj_out = None
+
+        # STE residual mixer at the outer (input) dim. Init to zero so the
+        # network starts off transparent.
+        self.residual_proj = nn.Linear(self.input_hidden_dim, self.input_hidden_dim)
+        nn.init.zeros_(self.residual_proj.weight)
+        nn.init.zeros_(self.residual_proj.bias)
+        self.residual_proj.weight._no_reinit = True
+
+    def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        # Padded mode (B, T, D_in).
+        B, T, _ = x.shape
+        mask = torch.ones(B, T, dtype=torch.bool, device=x.device)
+
+        bpred = self.routing_module(x, mask=mask)
+        residual = self.residual_proj(x.float())
+
+        chunked, _next_cu, next_max, next_mask = self.chunk_layer(
+            x, bpred.boundary_mask, mask=mask,
+        )
+
+        # Project into inner-stage working dim if required.
+        if self.proj_in is not None:
+            chunked = self.proj_in(chunked)
+
+        if self.inner_stage is not None:
+            chunked = self.inner_stage(chunked, ctx)
+
+        if self.proj_out is not None:
+            chunked = self.proj_out(chunked)
+
+        dechunked = self.dechunk_layer(
+            chunked, bpred.boundary_mask, bpred.boundary_prob, mask=mask,
+        )
+
+        # STE residual gating (fp32 like upstream).
+        out = (
+            dechunked.float() * _ste(bpred.selected_probs) + residual
+        ).to(x.dtype)
+
+        ctx.register_aux(
+            {
+                "bpred": bpred,
+                "target_ratio": self.target_compression_ratio,
+                "weight": self.ratio_loss_weight,
+            }
+        )
+        return out
+
+    def step(self, x: torch.Tensor, ctx: HNetContext, state: ChunkerStageState):
+        bpred = self.routing_module.step(x, state.routing_state)
+        residual = self.residual_proj(x.float())
+
+        inner_in = self.chunk_layer.step(x, bpred.boundary_mask)
+        if inner_in.shape[0] > 0:
+            if self.proj_in is not None:
+                inner_in = self.proj_in(inner_in)
+            if self.inner_stage is not None:
+                # Slice nested state to active rows, recurse, then scatter back.
+                sub_state = _slice_state(state.inner_state, bpred.boundary_mask)
+                inner_out = self.inner_stage.step(inner_in, ctx, sub_state)
+                _scatter_state(state.inner_state, sub_state, bpred.boundary_mask)
+            else:
+                inner_out = inner_in
+            if self.proj_out is not None:
+                inner_out = self.proj_out(inner_out)
+        else:
+            inner_out = inner_in  # empty tensor at outer dim already
+
+        dechunked = self.dechunk_layer.step(
+            inner_out, bpred.boundary_mask, bpred.boundary_prob, state.dechunk_state,
+        )
+
+        # selected_probs at step has shape (B, 1); STE expects something
+        # broadcastable to dechunked (B, 1, D).
+        out = (
+            dechunked.float() * _ste(bpred.selected_probs.unsqueeze(1)) + residual
+        ).to(x.dtype)
+
+        ctx.register_aux(
+            {
+                "bpred": bpred,
+                "target_ratio": self.target_compression_ratio,
+                "weight": self.ratio_loss_weight,
+            }
+        )
+        return out
+
+    def _allocate(self, batch_size, max_seqlen, dtype, device):
+        return ChunkerStageState(
+            routing_state=self.routing_module.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            ),
+            inner_state=(
+                self.inner_stage._allocate(batch_size, max_seqlen, dtype, device)
+                if self.inner_stage is not None else None
+            ),
+            dechunk_state=self.dechunk_layer.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            ),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# ComputeStage
+# --------------------------------------------------------------------------- #
+
+class ComputeStage(_BaseStage):
+    """A single Isotropic main_network. Terminal by default; an inner_stage
+    may be chained after the main_network for further nesting."""
+
+    def __init__(
+        self,
+        input_hidden_dim: int,
+        output_hidden_dim: int,
+        main_network: Dict[str, Any],
+        cond_key: str = "fused_cond",
+        d_cond: int = 0,
+        causal: bool = True,
+    ):
+        super().__init__(input_hidden_dim, output_hidden_dim, cond_key=cond_key)
+        if input_hidden_dim != output_hidden_dim:
+            raise ValueError(
+                f"ComputeStage requires input_hidden_dim==output_hidden_dim "
+                f"(got {input_hidden_dim} vs {output_hidden_dim})."
+            )
+        if int(main_network["d_model"]) != input_hidden_dim:
+            raise ValueError(
+                f"main_network.d_model ({main_network['d_model']}) must equal "
+                f"stage input_hidden_dim ({input_hidden_dim})."
+            )
+        self.causal = causal
+        self.main_network = build_isotropic(main_network, d_cond=d_cond, causal=causal)
+
+    def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        cond = self._get_cond(ctx)
+        mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
+        x = self.main_network(x, mask=mask, cond=cond)
+        if self.inner_stage is not None:
+            x = self.inner_stage(x, ctx)
+        return x
+
+    def step(self, x: torch.Tensor, ctx: HNetContext, state: ComputeStageState):
+        cond = self._get_cond(ctx)
+        x = self.main_network.step(x, state.main_state, cond=cond)
+        if self.inner_stage is not None:
+            x = self.inner_stage.step(x, ctx, state.inner_state)
+        return x
+
+    def _allocate(self, batch_size, max_seqlen, dtype, device):
+        return ComputeStageState(
+            main_state=self.main_network.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            ),
+            inner_state=(
+                self.inner_stage._allocate(batch_size, max_seqlen, dtype, device)
+                if self.inner_stage is not None else None
+            ),
+        )


### PR DESCRIPTION
Replace the recursive monolithic HNet with a flat-list of composable
stages (EncoderDecoderStage / ChunkerStage / ComputeStage) wired into a
recursive tree at construction time. Each stage owns its own inference
state dataclass; chunkers register ratio-loss aux on a shared
HNetContext. CondEncoderModule is extracted from HNetPolicy as a
standalone Hydra-instantiated module.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>