### PR TITLE
Add episode-level packed dataloading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+## Packed dataloading (episode-level)
+
+A variable-length, per-frame "packed" read path was added on top of the
+existing per-frame `ZarrDataset`. The intent is full-episode loading: each
+sample is one episode (or one chunk of a long episode), and a batch of
+samples is concatenated into a single flat stream with `cu_seqlens`
+boundaries (FlashAttention-style). The base read primitive and the
+collator are deliberately generic so an annotation-level packed dataset
+can be added later without rework.
+
+### Files touched
+
+- `egomimic/rldb/zarr/zarr_dataset_multi.py`
+  - `ZarrDataset._annotations_for_span(start, end)` — collects every
+    annotation whose `[start_idx, end_idx)` overlaps `[start, end)`.
+  - `ZarrDataset._read_span(start, end, *, episode_idx=None)` — reads each
+    `key_map` key over `[start, end)` with no horizon windowing and no
+    padding. Handles JPEG/JSON decode and transforms exactly like
+    `__getitem__`. Returns per-frame tensors of shape `(end - start, ...)`,
+    plus `seq_len`, `embodiment`, `metadata.robot_name`, the configured
+    annotation key as `list[str]`, and (optionally) `episode_idx`.
+    `metadata_keys` are skipped; failures propagate so the wrapping packed
+    dataset can resample.
+  - `__getitem__` is unchanged.
+
+- `egomimic/rldb/zarr/zarr_dataset_packed.py` (new)
+  - `ZarrEpisodePackedDataset(datasets, max_seq_len, min_seq_len, chunking,
+    max_resample_attempts)` — wraps a `dict[str, ZarrDataset]` (same shape
+    returned by the existing resolvers).
+    - Index is built once at construction: each entry is
+      `(episode_key, start, end)`. Each `__getitem__` index = one chunk
+      = one contiguous span from one episode.
+    - `chunking="sequential"`: episodes longer than `max_seq_len` are
+      split into consecutive non-overlapping chunks; the trailing chunk
+      may be shorter (dropped if `< min_seq_len`).
+    - `chunking="none"` (or `max_seq_len=None`): one entry per episode,
+      raises if any episode exceeds `max_seq_len`.
+    - On read failure (bad JPEG, transform error) it resamples to a
+      random other index up to `max_resample_attempts` times.
+    - Adds `chunk_offset` (start frame within the episode) to each sample
+      on top of what `_read_span` returns.
+    - Factories: `from_resolver(...)`, `from_local_folder(...)` — the
+      latter is a convenience that builds a `LocalEpisodeResolver`
+      internally for smoke tests.
+  - `pack_collate(batch)` — generic collator:
+    - Per-frame tensor keys (first dim equals the sample's `seq_len`):
+      `torch.cat` along time → `(sum(seq_lens), ...)`.
+    - List-valued keys (e.g. annotations): pass through as
+      `list[list[str]]`, matching the existing `annotation_collate`
+      contract.
+    - Scalar-per-sample keys (`embodiment`, `episode_idx`,
+      `chunk_offset`): collated into a `(B,)` tensor.
+    - Emits `seq_lens` (LongTensor `(B,)`), `cu_seqlens` (LongTensor
+      `(B+1,)`, `cu[0]==0`), `max_seq_len` (int), `batch_size` (int).
+
+- `egomimic/pl_utils/pl_data_utils.py`
+  - `MultiDataModuleWrapper` no longer hard-codes `annotation_collate`.
+    A new helper `_collate_fn_for(dataset)` picks `pack_collate` when the
+    dataset is a `ZarrEpisodePackedDataset`, otherwise `annotation_collate`.
+    Each per-dataset DataLoader gets its own collate fn — a packed
+    dataset can sit alongside unpacked datasets in the same combined
+    loader.
+
+### What is intentionally not implemented
+
+- Annotation-level packed dataset (`ZarrAnnotationPackedDataset`). The
+  `_read_span` primitive and `pack_collate` are written generically so
+  this can be added as a sibling class with different index-building
+  logic only.
+- Hydra config knobs / wiring for the packed datasets.
+- Model-side `cu_seqlens` plumbing and pos-emb adjustments.
+
+### Smoke test
+
+`scripts/smoke_packed_dataset.py` — runs against the pushT
+`/coc/cedarp-dxu345-0/Tsim_datasets/test_demos` folder, builds a
+`ZarrEpisodePackedDataset` (defaults `chunking="none"`), packs all
+episodes through a `DataLoader(collate_fn=pack_collate)`, then writes:
+- `packed_smoke_out/actions_packed.png` — every action dim plotted vs
+  the packed frame index, with red verticals at each `cu_seqlens`
+  boundary so per-episode segments are visible.
+- `packed_smoke_out/ep{b}_{episode_name}_pack_t{first}_to_t{last}.mp4` —
+  one full-playback MP4 per episode, capped at
+  `N_EPISODES_TO_SAVE_VIDEOS` (default 2).
+
+The script also cross-checks that the first/last `actions` frame at each
+`cu_seqlens` boundary in the packed batch byte-matches a direct
+per-frame read from the source `ZarrEpisode`.
+
+### Test data
+
+`/coc/cedarp-dxu345-0/Tsim_datasets/test_demos` — pushT, 4 episodes,
+`embodiment="pushshapes_sim"`, action dim 2, image keys
+`observations.images.front_img_1` (96×96 JPEG), state dim 5. No
+annotations populated (so `annotations` lists come back empty).

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -10,7 +10,24 @@ from termcolor import cprint
 from torch.utils.data import DataLoader, default_collate
 from transformers import AutoTokenizer
 
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
 logger = logging.getLogger(__name__)
+
+
+def _collate_fn_for(dataset) -> "callable":
+    """Pick a collate fn based on the dataset type.
+
+    Packed datasets (variable-length samples flattened along time) need
+    ``pack_collate`` to emit ``cu_seqlens``; everything else falls back to
+    ``annotation_collate``.
+    """
+    if isinstance(dataset, ZarrEpisodePackedDataset):
+        return pack_collate
+    return annotation_collate
 
 
 class RLDBModule(LightningDataModule):
@@ -96,7 +113,7 @@ class MultiDataModuleWrapper(LightningDataModule):
             iterables[dataset_name] = DataLoader(
                 dataset,
                 shuffle=True,
-                collate_fn=self.collate_fn,
+                collate_fn=_collate_fn_for(dataset),
                 **dataset_params,
             )
 
@@ -115,7 +132,7 @@ class MultiDataModuleWrapper(LightningDataModule):
             iterables[dataset_name] = DataLoader(
                 dataset,
                 shuffle=shuffle,
-                collate_fn=self.collate_fn,
+                collate_fn=_collate_fn_for(dataset),
                 **dataset_params,
             )
 

--- a/egomimic/rldb/zarr/zarr_dataset_multi.py
+++ b/egomimic/rldb/zarr/zarr_dataset_multi.py
@@ -1425,6 +1425,21 @@ class ZarrDataset(torch.utils.data.Dataset):
                 valid_annotations.append(ann.get("text", ""))
         return valid_annotations
 
+    def _annotations_for_span(self, start: int, end: int) -> list[str]:
+        """Return all annotation texts whose [start_idx, end_idx) overlap [start, end)."""
+        out: list[str] = []
+        for ann in self._load_annotations():
+            a_start = int(ann.get("start_idx", -1))
+            a_end = int(ann.get("end_idx", -1))
+            if a_start < 0 or a_end <= a_start:
+                continue
+            if a_end <= start or a_start >= end:
+                continue
+            text = ann.get("text", "")
+            if text:
+                out.append(text)
+        return out
+
     def __len__(self) -> int:
         return self.total_frames
 
@@ -1450,6 +1465,86 @@ class ZarrDataset(torch.utils.data.Dataset):
                     padding = np.repeat(last_frame, pad_len, axis=0)
                     data[k] = np.concatenate([data[k], padding], axis=0)
 
+        return data
+
+    def _read_span(
+        self,
+        start: int,
+        end: int,
+        *,
+        episode_idx: int | None = None,
+    ) -> dict:
+        """Read a variable-length span ``[start, end)`` for every key in ``key_map``.
+
+        Unlike ``__getitem__``, this performs no horizon-based windowing or
+        padding — each per-frame key is read exactly over the span. Designed
+        for packed dataloaders that batch multiple variable-length samples
+        into a single stream.
+
+        Returns a dict containing:
+          - per-frame tensors of shape ``(end - start, ...)`` for camera /
+            proprio / action keys
+          - the configured annotation key (``key_type == "annotation_keys"``)
+            → ``list[str]`` of annotation texts whose spans overlap
+            ``[start, end)``
+          - ``"seq_len"`` (int)
+          - ``"embodiment"`` and ``"metadata.robot_name"`` (int embodiment id)
+          - ``"episode_idx"`` if provided
+
+        Errors (bad JPEG, transform failure) propagate to the caller; the
+        wrapping packed dataset is responsible for resampling.
+        """
+        if end <= start:
+            raise ValueError(
+                f"_read_span requires end > start (got start={start}, end={end})"
+            )
+        if start < 0 or end > self.total_frames:
+            raise ValueError(
+                f"_read_span out of range [0, {self.total_frames}): "
+                f"start={start}, end={end}"
+            )
+
+        seq_len = end - start
+        data: dict = {}
+
+        for k in self.key_map:
+            spec = self.key_map[k]
+            zarr_key = spec["zarr_key"]
+            key_type = spec.get("key_type", None)
+
+            if key_type == "annotation_keys":
+                data[k] = self._annotations_for_span(start, end)
+                continue
+
+            if key_type == "metadata_keys":
+                continue
+
+            arr = self.episode_reader.read({zarr_key: (start, end)})[zarr_key]
+
+            if zarr_key in self._image_keys:
+                decoded_frames = []
+                for jpeg_bytes in arr:
+                    decoded = simplejpeg.decode_jpeg(jpeg_bytes, colorspace="RGB")
+                    decoded_frames.append(np.transpose(decoded, (2, 0, 1)) / 255.0)
+                arr = np.stack(decoded_frames, axis=0)
+            elif zarr_key in self._json_keys:
+                arr = [self._decode_json_entry(v) for v in arr]
+
+            data[k] = arr
+
+        if self.transform:
+            for transform in self.transform:
+                data = transform.transform(data)
+
+        for k, v in list(data.items()):
+            if isinstance(v, np.ndarray) and v.dtype != object:
+                data[k] = torch.from_numpy(v).to(torch.float32)
+
+        data["seq_len"] = seq_len
+        data["embodiment"] = get_embodiment_id(self.embodiment)
+        data["metadata.robot_name"] = get_embodiment_id(self.embodiment)
+        if episode_idx is not None:
+            data["episode_idx"] = int(episode_idx)
         return data
 
     def __getitem__(

--- a/egomimic/rldb/zarr/zarr_dataset_packed.py
+++ b/egomimic/rldb/zarr/zarr_dataset_packed.py
@@ -1,0 +1,350 @@
+"""
+Packed Zarr datasets and a pack_collate for flattened, variable-length sample
+batching.
+
+Each sample is one full episode (or one chunk of a long episode) read at the
+native per-frame resolution by ``ZarrDataset._read_span``. The collator
+concatenates samples along the time axis and emits ``cu_seqlens`` so the
+downstream model can recover per-sample boundaries (FlashAttention-style).
+
+Currently implemented:
+  - ``ZarrEpisodePackedDataset``: one sample per episode (or per chunk of a
+    long episode), intended for verifying full-episode loading paths.
+  - ``pack_collate``: tensor-side concatenation + cu_seqlens emission, plus
+    pass-through of variable-length list-valued keys (e.g. annotations).
+
+The base ``_read_span`` and the collator are deliberately written to be
+reusable by a future annotation-level packed dataset; only the index-building
+logic differs between the two flavours.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset, default_collate
+
+from egomimic.rldb.zarr.zarr_dataset_multi import (
+    EpisodeResolver,
+    LocalEpisodeResolver,
+    ZarrDataset,
+    get_fallback_idx,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+ChunkingMode = Literal["sequential", "none"]
+
+
+class ZarrEpisodePackedDataset(Dataset):
+    """One sample per episode (or per chunk of a long episode).
+
+    Each ``__getitem__`` call returns the dict produced by
+    ``ZarrDataset._read_span``, i.e. variable-length per-frame tensors plus
+    metadata. Samples are intended to flow into :func:`pack_collate`.
+
+    Args:
+        datasets: dict of episode-key -> per-episode ``ZarrDataset``. Same
+            shape returned by ``LocalEpisodeResolver.resolve`` /
+            ``S3EpisodeResolver.resolve``.
+        max_seq_len: hard cap on sample length. With ``chunking="sequential"``
+            an episode longer than this is split into consecutive chunks of
+            length ``max_seq_len`` (last chunk may be shorter). ``None``
+            disables chunking.
+        min_seq_len: drop chunks shorter than this. Useful for the trailing
+            chunk of an episode.
+        chunking: ``"sequential"`` for consecutive non-overlapping chunks,
+            ``"none"`` to emit each episode as a single sample (raises if
+            ``max_seq_len`` is exceeded — caller should pre-filter).
+        max_resample_attempts: per ``__getitem__`` cap on resampling after a
+            read failure (bad JPEG, transform failure, etc.).
+    """
+
+    def __init__(
+        self,
+        datasets: dict[str, ZarrDataset],
+        max_seq_len: int | None = None,
+        min_seq_len: int = 1,
+        chunking: ChunkingMode = "sequential",
+        max_resample_attempts: int | None = None,
+    ):
+        if not datasets:
+            raise ValueError("ZarrEpisodePackedDataset received an empty datasets dict")
+        if min_seq_len < 1:
+            raise ValueError(f"min_seq_len must be >= 1, got {min_seq_len}")
+        if chunking not in ("sequential", "none"):
+            raise ValueError(f"Unknown chunking mode: {chunking}")
+
+        self.datasets = datasets
+        self.max_seq_len = max_seq_len
+        self.min_seq_len = min_seq_len
+        self.chunking = chunking
+        self.max_resample_attempts = max_resample_attempts
+
+        # Stable episode-index assignment: sorted by key.
+        self._episode_keys: list[str] = sorted(datasets.keys())
+        self._episode_idx_by_key: dict[str, int] = {
+            key: i for i, key in enumerate(self._episode_keys)
+        }
+
+        self.index: list[tuple[str, int, int]] = self._build_index()
+        if not self.index:
+            raise ValueError(
+                "ZarrEpisodePackedDataset built an empty index — every episode "
+                f"was shorter than min_seq_len={min_seq_len}."
+            )
+
+        super().__init__()
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_index(self) -> list[tuple[str, int, int]]:
+        index: list[tuple[str, int, int]] = []
+        max_len = self.max_seq_len
+        for key in self._episode_keys:
+            ds = self.datasets[key]
+            episode_len = int(ds.total_frames)
+            if episode_len < self.min_seq_len:
+                continue
+
+            if max_len is None or self.chunking == "none":
+                if max_len is not None and episode_len > max_len:
+                    raise ValueError(
+                        f"Episode {key} has {episode_len} frames > max_seq_len="
+                        f"{max_len} but chunking='none'. Either enable "
+                        f"chunking or raise max_seq_len."
+                    )
+                index.append((key, 0, episode_len))
+                continue
+
+            # Sequential chunking.
+            for start in range(0, episode_len, max_len):
+                end = min(start + max_len, episode_len)
+                if end - start < self.min_seq_len:
+                    continue
+                index.append((key, start, end))
+
+        return index
+
+    @classmethod
+    def from_resolver(
+        cls,
+        resolver: EpisodeResolver,
+        *,
+        max_seq_len: int | None = None,
+        min_seq_len: int = 1,
+        chunking: ChunkingMode = "sequential",
+        max_resample_attempts: int | None = None,
+        **resolve_kwargs,
+    ) -> "ZarrEpisodePackedDataset":
+        """Build from an ``EpisodeResolver`` (mirrors ``MultiDataset._from_resolver``)."""
+        if isinstance(resolver, LocalEpisodeResolver):
+            datasets = resolver.resolve(**resolve_kwargs)
+        else:
+            datasets = resolver.resolve(**resolve_kwargs)
+        return cls(
+            datasets=datasets,
+            max_seq_len=max_seq_len,
+            min_seq_len=min_seq_len,
+            chunking=chunking,
+            max_resample_attempts=max_resample_attempts,
+        )
+
+    @classmethod
+    def from_local_folder(
+        cls,
+        folder_path: str | Path,
+        *,
+        key_map: dict,
+        transform_list: list | None = None,
+        debug: int | bool | None = None,
+        max_seq_len: int | None = None,
+        min_seq_len: int = 1,
+        chunking: ChunkingMode = "sequential",
+        max_resample_attempts: int | None = None,
+        filters=None,
+    ) -> "ZarrEpisodePackedDataset":
+        """Convenience factory that discovers all episodes under a local folder.
+
+        Useful for smoke tests against a known local dataset (e.g. the pushT
+        ``test_demos`` directory) without needing the SQL-backed resolver.
+        """
+        resolver = LocalEpisodeResolver(
+            folder_path=Path(folder_path),
+            key_map=key_map,
+            transform_list=transform_list,
+            debug=debug,
+        )
+        return cls.from_resolver(
+            resolver,
+            max_seq_len=max_seq_len,
+            min_seq_len=min_seq_len,
+            chunking=chunking,
+            max_resample_attempts=max_resample_attempts,
+            filters=filters,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Dataset protocol
+    # ------------------------------------------------------------------ #
+
+    def __len__(self) -> int:
+        return len(self.index)
+
+    def __getitem__(self, i: int) -> dict:
+        attempts = 0
+        max_attempts = self.max_resample_attempts or len(self.index)
+        idx = i
+        while True:
+            key, start, end = self.index[idx]
+            ds = self.datasets[key]
+            try:
+                data = ds._read_span(
+                    start,
+                    end,
+                    episode_idx=self._episode_idx_by_key[key],
+                )
+            except Exception as e:
+                attempts += 1
+                if attempts >= max_attempts:
+                    raise RuntimeError(
+                        f"ZarrEpisodePackedDataset exhausted resampling after "
+                        f"{attempts} attempts; last error on episode {key} "
+                        f"[{start}, {end}): {type(e).__name__}: {e}"
+                    ) from e
+                logger.warning(
+                    "Read failed on episode %s [%d, %d) — %s: %s | "
+                    "attempt %d, resampling",
+                    key,
+                    start,
+                    end,
+                    type(e).__name__,
+                    e,
+                    attempts,
+                )
+                # Pick another index uniformly at random.
+                next_idx, _ = get_fallback_idx(
+                    idx=idx,
+                    candidates=range(len(self.index)),
+                    _attempts=attempts,
+                    max_attempts=max_attempts + 1,
+                    exhausted_error=(
+                        "ZarrEpisodePackedDataset cannot find any valid index"
+                    ),
+                )
+                idx = next_idx
+                continue
+
+            data["chunk_offset"] = int(start)
+            return data
+
+
+# ---------------------------------------------------------------------- #
+# Pack collator
+# ---------------------------------------------------------------------- #
+
+
+def _is_per_frame_tensor(value, seq_len: int) -> bool:
+    """A tensor is "per-frame" if its first dim equals the sample's seq_len."""
+    if isinstance(value, torch.Tensor):
+        return value.ndim >= 1 and value.shape[0] == seq_len
+    if isinstance(value, np.ndarray):
+        return value.ndim >= 1 and value.shape[0] == seq_len
+    return False
+
+
+def pack_collate(batch: list[dict]) -> dict:
+    """Pack variable-length samples into a single flattened batch.
+
+    Concatenates per-frame tensors along the time axis and emits
+    ``cu_seqlens`` (cumulative sequence lengths) so the downstream model can
+    recover per-sample boundaries — same convention as FlashAttention's
+    variable-length API.
+
+    Output keys:
+      - per-frame tensors: shape ``(sum(seq_lens), ...)`` along the
+        concatenated time axis.
+      - ``"seq_lens"``: ``LongTensor`` of length ``B`` with each sample's
+        length.
+      - ``"cu_seqlens"``: ``LongTensor`` of length ``B + 1``, ``cu[0] == 0``
+        and ``cu[i] == sum(seq_lens[:i])``.
+      - ``"max_seq_len"``: int, ``max(seq_lens)``.
+      - ``"batch_size"``: int, number of samples in the pack.
+      - List-valued keys (e.g. annotations) → ``list[list[str]]`` (one entry
+        per sample), preserving the existing ``annotation_collate``
+        contract.
+      - Scalar-per-sample keys (e.g. ``embodiment``, ``episode_idx``,
+        ``chunk_offset``) → ``LongTensor`` of length ``B``.
+    """
+    if not batch:
+        raise ValueError("pack_collate received an empty batch")
+
+    seq_lens = [int(s["seq_len"]) for s in batch]
+    cu_seqlens = [0]
+    acc = 0
+    for sl in seq_lens:
+        acc += sl
+        cu_seqlens.append(acc)
+
+    # Discover per-frame tensor keys vs. list keys vs. scalar keys, using the
+    # first sample as the schema. All samples must share keys.
+    first = batch[0]
+    per_frame_keys: list[str] = []
+    list_keys: list[str] = []
+    scalar_keys: list[str] = []
+
+    for k, v in first.items():
+        if k == "seq_len":
+            continue
+        if isinstance(v, list):
+            list_keys.append(k)
+        elif _is_per_frame_tensor(v, seq_lens[0]):
+            per_frame_keys.append(k)
+        else:
+            scalar_keys.append(k)
+
+    out: dict = {}
+
+    # Per-frame tensors: torch.cat along dim 0.
+    for k in per_frame_keys:
+        parts = []
+        for sample in batch:
+            v = sample[k]
+            if isinstance(v, np.ndarray):
+                v = torch.from_numpy(v)
+            parts.append(v)
+        out[k] = torch.cat(parts, dim=0)
+
+    # List-valued keys: pass through as list-of-lists (matches annotation_collate).
+    for k in list_keys:
+        out[k] = [sample[k] for sample in batch]
+
+    # Scalar-per-sample keys: collate into a 1D tensor where possible.
+    for k in scalar_keys:
+        values = [sample[k] for sample in batch]
+        try:
+            out[k] = default_collate(values)
+        except Exception:
+            out[k] = values
+
+    out["seq_lens"] = torch.as_tensor(seq_lens, dtype=torch.long)
+    out["cu_seqlens"] = torch.as_tensor(cu_seqlens, dtype=torch.long)
+    out["max_seq_len"] = int(max(seq_lens))
+    out["batch_size"] = len(batch)
+    return out
+
+
+__all__ = [
+    "ZarrEpisodePackedDataset",
+    "pack_collate",
+]

--- a/scripts/smoke_packed_dataset.py
+++ b/scripts/smoke_packed_dataset.py
@@ -1,0 +1,222 @@
+"""
+Smoke test for ZarrEpisodePackedDataset with chunking='none'.
+
+Loads the pushT test_demos folder, runs it through a DataLoader with
+pack_collate, then dumps:
+  - PNG of the first / mid / last frame of each episode in the batch
+  - PNG line plot of every action dim vs packed frame index, with vertical
+    lines at cu_seqlens boundaries to mark per-episode segments
+
+Outputs go to ./packed_smoke_out/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import imageio.v2 as imageio
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
+KEY_MAP = {
+    "front_img_1": {
+        "key_type": "camera_keys",
+        "zarr_key": "observations.images.front_img_1",
+    },
+    "state_agent_obj": {
+        "key_type": "proprio_keys",
+        "zarr_key": "observations.state",
+    },
+    "actions": {
+        "key_type": "action_keys",
+        "zarr_key": "actions",
+    },
+    "annotations": {
+        "key_type": "annotation_keys",
+        "zarr_key": "annotations",
+    },
+    "embodiment": {
+        "key_type": "metadata_keys",
+        "zarr_key": "metadata.embodiment",
+    },
+}
+
+DATA_FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets/test_demos"
+OUT_DIR = Path("./packed_smoke_out")
+N_EPISODES_TO_SAVE_VIDEOS = 2  # cap on per-episode MP4 dumps
+VIDEO_FPS = 30
+
+
+def _img_to_uint8(frame_chw: torch.Tensor) -> np.ndarray:
+    """(3, H, W) float in [0, 1] -> (H, W, 3) uint8 for PIL."""
+    arr = frame_chw.detach().cpu().numpy()
+    arr = np.clip(arr, 0.0, 1.0)
+    arr = (arr * 255.0).astype(np.uint8)
+    return np.transpose(arr, (1, 2, 0))
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    ds = ZarrEpisodePackedDataset.from_local_folder(
+        folder_path=DATA_FOLDER,
+        key_map=KEY_MAP,
+        max_seq_len=None,
+        chunking="none",
+    )
+    print(f"# samples (one per full episode): {len(ds)}")
+    print(f"# unique episodes: {len(ds.datasets)}")
+    for i, (key, start, end) in enumerate(ds.index):
+        print(f"  idx={i}  episode={key}  frames=[{start}, {end})  len={end - start}")
+
+    # Pack all 4 episodes into a single batch.
+    dl = DataLoader(
+        ds,
+        batch_size=len(ds),
+        shuffle=False,
+        collate_fn=pack_collate,
+        num_workers=0,
+    )
+    batch = next(iter(dl))
+
+    seq_lens = batch["seq_lens"].tolist()
+    cu = batch["cu_seqlens"].tolist()
+    actions = batch["actions"]
+    images = batch["front_img_1"]
+    state = batch["state_agent_obj"]
+
+    print("\n--- packed batch ---")
+    print(f"batch_size       = {batch['batch_size']}")
+    print(f"seq_lens         = {seq_lens}")
+    print(f"cu_seqlens       = {cu}")
+    print(f"max_seq_len      = {batch['max_seq_len']}")
+    print(
+        f"actions.shape    = {tuple(actions.shape)}  (expected first dim = {sum(seq_lens)})"
+    )
+    print(f"front_img_1.shape= {tuple(images.shape)}")
+    print(f"state.shape      = {tuple(state.shape)}")
+    print(f"embodiment       = {batch['embodiment'].tolist()}")
+    print(f"episode_idx      = {batch['episode_idx'].tolist()}")
+    print(f"chunk_offset     = {batch['chunk_offset'].tolist()}")
+    annotations = batch["annotations"]
+    print(f"annotations      = {annotations}")
+
+    assert actions.shape[0] == sum(
+        seq_lens
+    ), f"per-frame dim {actions.shape[0]} != sum(seq_lens) {sum(seq_lens)}"
+    assert cu[0] == 0 and cu[-1] == sum(seq_lens), "cu_seqlens malformed"
+    for i in range(len(seq_lens)):
+        assert (
+            cu[i + 1] - cu[i] == seq_lens[i]
+        ), f"cu_seqlens segment {i} mismatch: {cu[i + 1] - cu[i]} vs {seq_lens[i]}"
+
+    ep_keys = [ds.index[i][0] for i in range(len(ds))]
+
+    # 1. Dump an MP4 per episode (full playback) for the first N_EPISODES_TO_SAVE_VIDEOS
+    # episodes in the batch. The actions plot below still covers every
+    # packed episode so boundary checks aren't lost.
+    n_to_save = min(N_EPISODES_TO_SAVE_VIDEOS, batch["batch_size"])
+    saved_videos: list[Path] = []
+    for b in range(n_to_save):
+        s, e = cu[b], cu[b + 1]
+        ep_name = ep_keys[b]
+        out_path = OUT_DIR / f"ep{b:02d}_{ep_name}_pack_t{s}_to_t{e - 1}.mp4"
+        with imageio.get_writer(
+            str(out_path),
+            fps=VIDEO_FPS,
+            codec="libx264",
+            macro_block_size=1,
+        ) as writer:
+            for t in range(s, e):
+                writer.append_data(_img_to_uint8(images[t]))
+        saved_videos.append(out_path)
+        print(f"saved {e - s}-frame mp4 for ep {b} ({ep_name}) -> {out_path}")
+    if batch["batch_size"] > n_to_save:
+        print(
+            f"(skipped video dumps for {batch['batch_size'] - n_to_save} additional episode(s) "
+            f"— bump N_EPISODES_TO_SAVE_VIDEOS to dump more)"
+        )
+
+    # 2. Plot all action dims over packed frame index, marking episode boundaries.
+    actions_np = actions.detach().cpu().numpy()
+    n_frames, action_dim = actions_np.shape
+    fig, axes = plt.subplots(action_dim, 1, figsize=(12, 2.4 * action_dim), sharex=True)
+    if action_dim == 1:
+        axes = [axes]
+    t_axis = np.arange(n_frames)
+    for d in range(action_dim):
+        axes[d].plot(t_axis, actions_np[:, d], linewidth=0.8, color="tab:blue")
+        for boundary in cu[1:-1]:
+            axes[d].axvline(boundary, color="tab:red", linestyle="--", alpha=0.6)
+        axes[d].set_ylabel(f"action[{d}]")
+        axes[d].grid(True, alpha=0.3)
+    # Annotate which packed frame range belongs to which episode under the bottom plot.
+    for b in range(batch["batch_size"]):
+        s, e = cu[b], cu[b + 1]
+        mid = (s + e) // 2
+        axes[-1].text(
+            mid,
+            axes[-1].get_ylim()[0],
+            ep_keys[b],
+            ha="center",
+            va="bottom",
+            fontsize=8,
+            color="tab:red",
+        )
+    axes[-1].set_xlabel("packed frame index")
+    fig.suptitle(
+        f"Actions packed across {batch['batch_size']} episodes "
+        f"(total {n_frames} frames; red dashes = cu_seqlens boundaries)"
+    )
+    fig.tight_layout()
+    actions_plot = OUT_DIR / "actions_packed.png"
+    fig.savefig(actions_plot, dpi=120)
+    plt.close(fig)
+    print(f"saved actions plot -> {actions_plot}")
+
+    # 3. Cross-check: actions at packed boundaries should equal actions at
+    # frame 0 and last frame of each episode, read directly from the per-episode
+    # ZarrDataset.
+    print("\n--- cross-check vs per-episode reads ---")
+    sorted_keys = sorted(ds.datasets.keys())
+    for b, key in enumerate(sorted_keys):
+        ep_ds = ds.datasets[key]
+        # Direct per-frame read of first and last action.
+        first_direct = ep_ds.episode_reader.read(
+            {KEY_MAP["actions"]["zarr_key"]: (0, 1)}
+        )[KEY_MAP["actions"]["zarr_key"]][0]
+        last_direct = ep_ds.episode_reader.read(
+            {
+                KEY_MAP["actions"]["zarr_key"]: (
+                    ep_ds.total_frames - 1,
+                    ep_ds.total_frames,
+                )
+            }
+        )[KEY_MAP["actions"]["zarr_key"]][0]
+        s, e = cu[b], cu[b + 1]
+        first_packed = actions_np[s]
+        last_packed = actions_np[e - 1]
+        first_match = np.allclose(first_direct, first_packed, atol=1e-6)
+        last_match = np.allclose(last_direct, last_packed, atol=1e-6)
+        print(
+            f"  {key}: first match={first_match} last match={last_match} | "
+            f"direct first={first_direct.tolist()} packed first={first_packed.tolist()}"
+        )
+        assert first_match and last_match, f"action mismatch for {key}"
+
+    print("\nAll checks passed.")
+    print(f"See outputs in: {OUT_DIR.resolve()}")
+    print("\n--- saved MP4s (absolute paths) ---")
+    for vp in saved_videos:
+        print(vp.resolve())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds ZarrDataset._read_span for variable-length, no-pad span reads
and a new ZarrEpisodePackedDataset + pack_collate that flatten full
episodes (or sequential chunks) into one stream with cu_seqlens.
MultiDataModuleWrapper now picks pack_collate per-dataset when the
dataset is packed. Includes a pushT smoke script under scripts/.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>