### PR TITLE
Deduplicate data configs via interpolation + algo-agnostic keymap base

### DIFF
--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -1068,6 +1068,9 @@ class HPT(Algo):
                 "domain": embodiment_name,  # readability on config side
                 "data": data,
             }
+            # stem_process replaces image tensors with encoder outputs in place,
+            # so keep a fresh copy for the forward() call below.
+            forward_data = self._clone_batch(hpt_batch["data"])
 
             # BC val loss — same call as forward_training.
             if self.freeze_repr:
@@ -1078,9 +1081,7 @@ class HPT(Algo):
                 val_loss = self.nets["policy"].compute_loss(hpt_batch)
             unnorm_preds[f"{embodiment_name}_loss"] = val_loss
 
-            actions = self.nets["policy"].forward(
-                hpt_batch["domain"], hpt_batch["data"]
-            )
+            actions = self.nets["policy"].forward(hpt_batch["domain"], forward_data)
             predictions = OrderedDict()
 
             for key in actions:

--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -1179,20 +1179,25 @@ class HPT(Algo):
         """
         data = {}
 
+        # MultiDataset emits dotted batch keys (e.g. "observations.state.ee_pose"),
+        # but HPT stems are registered under the last segment ("state_ee_pose",
+        # "front_img_1"). Translate via rsplit; no-op on already-flat keys.
         for key in proprio_keys:
             if key in batch:
-                data[f"state_{key}"] = batch[key].unsqueeze(1)
+                short = key.rsplit(".", 1)[-1]
+                data[f"state_{short}"] = batch[key].unsqueeze(1)
 
         for key in cam_keys:
             if key in batch:
+                short = key.rsplit(".", 1)[-1]
                 _data = batch[key]
                 if not torch.all(_data == 0):
-                    if self.nets.training and key in self.encoders:
+                    if self.nets.training and short in self.encoders:
                         _data = self.train_image_augs(_data)
-                    elif self.eval_image_augs and key in self.encoders:
+                    elif self.eval_image_augs and short in self.encoders:
                         _data = self.eval_image_augs(_data)
 
-                data[key] = _data.unsqueeze(1).unsqueeze(1)
+                data[short] = _data.unsqueeze(1).unsqueeze(1)
 
         for key in lang_keys:
             if key in batch:

--- a/egomimic/hydra_configs/data/aria.yaml
+++ b/egomimic/hydra_configs/data/aria.yaml
@@ -17,23 +17,10 @@ train_datasets:
       filter_lambdas:
         - "lambda row: row['episode_hash'] == '2025-09-20-17-47-54-000000'"
     mode: total
+
 valid_datasets:
-  aria_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /coc/flash7/scratch/egoverseDebugDatasets/aria
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
-        mode: cartesian
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
-        mode: cartesian
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: row['episode_hash'] == '2025-09-20-17-47-54-000000'"
-    mode: total
+  aria_bimanual: ${train_datasets.aria_bimanual}
+
 train_dataloader_params:
   aria_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/aria_keypoints.yaml
+++ b/egomimic/hydra_configs/data/aria_keypoints.yaml
@@ -1,4 +1,5 @@
 _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
 train_datasets:
   aria_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
@@ -15,22 +16,10 @@ train_datasets:
       robot_name: "aria_bimanual"
       task: "fold_clothes_indomain"
     mode: total
+
 valid_datasets:
-  aria_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /coc/flash7/scratch/egoverseS3ZarrDataset
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
-        mode: keypoints
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
-        mode: keypoints_headframe_ypr
-    filters:
-      robot_name: "aria_bimanual"
-      task: "fold_clothes_indomain"
-    mode: total
+  aria_bimanual: ${train_datasets.aria_bimanual}
+
 train_dataloader_params:
   aria_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/aria_keypoints_wrist.yaml
+++ b/egomimic/hydra_configs/data/aria_keypoints_wrist.yaml
@@ -1,4 +1,5 @@
 _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
 train_datasets:
   aria_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
@@ -15,22 +16,10 @@ train_datasets:
       robot_name: "aria_bimanual"
       task: "fold_clothes_indomain"
     mode: total
+
 valid_datasets:
-  aria_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /coc/flash7/scratch/egoverseS3ZarrDataset
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
-        mode: keypoints
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
-        mode: keypoints_wristframe_ypr
-    filters:
-      robot_name: "aria_bimanual"
-      task: "fold_clothes_indomain"
-    mode: total
+  aria_bimanual: ${train_datasets.aria_bimanual}
+
 train_dataloader_params:
   aria_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/aria_pi.yaml
+++ b/egomimic/hydra_configs/data/aria_pi.yaml
@@ -15,21 +15,10 @@ train_datasets:
       filter_lambdas:
         - "lambda row: row['episode_hash'] == '2025-09-20-17-47-54-000000'"
     mode: total
+
 valid_datasets:
-  aria_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: row['episode_hash'] == '2025-09-20-17-47-54-000000'"
-    mode: total
+  aria_bimanual: ${train_datasets.aria_bimanual}
+
 train_dataloader_params:
   aria_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/cotrain_pi_base.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_base.yaml
@@ -1,4 +1,5 @@
 _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
 train_datasets:
   eva_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
@@ -7,7 +8,7 @@ train_datasets:
       folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
       key_map:
         _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
-        keymap_mode: cartesian_pi
+        keymap_mode: cartesian
         annotation_key: annotations
       transform_list:
         _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
@@ -33,35 +34,17 @@ train_datasets:
 
 valid_datasets:
   eva_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
-      folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
-      key_map:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
-        keymap_mode: cartesian_pi
-        annotation_key: annotations
-      transform_list:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
-        mode: cartesian
-    filters: null
+    _target_: ${train_datasets.eva_bimanual._target_}
+    resolver: ${train_datasets.eva_bimanual.resolver}
+    filters: ${train_datasets.eva_bimanual.filters}
     mode: valid
-    valid_ratio: 0.05
+    valid_ratio: ${train_datasets.eva_bimanual.valid_ratio}
   aria_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3AnnotationCutoffEpisodeResolver
-      folder_path: /storage/home/hcoda1/4/paphiwetsa3/r-dxu345-0/datasets/pick_place_elmond_refactor
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
-        keymap_mode: cartesian
-        annotation_key: annotations
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
-        mode: cartesian
-    filters: null
+    _target_: ${train_datasets.aria_bimanual._target_}
+    resolver: ${train_datasets.aria_bimanual.resolver}
+    filters: ${train_datasets.aria_bimanual.filters}
     mode: valid
-    valid_ratio: 0.05
+    valid_ratio: ${train_datasets.aria_bimanual.valid_ratio}
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/cotrain_pi_lang.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_lang.yaml
@@ -1,8 +1,12 @@
 defaults:
   - cotrain_pi_base
   - _self_
+
 train_datasets:
   eva_bimanual:
+    resolver:
+      key_map:
+        keymap_mode: cartesian_pi
     filters:
       _target_: egomimic.rldb.filters.ScaleAnnotationDatasetFilter
       project_name: "dense-language"
@@ -28,12 +32,3 @@ valid_datasets:
       project_name: "dense-language"
       filter_lambdas:
         - "lambda row: row['robot_name'] == 'aria_bimanual' and row['task'] == 'pick_place' and row['zarr_processed_path'] != '' and 'alignment' not in (row.get('task_description') or '')"
-
-# Prompt config moved to the model side. To reproduce the previous behaviour
-# of this data config, pair with the following overrides on the model
-# (model.robomimic_model.*):
-#   annotation_key: "annotations"
-#   default_prompt: "this is a bad action"
-#   control_mode:
-#     aria: "cam frame xyzypr per arm"
-#     eva:  "cam frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/data/cotrain_pi_lang_wrist.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_lang_wrist.yaml
@@ -6,46 +6,12 @@ train_datasets:
   eva_bimanual:
     resolver:
       key_map:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
-        keymap_mode: cartesian_wristframe_ypr # check if this works with the transform list below
-        annotation_key: annotations
-      transform_list:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
-        mode: cartesian_wristframe_ypr
-  aria_bimanual:
-    resolver:
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
-        keymap_mode: cartesian
-        annotation_key: annotations
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
-        mode: cartesian_wristframe_ypr
-
-valid_datasets:
-  eva_bimanual:
-    resolver:
-      key_map:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
         keymap_mode: cartesian_wristframe_ypr
-        annotation_key: annotations
       transform_list:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
         mode: cartesian_wristframe_ypr
   aria_bimanual:
     resolver:
       key_map:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_keymap
         keymap_mode: cartesian
-        annotation_key: annotations
       transform_list:
-        _target_: egomimic.rldb.embodiment.human.Aria.get_transform_list
         mode: cartesian_wristframe_ypr
-
-# Prompt config moved to the model side. For the wristframe pipeline,
-# pair this data config with model overrides (model.robomimic_model.*):
-#   annotation_key: "annotations"
-#   default_prompt: "this is a bad action"
-#   control_mode:
-#     aria: "wrist frame xyzypr per arm"
-#     eva:  "wrist frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/data/cotrain_pi_no_lang.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_no_lang.yaml
@@ -4,6 +4,9 @@ defaults:
 
 train_datasets:
   eva_bimanual:
+    resolver:
+      key_map:
+        keymap_mode: cartesian_pi
     filters:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
@@ -13,20 +16,3 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: (row['robot_name'] == 'aria_bimanual') & (row['task'] == 'fold_clothes') & (row['zarr_processed_path'] != '')"
-
-valid_datasets:
-  eva_bimanual:
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: (row['robot_name'] == 'eva_bimanual') & (row['task'] == 'fold_clothes') & (row['zarr_processed_path'] != '')"
-  aria_bimanual:
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: (row['robot_name'] == 'aria_bimanual') & (row['task'] == 'fold_clothes') & (row['zarr_processed_path'] != '')"
-
-# Prompt config moved to the model side. Pair this data config with model
-# overrides (model.robomimic_model.*):
-#   annotation_key: null
-#   default_prompt: "fold the clothes"

--- a/egomimic/hydra_configs/data/eva.yaml
+++ b/egomimic/hydra_configs/data/eva.yaml
@@ -1,4 +1,5 @@
 _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
 train_datasets:
   eva_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
@@ -18,22 +19,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  eva_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path:  /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
-        keymap_mode: cartesian
-      transform_list:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
-        mode: cartesian
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: row['episode_hash'] == '2025-12-26-18-07-46-296000'"
-    mode: total
+  eva_bimanual: ${train_datasets.eva_bimanual}
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/eva_action_expert.yaml
+++ b/egomimic/hydra_configs/data/eva_action_expert.yaml
@@ -20,21 +20,11 @@ train_datasets:
 
 valid_datasets:
   eva_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_action_expert.S3ActionExpertEpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      fixed_horizon: 100
-      key_map:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
-        keymap_mode: cartesian
-        annotation_key: annotations
-      transform_list:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
-        mode: cartesian_wristframe_ypr
-    filters: null
+    _target_: ${train_datasets.eva_bimanual._target_}
+    resolver: ${train_datasets.eva_bimanual.resolver}
+    filters: ${train_datasets.eva_bimanual.filters}
     mode: valid
-    valid_ratio: 0.05
+    valid_ratio: ${train_datasets.eva_bimanual.valid_ratio}
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/eva_pi.yaml
+++ b/egomimic/hydra_configs/data/eva_pi.yaml
@@ -7,6 +7,8 @@ train_datasets:
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalAnnotationCutoffEpisodeResolver
       folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
+      key_map:
+        keymap_mode: cartesian_pi
     filters:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
@@ -15,19 +17,5 @@ train_datasets:
   aria_bimanual: null
 
 valid_datasets:
-  eva_bimanual:
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalAnnotationCutoffEpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pick_place_diverse
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: row.get('embodiment') == 'eva_bimanual'"
-    mode: total
+  eva_bimanual: ${train_datasets.eva_bimanual}
   aria_bimanual: null
-
-
-# Prompt config moved to the model side. Pair this data config with model
-# overrides (model.robomimic_model.*):
-#   annotation_key: "annotations"
-#   default_prompt: "this is a bad action"

--- a/egomimic/hydra_configs/data/eva_pi_lang.yaml
+++ b/egomimic/hydra_configs/data/eva_pi_lang.yaml
@@ -4,6 +4,9 @@ defaults:
 
 train_datasets:
   eva_bimanual:
+    resolver:
+      key_map:
+        keymap_mode: cartesian_pi
     filters:
       _target_: egomimic.rldb.filters.ScaleAnnotationDatasetFilter
       project_name: "dense-language"
@@ -19,10 +22,3 @@ valid_datasets:
       filter_lambdas:
         - "lambda row: row['robot_name'] == 'eva_bimanual' and row['task'] == 'pick_place' and row['zarr_processed_path'] != '' and 'alignment' not in (row.get('task_description') or '')"
   aria_bimanual: null
-
-# Prompt config moved to the model side. Pair this data config with model
-# overrides (model.robomimic_model.*):
-#   annotation_key: "annotations"
-#   default_prompt: "this is a bad action"
-#   control_mode:
-#     eva: "cam frame xyzypr gripper per arm"

--- a/egomimic/hydra_configs/data/industry_eva_pi.yaml
+++ b/egomimic/hydra_configs/data/industry_eva_pi.yaml
@@ -40,46 +40,24 @@ train_datasets:
       lab: "scale"
       task: "flagship_fold_clothes"
     mode: train
+
 valid_datasets:
   eva_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.eva.Eva.get_transform_list
-    filters:
-      robot_name: "eva_bimanual"
-      task: "fold_clothes"
+    _target_: ${train_datasets.eva_bimanual._target_}
+    resolver: ${train_datasets.eva_bimanual.resolver}
+    filters: ${train_datasets.eva_bimanual.filters}
     mode: valid
   mecka_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_transform_list
-    filters:
-      lab: "mecka"
-      task: "fold_clothes"
+    _target_: ${train_datasets.mecka_bimanual._target_}
+    resolver: ${train_datasets.mecka_bimanual.resolver}
+    filters: ${train_datasets.mecka_bimanual.filters}
     mode: valid
   scale_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_transform_list
-    filters:
-      lab: "scale"
-      task: "flagship_fold_clothes"
+    _target_: ${train_datasets.scale_bimanual._target_}
+    resolver: ${train_datasets.scale_bimanual.resolver}
+    filters: ${train_datasets.scale_bimanual.filters}
     mode: valid
+
 train_dataloader_params:
   eva_bimanual:
     batch_size: 21

--- a/egomimic/hydra_configs/data/mecka.yaml
+++ b/egomimic/hydra_configs/data/mecka.yaml
@@ -17,23 +17,10 @@ train_datasets:
       filter_lambdas:
         - "lambda row: row['episode_hash'] == '69199812208123403bbdb24f'"
     mode: total
+
 valid_datasets:
-  mecka_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /coc/flash7/scratch/egoverseDebugDatasets/mecka
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_keymap
-        mode: cartesian
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_transform_list
-        mode: cartesian
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: row['episode_hash'] == '69199812208123403bbdb24f'"
-    mode: total
+  mecka_bimanual: ${train_datasets.mecka_bimanual}
+
 train_dataloader_params:
   mecka_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/mecka_pi.yaml
+++ b/egomimic/hydra_configs/data/mecka_pi.yaml
@@ -14,20 +14,14 @@ train_datasets:
       lab: "mecka"
       task: "folding_clothes"
     mode: train
+
 valid_datasets:
   mecka_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_transform_list
-    filters:
-      lab: "mecka"
-      task: "folding_clothes"
+    _target_: ${train_datasets.mecka_bimanual._target_}
+    resolver: ${train_datasets.mecka_bimanual.resolver}
+    filters: ${train_datasets.mecka_bimanual.filters}
     mode: valid
+
 train_dataloader_params:
   mecka_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/mecka_scale_cotrain_pi.yaml
+++ b/egomimic/hydra_configs/data/mecka_scale_cotrain_pi.yaml
@@ -13,7 +13,6 @@ train_datasets:
     filters:
       lab: "mecka"
       task: "fold_clothes"
-      # episode_hash: "6930856076acbe36f0806bfb"
     mode: train
   scale_bimanual:
     _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
@@ -27,37 +26,20 @@ train_datasets:
     filters:
       lab: "scale"
       task: "flagship_fold_clothes"
-      # episode_hash: "2026-03-18-19-03-29-311551"
     mode: train
+
 valid_datasets:
   mecka_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Mecka.get_transform_list
-    filters:
-      lab: "mecka"
-      task: "fold_clothes"
-      # episode_hash: "6930856076acbe36f0806bfb"
+    _target_: ${train_datasets.mecka_bimanual._target_}
+    resolver: ${train_datasets.mecka_bimanual.resolver}
+    filters: ${train_datasets.mecka_bimanual.filters}
     mode: valid
   scale_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_transform_list
-    filters:
-      lab: "scale"
-      task: "flagship_fold_clothes"
-      # episode_hash: "2026-03-18-19-03-29-311551"
+    _target_: ${train_datasets.scale_bimanual._target_}
+    resolver: ${train_datasets.scale_bimanual.resolver}
+    filters: ${train_datasets.scale_bimanual.filters}
     mode: valid
+
 train_dataloader_params:
   mecka_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/scale.yaml
+++ b/egomimic/hydra_configs/data/scale.yaml
@@ -17,23 +17,10 @@ train_datasets:
       filter_lambdas:
         - "lambda row: row['episode_hash'] in {'2026-03-16-01-22-26-448000'}"
     mode: total
+
 valid_datasets:
-  scale_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /coc/flash7/scratch/egoverseDebugDatasets/egoverseS3DatasetTest/
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_keymap
-        mode: cartesian
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_transform_list
-        mode: cartesian
-    filters:
-      _target_: egomimic.rldb.filters.DatasetFilter
-      filter_lambdas:
-        - "lambda row: row['episode_hash'] in {'2026-03-16-01-22-26-448000'}"
-    mode: total
+  scale_bimanual: ${train_datasets.scale_bimanual}
+
 train_dataloader_params:
   scale_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/data/scale_pi.yaml
+++ b/egomimic/hydra_configs/data/scale_pi.yaml
@@ -14,20 +14,16 @@ train_datasets:
       filter_lambdas:
         - "lambda row: ((row['task'] == 'Folding Clothes') | (row['task'] == '[flagship] Folding Clothes')) & (row['lab'] == 'scale') & (row['robot_name'] == 'scale_bimanual') & (row['is_deleted'] == false)"
     mode: train
+
 valid_datasets:
   scale_bimanual:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
-    resolver:
-      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
-      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
-      key_map:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_keymap
-      transform_list:
-        _target_: egomimic.rldb.embodiment.human.Scale.get_transform_list
+    _target_: ${train_datasets.scale_bimanual._target_}
+    resolver: ${train_datasets.scale_bimanual.resolver}
     filters:
       task:
         - "lambda row: ((row['task'] == 'Folding Clothes') | (row['task'] == '[flagship] Folding Clothes')) & (row['lab'] == 'scale') & (row['robot_name'] == 'scale_bimanual') & (row['is_deleted'] == false)"
     mode: valid
+
 train_dataloader_params:
   scale_bimanual:
     batch_size: 32

--- a/egomimic/hydra_configs/evaluator/viz/cartesian.yaml
+++ b/egomimic/hydra_configs/evaluator/viz/cartesian.yaml
@@ -1,24 +1,24 @@
 eva_bimanual:
   _target_: egomimic.rldb.embodiment.eva.Eva.viz_gt_preds
   _partial_: true
-  image_key: front_img_1
+  image_key: observations.images.front_img_1
   action_key: actions_cartesian
   mode: traj
 aria_bimanual:
   _target_: egomimic.rldb.embodiment.human.Aria.viz_gt_preds
   _partial_: true
-  image_key: front_img_1
+  image_key: observations.images.front_img_1
   action_key: actions_cartesian
   mode: traj
 mecka_bimanual:
   _target_: egomimic.rldb.embodiment.human.Mecka.viz_gt_preds
   _partial_: true
-  image_key: front_img_1
+  image_key: observations.images.front_img_1
   action_key: actions_cartesian
   mode: traj
 scale_bimanual:
   _target_: egomimic.rldb.embodiment.human.Scale.viz_gt_preds
   _partial_: true
-  image_key: front_img_1
+  image_key: observations.images.front_img_1
   action_key: actions_cartesian
   mode: traj


### PR DESCRIPTION
- cotrain_pi_base.yaml now defaults to keymap_mode: cartesian (HPT-style); PI inheritors (eva_pi, eva_pi_lang, cotrain_pi_lang, cotrain_pi_no_lang) override to cartesian_pi.
- valid_datasets blocks now interpolate from train_datasets (${train_datasets.X} or per-field ${train_datasets.X.resolver}/.filters/._target_) instead of duplicating bodies. Children that share filters across train/valid (cotrain_pi_no_lang, cotrain_pi_lang_wrist) drop the valid override entirely; cotrain_pi_lang/eva_pi_lang keep an explicit valid-filter override where the lambda actually differs (excludes 'alignment').
- Net: 189 lines removed across 18 files. Composed YAML byte-identical to pre-refactor for every config (verified via OmegaConf.to_yaml(..., resolve=True) snapshot diff).