### PR TITLE
HNet packed training: algo + stages + data + evaluator

### DIFF
--- a/egomimic/algo/hnet.py
+++ b/egomimic/algo/hnet.py
@@ -13,6 +13,7 @@ Loss = action MSE (next-action prediction) +
 The per-chunker ratio-loss weights live inside the chunker stages themselves;
 this algo just calls ``ratio_loss_from_aux(ctx.aux)`` after forward.
 """
+
 from collections import OrderedDict
 from typing import Optional
 
@@ -24,7 +25,7 @@ from egomimic.algo.algo import Algo
 from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
 from egomimic.models.hnet_nets.context import HNetContext
 from egomimic.models.hnet_nets.hnet import HNet as HNetCore
-from egomimic.models.hnet_nets.hnet import ratio_loss_from_aux
+from egomimic.models.hnet_nets.hnet import chunk_stats_from_aux, ratio_loss_from_aux
 from egomimic.rldb.embodiment.embodiment import get_embodiment_id
 
 
@@ -91,16 +92,120 @@ class HNetPolicy(nn.Module):
         h = self.hnet(x, ctx)
         return self.action_out(h), ctx.aux
 
+    def forward_packed(
+        self,
+        actions_packed: torch.Tensor,
+        obs_packed: dict,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+    ):
+        """Packed-mode teacher-forced forward.
+
+        Mirrors :meth:`forward` for variable-length episodes packed into a
+        single flat stream (FlashAttention-style varlen). The BOS shift and
+        ``pos_emb`` indexing happen per sub-sequence — for each subseq
+        ``[s, e)``, position s gets BOS and positions s+1..e-1 get
+        ``action_in(actions[s..e-2])``; ``pos_emb`` is indexed by ``t - s``
+        within each subseq so every episode starts at position 0.
+
+        Args:
+            actions_packed: (T_total, action_dim) packed ground-truth actions.
+            obs_packed:     dict of (T_total, ...) per-frame obs tensors.
+            cu_seqlens:     (B+1,) long, cumulative subseq lengths (starts 0).
+            max_seqlen:     int, longest subseq length.
+
+        Returns: (pred_packed (T_total, action_dim), aux).
+        """
+        device = actions_packed.device
+        T_total = actions_packed.shape[0]
+        if not torch.is_tensor(cu_seqlens):
+            cu_seqlens = torch.tensor(cu_seqlens, device=device, dtype=torch.long)
+        else:
+            cu_seqlens = cu_seqlens.to(device=device, dtype=torch.long)
+        if max_seqlen > self.action_horizon:
+            raise ValueError(
+                f"max_seqlen={max_seqlen} exceeds pos_emb length "
+                f"action_horizon={self.action_horizon}; increase action_horizon "
+                f"or chunk episodes to <= action_horizon frames."
+            )
+
+        # 1. Tokenize, then global shift-right by 1, then overwrite each
+        #    subseq's first slot with BOS. Under autocast (e.g. bf16) the
+        #    activations are downcast but ``self.bos`` stays in fp32; we
+        #    match the activation dtype to keep the index-put happy.
+        a_emb = self.action_in(actions_packed)  # (T_total, D)
+        x_shifted = torch.cat(
+            [
+                torch.zeros(1, self.d_model, device=device, dtype=a_emb.dtype),
+                a_emb[:-1],
+            ],
+            dim=0,
+        )  # (T_total, D)
+        bos = self.bos.squeeze(0).squeeze(0).to(a_emb.dtype)  # (D,)
+        starts = cu_seqlens[:-1]  # (B,)
+        x_shifted = x_shifted.clone()
+        x_shifted[starts] = bos
+
+        # 2. Per-sub-sequence pos_emb: position t in subseq [s, e) gets index t-s.
+        #    Build seq_idx (which subseq each token belongs to), then subtract
+        #    that subseq's start to get the local position index.
+        pos_t = torch.arange(T_total, device=device)
+        # seq_idx[t] = number of subseq starts strictly less-than-or-equal to t
+        # Same as: (cu_seqlens[1:] <= t).sum() ... but easier:
+        seq_idx = (pos_t[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)  # (T_total,)
+        local_pos = pos_t - cu_seqlens[seq_idx]  # (T_total,)
+        pos = self.pos_emb.squeeze(0)[local_pos].to(x_shifted.dtype)  # (T_total, D)
+        x_packed = x_shifted + pos
+
+        # 3. Packed cond. ``cond_encoder.encode`` expects (B, T, ...); for a
+        #    packed stream the simplest path is to feed (1, T_total, ...) and
+        #    squeeze the leading dim back out. The encoder's per-frame branch
+        #    (state x.dim()==3 / images x.dim()==5) fires correctly because
+        #    obs_packed already carries the per-frame dim.
+        obs_for_encode = {k: v.unsqueeze(0) for k, v in obs_packed.items()}
+        cond_padded = self.cond_encoder.encode(obs_for_encode, T_action=T_total)
+        cond_packed = {k: v.squeeze(0) for k, v in cond_padded.items()}
+
+        # 4. Build packed ctx and run.
+        ctx = HNetContext(
+            cond_dict=cond_packed,
+            aux=[],
+            inference_params=None,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=int(max_seqlen),
+        )
+        h = self.hnet(x_packed, ctx)  # (T_total, D)
+        return self.action_out(h), ctx.aux
+
     @torch.no_grad()
-    def generate(self, obs: dict, batch_size: int, device) -> torch.Tensor:
-        """Autoregressive rollout from BOS for ``action_horizon`` steps."""
-        T = self.action_horizon
+    def generate(
+        self,
+        obs: dict,
+        batch_size: int,
+        device,
+        T: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Autoregressive rollout from BOS for ``T`` steps (default
+        ``action_horizon``). ``T`` may be < ``action_horizon`` when rolling
+        out an individual episode whose length is known to be shorter — the
+        pos_emb is sized at action_horizon so any T <= action_horizon
+        works."""
+        if T is None:
+            T = self.action_horizon
+        if T > self.action_horizon:
+            raise ValueError(
+                f"generate T={T} exceeds pos_emb length action_horizon="
+                f"{self.action_horizon}"
+            )
         cond_dict = self.cond_encoder.encode(obs, T)
         actions = torch.zeros(batch_size, T, self.action_dim, device=device)
         dtype = next(self.parameters()).dtype
 
         inference_params = self.hnet.allocate_inference_cache(
-            batch_size=batch_size, max_seqlen=T, device=device, dtype=dtype,
+            batch_size=batch_size,
+            max_seqlen=T,
+            device=device,
+            dtype=dtype,
         )
 
         # Per-step cond_dict slice (B, d_cond) — AdaLN broadcasts over the
@@ -111,7 +216,9 @@ class HNetPolicy(nn.Module):
         cur = self.bos.expand(batch_size, -1, -1) + self.pos_emb[:, 0:1]
         for t in range(T):
             ctx = HNetContext(
-                cond_dict=slice_cond(t), aux=[], inference_params=inference_params,
+                cond_dict=slice_cond(t),
+                aux=[],
+                inference_params=inference_params,
             )
             h = self.hnet.step(cur, ctx)
             a_t = self.action_out(h)
@@ -129,20 +236,52 @@ class HNet(Algo):
 
     def __init__(
         self,
-        data_schematic,
         action_dim: int,
         action_horizon: int,
         d_model: int,
         d_cond: int,
         cond_encoder: CondEncoderModule,
         hnet: HNetCore,
+        norm_stats,
         domains: list = None,
         ac_keys: dict = None,
         device=None,
+        init_weights_range: Optional[float] = None,
+        lr_multipliers: Optional[list] = None,
+        use_parameter_groups: bool = False,
+        weight_decay: float = 0.0,
         **kwargs,
     ):
+        """
+        Training recipe knobs (all OFF by default — opt-in):
+
+        - ``init_weights_range``: if set (e.g. ``0.02``), call
+          ``hnet.init_weights(init_weights_range)`` after policy construction
+          so ``out_proj`` / ``fc2`` weights get ``1/sqrt(n_residuals)``
+          scaling.
+        - ``lr_multipliers``: list of per-stage LR scales (outer→inner). If
+          set, call ``hnet.apply_lr_multiplier(...)`` which stamps every
+          parameter's ``_optim`` dict with ``lr_multiplier``.
+        - ``use_parameter_groups``: if True, expose
+          ``self.parameter_groups()`` so ``pl_model.configure_optimizers``
+          builds AdamW param groups (bias / norm weights get
+          ``weight_decay=0``; per-group ``lr = base_lr * lr_multiplier``).
+        - ``weight_decay``: the base WD used when building parameter groups
+          (only consulted when ``use_parameter_groups=True``). Outside of
+          that, the optimizer config in the model YAML drives WD.
+
+        Leaving all of these at their defaults reproduces "standard
+        training": PyTorch default init, single LR for all params, single
+        WD for all params from the optimizer config.
+        """
         super().__init__()
-        self.data_schematic = data_schematic
+        # ``norm_stats`` is a ``MultiDataset`` instance that owns the
+        # per-embodiment per-feature normalization stats AND the key-topology
+        # helpers (``keys_of_type``, ``is_key_with_embodiment``,
+        # ``zarr_key_to_keyname``). pl_model._instantiate_model passes it in
+        # automatically; the previous ``data_schematic`` parameter was legacy
+        # and is gone.
+        self.norm_stats = norm_stats
         self.domains = list(domains or [])
         self.ac_keys = dict(ac_keys or {})
         self.action_horizon = action_horizon
@@ -151,6 +290,11 @@ class HNet(Algo):
             "cuda" if torch.cuda.is_available() else "cpu"
         )
 
+        # Cache training-recipe knobs for configure_optimizers.
+        self.use_parameter_groups = bool(use_parameter_groups)
+        self.lr_multipliers = list(lr_multipliers) if lr_multipliers else None
+        self.weight_decay = float(weight_decay)
+
         policy = HNetPolicy(
             action_dim=action_dim,
             action_horizon=action_horizon,
@@ -158,10 +302,21 @@ class HNet(Algo):
             cond_encoder=cond_encoder,
             hnet=hnet,
         )
+        # Apply opt-in training recipe BEFORE moving to device so the init
+        # writes hit cpu params (matches upstream's pattern of init pre-move).
+        if init_weights_range is not None:
+            hnet.init_weights(initializer_range=float(init_weights_range))
+        if self.lr_multipliers is not None:
+            hnet.apply_lr_multiplier(self.lr_multipliers)
+        # Stash the inner HNetCore so parameter_groups can reach it without
+        # going through nets["policy"].hnet.
+        self._hnet_core = hnet
+
         self.nets = nn.ModuleDict({"policy": policy})
         self.nets = self.nets.float().to(self.device)
 
-        # Resolve per-embodiment keys via data_schematic (like HPT).
+        # Resolve per-embodiment keys via norm_stats (which owns the
+        # MultiDataset key topology — same surface HPT uses).
         self.embodiment_ids = {}
         self.proprio_keys = {}
         self.lang_keys = {}
@@ -173,23 +328,35 @@ class HNet(Algo):
             self.proprio_keys[emb_id] = []
             self.lang_keys[emb_id] = []
             self.camera_keys[emb_id] = []
-            for key in data_schematic.keys_of_type("action_keys", emb_id):
+            for key in norm_stats.keys_of_type("action_keys", emb_id):
                 if (
-                    data_schematic.is_key_with_embodiment(key, emb_id)
+                    norm_stats.is_key_with_embodiment(key, emb_id)
                     and key == self.ac_keys[emb]
                 ):
                     self.resolved_ac_keys[emb_id] = key
-            for key in data_schematic.keys_of_type("proprio_keys", emb_id):
-                if data_schematic.is_key_with_embodiment(key, emb_id):
+            for key in norm_stats.keys_of_type("proprio_keys", emb_id):
+                if norm_stats.is_key_with_embodiment(key, emb_id):
                     self.proprio_keys[emb_id].append(key)
-            for key in data_schematic.keys_of_type("lang_keys", emb_id):
-                if data_schematic.is_key_with_embodiment(key, emb_id):
+            for key in norm_stats.keys_of_type("lang_keys", emb_id):
+                if norm_stats.is_key_with_embodiment(key, emb_id):
                     self.lang_keys[emb_id].append(key)
-            for key in data_schematic.keys_of_type("camera_keys", emb_id):
-                if data_schematic.is_key_with_embodiment(key, emb_id):
+            for key in norm_stats.keys_of_type("camera_keys", emb_id):
+                if norm_stats.is_key_with_embodiment(key, emb_id):
                     self.camera_keys[emb_id].append(key)
 
     # ---- Algo API --------------------------------------------------------
+
+    # Keys emitted by ``pack_collate`` that aren't zarr-mapped data tensors
+    # and must be passed through ``process_batch_for_training`` unchanged.
+    _PACKED_META_KEYS = (
+        "cu_seqlens",
+        "max_seq_len",
+        "seq_lens",
+        "batch_size",
+        "embodiment",
+        "episode_idx",
+        "chunk_offset",
+    )
 
     @override
     def process_batch_for_training(self, batch):
@@ -197,17 +364,40 @@ class HNet(Algo):
         for emb_name, _batch in batch.items():
             emb_id = get_embodiment_id(emb_name)
             processed[emb_id] = {}
+            # Detect packed batches by the presence of cu_seqlens. Packed and
+            # padded batches have a different key topology; treat them
+            # separately so we don't try to keyname-resolve the meta keys.
+            is_packed = "cu_seqlens" in _batch
+
             for key, value in _batch.items():
-                key_name = self.data_schematic.zarr_key_to_keyname(key, emb_id)
-                if key is not None:
+                if is_packed and key in self._PACKED_META_KEYS:
+                    processed[emb_id][key] = value
+                    continue
+                key_name = self.norm_stats.zarr_key_to_keyname(key, emb_id)
+                # Pre-existing typo: tested ``key is not None`` instead of
+                # ``key_name``, which caused unrelated batch keys (e.g.
+                # ``metadata.robot_name`` from _read_span) to be stored under
+                # the None key. Skip silently when keyname can't be resolved.
+                if key_name is not None:
                     processed[emb_id][key_name] = value
 
             ac_key = self.resolved_ac_keys[emb_id]
-            B, S, _ = processed[emb_id][ac_key].shape
-            processed[emb_id]["pad_mask"] = torch.ones(
-                B, S, 1, device=processed[emb_id][ac_key].device
-            )
-            processed[emb_id] = self.data_schematic.normalize_data(processed[emb_id], emb_id)
+            if is_packed:
+                # Packed actions are (T_total, action_dim). No pad_mask needed
+                # since variable-length is expressed via cu_seqlens.
+                processed[emb_id]["pad_mask"] = None
+                processed[emb_id]["_packed"] = True
+            else:
+                B, S, _ = processed[emb_id][ac_key].shape
+                processed[emb_id]["pad_mask"] = torch.ones(
+                    B, S, 1, device=processed[emb_id][ac_key].device
+                )
+                processed[emb_id]["_packed"] = False
+            # Per-feature normalization via MultiDataset stats: each tensor
+            # gets ``(x - mean) / std`` (or quantile equivalent) broadcast
+            # against (action_dim,) / (proprio_dim,) stats. Works for both
+            # padded ``(B, T, D)`` and packed ``(T_total, D)`` shapes.
+            processed[emb_id] = self.norm_stats.normalize(processed[emb_id], emb_id)
             processed[emb_id]["embodiment"] = torch.tensor(
                 [emb_id], device=self.device, dtype=torch.int64
             )
@@ -239,12 +429,24 @@ class HNet(Algo):
             actions = _batch[ac_key]
             obs = self._build_obs(_batch, emb_id)
 
-            pred, aux = policy(actions, obs)
+            if _batch.get("_packed", False):
+                cu_seqlens = _batch["cu_seqlens"]
+                max_seqlen = int(_batch["max_seq_len"])
+                pred, aux = policy.forward_packed(actions, obs, cu_seqlens, max_seqlen)
+            else:
+                pred, aux = policy(actions, obs)
+
             mse = nn.functional.mse_loss(pred, actions)
             rloss = ratio_loss_from_aux(aux, device=mse.device)
             predictions[f"{emb_id}_pred"] = pred
             predictions[f"{emb_id}_action_loss"] = mse
             predictions[f"{emb_id}_ratio_loss"] = rloss
+
+            # Per-chunker stats for logging. avg_chunk_len = T / max(#boundaries, 1)
+            # so it == 1/F when F>0 and falls back to T when F==0 (no compression).
+            stats = chunk_stats_from_aux(aux)
+            for k, v in stats.items():
+                predictions[f"{emb_id}_{k}"] = torch.tensor(v, device=mse.device)
         return predictions
 
     @override
@@ -253,15 +455,82 @@ class HNet(Algo):
         policy = self.nets["policy"]
         for emb_id, _batch in batch.items():
             ac_key = self.resolved_ac_keys[emb_id]
+            if _batch.get("_packed", False):
+                # Packed validation: per-episode autoregressive rollout from
+                # BOS for that episode's length, then pad results back into a
+                # padded ``(B, T_max, action_dim)`` tensor for downstream
+                # metric / viz computation. Slow but matches inference-time
+                # semantics; we expose seq_lens for masking.
+                preds_padded, seq_lens = self._ar_rollout_packed(_batch, emb_id)
+                preds = OrderedDict()
+                preds[ac_key] = preds_padded
+                unnorm_actions = self.norm_stats.unnormalize(preds, emb_id)
+                for key, val in unnorm_actions.items():
+                    unnorm[f"emb{emb_id}_{key}"] = val
+                unnorm[f"emb{emb_id}_seq_lens"] = seq_lens
+                continue
             obs = self._build_obs(_batch, emb_id)
             B = next(iter(obs.values())).shape[0] if obs else _batch[ac_key].shape[0]
             actions = policy.generate(obs, batch_size=B, device=self.device)
             preds = OrderedDict()
             preds[ac_key] = actions
-            unnorm_actions = self.data_schematic.unnormalize_data(preds, emb_id)
+            unnorm_actions = self.norm_stats.unnormalize(preds, emb_id)
             for key, val in unnorm_actions.items():
                 unnorm[f"emb{emb_id}_{key}"] = val
         return unnorm
+
+    @torch.no_grad()
+    def _ar_rollout_packed(self, _batch: dict, emb_id: int):
+        """Per-episode AR rollout for a packed validation batch.
+
+        For each sub-sequence ``[s, e)`` in ``cu_seqlens``:
+          1. Slice that episode's obs into ``(1, T_ep, ...)``.
+          2. Call ``policy.generate(obs_ep, batch_size=1, T=T_ep)`` to AR
+             rollout exactly ``T_ep`` steps from BOS.
+          3. Stash the prediction.
+
+        Returns:
+            preds_padded: ``(B, T_max, action_dim)`` (zero-padded past each
+                episode's length).
+            seq_lens:     ``(B,)`` long, the per-episode rollout lengths
+                (matches ``_batch['seq_lens']`` and used for masking the
+                padding in downstream MSE).
+        """
+        policy = self.nets["policy"]
+        cu = _batch["cu_seqlens"]
+        seq_lens = _batch["seq_lens"].clone()
+        B = int(seq_lens.shape[0])
+        T_max = int(seq_lens.max().item())
+        action_dim = policy.action_dim
+        device = self.device
+
+        # Gather the obs keys we need for the cond encoder.
+        obs_keys = (
+            self.proprio_keys[emb_id]
+            + self.lang_keys[emb_id]
+            + self.camera_keys[emb_id]
+        )
+        obs_keys = [k for k in obs_keys if k in _batch]
+
+        preds_padded = torch.zeros(B, T_max, action_dim, device=device)
+
+        for b in range(B):
+            s = int(cu[b].item())
+            e = int(cu[b + 1].item())
+            T_ep = e - s
+            # Slice each obs key to the episode's range and add a leading
+            # batch dim. The packed tensor is (T_total, ...) so slicing along
+            # dim 0 gives (T_ep, ...) → unsqueeze → (1, T_ep, ...).
+            obs_ep = {k: _batch[k][s:e].unsqueeze(0) for k in obs_keys}
+            a_ep = policy.generate(
+                obs_ep,
+                batch_size=1,
+                device=device,
+                T=T_ep,
+            )  # (1, T_ep, action_dim)
+            preds_padded[b, :T_ep] = a_ep.squeeze(0)
+
+        return preds_padded, seq_lens
 
     @override
     def compute_losses(self, predictions, batch):
@@ -275,6 +544,18 @@ class HNet(Algo):
             # Ratio-loss weights are baked into each chunker stage, so r
             # is already a properly-weighted sum.
             total = total + a + r
+
+            # Pass non-loss stats through to logging (boundary_rate /
+            # avg_chunk_len, per-chunker and aggregate). They are 0-dim
+            # tensors so log_info.item() still works.
+            for key, value in predictions.items():
+                prefix = f"{emb_id}_"
+                if not key.startswith(prefix):
+                    continue
+                tail = key[len(prefix) :]
+                if tail in ("pred", "action_loss", "ratio_loss"):
+                    continue
+                loss_dict[f"emb{emb_id}_{tail}"] = value
         loss_dict["action_loss"] = total / max(len(batch), 1)
         return loss_dict
 
@@ -285,3 +566,56 @@ class HNet(Algo):
         for k, v in info["losses"].items():
             log[k] = v.item()
         return log
+
+    # ----- Optional training recipe hook for pl_model.configure_optimizers ----- #
+
+    def parameter_groups(self, base_lr: float):
+        """Return AdamW-ready ``list[dict]`` if ``use_parameter_groups``,
+        else ``None`` (caller falls back to ``self.nets.parameters()``).
+
+        Groups are built by the inner HNet stage tree via
+        ``HNetCore.parameter_groups(weight_decay=self.weight_decay)``, then
+        each group's ``lr`` is set to ``base_lr * lr_multiplier``. Params
+        that aren't part of the HNet stage tree (e.g. ``action_in``,
+        ``action_out``, ``cond_encoder``, ``bos``, ``pos_emb``) are added in
+        a single extra group with ``lr_multiplier=1.0`` so optimizer
+        instantiation still sees every learnable parameter exactly once.
+        """
+        if not self.use_parameter_groups:
+            return None
+
+        # Groups for params inside the HNet stage tree.
+        groups = self._hnet_core.parameter_groups(weight_decay=self.weight_decay)
+        for g in groups:
+            g["lr"] = float(base_lr) * float(g.get("lr_multiplier", 1.0))
+
+        # Extra group for everything *not* inside the HNet stage tree.
+        hnet_param_ids = {id(p) for g in groups for p in g["params"]}
+        extra_params, extra_bias_norm = [], []
+        for name, p in self.nets.named_parameters():
+            if id(p) in hnet_param_ids or not p.requires_grad:
+                continue
+            # Bias / norm-weight detection (same rule as parameter_groups).
+            if name.endswith(".bias") or ".norm" in name or "rmsnorm" in name.lower():
+                extra_bias_norm.append(p)
+            else:
+                extra_params.append(p)
+        if extra_params:
+            groups.append(
+                {
+                    "params": extra_params,
+                    "lr": float(base_lr),
+                    "lr_multiplier": 1.0,
+                    "weight_decay": self.weight_decay,
+                }
+            )
+        if extra_bias_norm:
+            groups.append(
+                {
+                    "params": extra_bias_norm,
+                    "lr": float(base_lr),
+                    "lr_multiplier": 1.0,
+                    "weight_decay": 0.0,
+                }
+            )
+        return groups

--- a/egomimic/eval/eval_hnet.py
+++ b/egomimic/eval/eval_hnet.py
@@ -1,0 +1,148 @@
+"""
+Validation evaluator for the stage-based H-Net policy.
+
+Drops the HPT-specific machinery (auxiliary heads, shared action key,
+reverse-KL, transform-list cam-frame projection) and supports packed
+validation batches: the algo's ``forward_eval`` runs an autoregressive
+rollout per episode in the pack and returns ``(B, T_max, action_dim)``
+padded predictions plus the per-episode ``seq_lens``. We compute MSE only on
+the valid positions of each episode (no padding contribution), then hand a
+single per-episode frame to the configured ``viz_func`` for the validation
+video.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+
+from egomimic.eval.eval_video import EvalVideo
+from egomimic.rldb.embodiment.embodiment import get_embodiment
+
+
+def _masked_mse(
+    pred: torch.Tensor, gt: torch.Tensor, seq_lens: torch.Tensor
+) -> torch.Tensor:
+    """Mean squared error averaged only over valid (non-padded) positions.
+
+    ``pred`` / ``gt``: ``(B, T_max, D)``. ``seq_lens``: ``(B,)`` long, gives
+    the number of valid time-steps per row.
+    """
+    B, T_max, _ = pred.shape
+    # (B, T_max) bool mask of valid positions.
+    arange = torch.arange(T_max, device=pred.device)[None, :]
+    mask = arange < seq_lens.to(pred.device)[:, None]  # (B, T_max)
+    err = ((pred - gt) ** 2).mean(dim=-1)  # (B, T_max)
+    valid = mask.float()
+    return (err * valid).sum() / valid.sum().clamp(min=1)
+
+
+def _unpack_to_padded(
+    packed: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> torch.Tensor:
+    """``(T_total, ...) -> (B, T_max, ...)`` zero-padded past each ep's length."""
+    B = int(seq_lens.shape[0])
+    T_max = int(seq_lens.max().item())
+    tail = packed.shape[1:]
+    out = torch.zeros((B, T_max) + tail, device=packed.device, dtype=packed.dtype)
+    for b in range(B):
+        s = int(cu_seqlens[b].item())
+        e = int(cu_seqlens[b + 1].item())
+        out[b, : e - s] = packed[s:e]
+    return out
+
+
+class HNetEvalVideo(EvalVideo):
+    """H-Net validation eval. Computes paired-MSE on packed (or padded)
+    validation batches and renders per-episode trajectory frames.
+    """
+
+    def compute_metrics_and_viz(
+        self, batch: Dict[int, Dict[str, Any]]
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[int, np.ndarray]]:
+        algo = self.model
+        preds = algo.forward_eval(batch)
+
+        metrics: dict = {}
+        images_dict: dict = {}
+        total_loss = None
+        n_loss = 0
+
+        for emb_id, _batch in batch.items():
+            embodiment_name = get_embodiment(emb_id).lower()
+            ac_key = algo.ac_keys[embodiment_name]
+            is_packed = _batch.get("_packed", False)
+
+            # Always unnormalize GT to raw scale; the algo's forward_eval
+            # already unnormalizes preds.
+            _batch_unnorm = algo.norm_stats.unnormalize(_batch, emb_id)
+
+            pred_key = f"emb{emb_id}_{ac_key}"
+            pred = preds.get(pred_key)
+            if pred is None:
+                continue
+
+            if is_packed:
+                cu = _batch["cu_seqlens"]
+                seq_lens = preds.get(f"emb{emb_id}_seq_lens", _batch["seq_lens"])
+                gt = _unpack_to_padded(_batch_unnorm[ac_key], cu, seq_lens)
+                mse_val = _masked_mse(pred, gt, seq_lens)
+                metrics[f"Valid/emb{emb_id}_{ac_key}_paired_mse"] = mse_val.detach()
+                # Final-position MSE = per-episode last valid index.
+                last_idx = (seq_lens - 1).clamp(min=0)
+                B = pred.shape[0]
+                idx = last_idx.to(pred.device)
+                final_pred = pred[torch.arange(B, device=pred.device), idx]
+                final_gt = gt[torch.arange(B, device=pred.device), idx]
+                metrics[f"Valid/emb{emb_id}_{ac_key}_final_mse"] = (
+                    ((final_pred - final_gt) ** 2).mean().detach()
+                )
+
+                # Build the viz batch: use frame 0 of each episode's image
+                # for the background, and the full predicted / GT trajectory
+                # overlay on top.
+                first_frame_img = None
+                cam_keys = algo.camera_keys.get(emb_id, [])
+                if cam_keys:
+                    img_key = cam_keys[0]
+                    if img_key in _batch_unnorm:
+                        packed_img = _batch_unnorm[img_key]
+                        unpacked = _unpack_to_padded(packed_img, cu, seq_lens)
+                        first_frame_img = unpacked[:, 0]  # (B, C, H, W)
+
+                viz_batch = {
+                    ac_key: gt,
+                    "embodiment": _batch["embodiment"],
+                }
+                if first_frame_img is not None:
+                    viz_batch[cam_keys[0]] = first_frame_img
+                viz_preds = {f"{embodiment_name}_{ac_key}": pred}
+            else:
+                # Padded mode (legacy).
+                gt = _batch_unnorm[ac_key]
+                mse_val = ((pred - gt) ** 2).mean()
+                metrics[f"Valid/emb{emb_id}_{ac_key}_paired_mse"] = mse_val.detach()
+                metrics[f"Valid/emb{emb_id}_{ac_key}_final_mse"] = (
+                    ((pred[:, -1] - gt[:, -1]) ** 2).mean().detach()
+                )
+                viz_batch = copy.copy(_batch_unnorm)
+                viz_preds = {f"{embodiment_name}_{ac_key}": pred}
+
+            if total_loss is None:
+                total_loss = torch.zeros_like(mse_val)
+            total_loss = total_loss + mse_val
+            n_loss += 1
+
+            if self.viz_func is not None and embodiment_name in self.viz_func:
+                ims = self.viz_func[embodiment_name](viz_preds, viz_batch)
+                images_dict[emb_id] = ims
+
+        if total_loss is not None and n_loss > 0:
+            metrics["Valid/action_loss"] = total_loss / n_loss
+
+        return metrics, images_dict

--- a/egomimic/hydra_configs/data/tsimulation.yaml
+++ b/egomimic/hydra_configs/data/tsimulation.yaml
@@ -1,39 +1,54 @@
 _target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
 
-# Pushshapes' action chunk length. Lives at the root of this file so the
-# model config can interpolate it too (it's referenced from
-# `data.action_horizon`) — there is exactly one place to change it.
-action_horizon: 32
+# NOTE: action_horizon is hard-coded as 1024 in this file (both keymap calls
+# below) AND in egomimic/hydra_configs/model/hnet_pushshapes.yaml. The two
+# must match; ``hydra.utils.instantiate(cfg.data, ...)`` forwards every
+# top-level key to ``MultiDataModuleWrapper.__init__``, so we can't keep a
+# top-level ``action_horizon`` here. The longest episode in
+# Tsim_datasets2/circle is 958 frames; 1024 leaves room.
 
+# Packed dataloading. Each sample is one full episode (chunking="none"),
+# and `pack_collate` (selected automatically by `_collate_fn_for` in
+# pl_data_utils) concatenates `batch_size` episodes into a single flat
+# stream with `cu_seqlens` boundaries. The algo's `forward_training`
+# detects the packed batch (presence of `cu_seqlens`) and dispatches to
+# `HNetPolicy.forward_packed`.
 train_datasets:
   pushshapes_sim:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
-      folder_path: /mnt/c/Users/aidan/Desktop/EgoVerse/Tsimulation/test_demos
+      folder_path: /coc/cedarp-dxu345-0/Tsim_datasets2/circle
       key_map:
         _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
-        action_horizon: ${data.action_horizon}
+        action_horizon: 1024
       transform_list: null
-    mode: total
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: null
 
 valid_datasets:
   pushshapes_sim:
-    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
     resolver:
       _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
-      folder_path: /mnt/c/Users/aidan/Desktop/EgoVerse/Tsimulation/test_demos
+      folder_path: /coc/cedarp-dxu345-0/Tsim_datasets2/circle
       key_map:
         _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
-        action_horizon: ${data.action_horizon}
+        action_horizon: 1024
       transform_list: null
-    mode: total
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: null
 
+# A40 baseline (44.4 GiB): one full episode at T~958 peaks at ~1.8 GiB,
+# so 8 episodes packed should land in 12–16 GiB worst case. Headroom for
+# the chunker firing more boundaries as training progresses.
 train_dataloader_params:
   pushshapes_sim:
-    batch_size: 4
+    batch_size: 8
     num_workers: 2
 valid_dataloader_params:
   pushshapes_sim:
-    batch_size: 4
+    batch_size: 8
     num_workers: 2

--- a/egomimic/hydra_configs/evaluator/eval_hnet.yaml
+++ b/egomimic/hydra_configs/evaluator/eval_hnet.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - viz@viz_func: cartesian
+  - _self_
+
+_target_: egomimic.eval.eval_hnet.HNetEvalVideo
+
+# H-Net validation can be slow because each episode rolls out
+# autoregressively via ``policy.generate``. Cap the number of val batches
+# the evaluator visits per epoch so a 30-batch val loader doesn't take
+# 90 minutes. Tune up once kernels are installed.
+limit_val_batches: 4

--- a/egomimic/hydra_configs/logger/csv.yaml
+++ b/egomimic/hydra_configs/logger/csv.yaml
@@ -1,0 +1,11 @@
+# Local-only Lightning CSV logger. Writes metrics to
+# ``${paths.output_dir}/csv_logs/lightning_logs/version_*/metrics.csv``.
+# Useful for debug runs where wandb is overkill but we still want to see
+# the loss curve (training without a logger means Lightning drops every
+# log_dict call on the floor).
+csv:
+  _target_: lightning.pytorch.loggers.CSVLogger
+  save_dir: "${paths.output_dir}/csv_logs"
+  name: "lightning_logs"
+  version: null
+  flush_logs_every_n_steps: 1

--- a/egomimic/hydra_configs/model/hnet_pushshapes.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes.yaml
@@ -1,11 +1,15 @@
 _target_: egomimic.pl_utils.pl_model.ModelWrapper
 robomimic_model:
   _target_: egomimic.algo.hnet.HNet
-  data_schematic: _${data.dataset.data_schematic}
+  # ``norm_stats`` is injected at runtime by
+  # ``pl_model.ModelWrapper._instantiate_model``; do not set it here.
 
   # ---- core dims ----
   action_dim: 2
-  action_horizon: 32
+  # Upper bound on a single sub-sequence length in packed mode (the policy's
+  # learned pos_emb is sized at action_horizon). Longest pushshapes episode
+  # is 958 frames; 1024 leaves headroom.
+  action_horizon: 1024
   d_model: 128
   d_cond: 128
 
@@ -86,6 +90,27 @@ robomimic_model:
   domains: ["pushshapes_sim"]
   ac_keys:
     pushshapes_sim: "actions"
+
+  # ---- training recipe (all OPT-IN; default disabled) ----
+  # Ported from upstream hnet/models/hnet.py + hnet/utils/train.py.
+  # Leaving these unset reproduces "standard training": PyTorch default
+  # Linear init, single LR for all params, single weight_decay from the
+  # optimizer config below.
+  #
+  #   init_weights_range: 0.02          # residual-stream-aware init
+  #                                     #   (out_proj/fc2 scaled by 1/sqrt(n_residuals))
+  #   lr_multipliers: [3.0, 1.7, 0.9]   # per-stage LR scale (outer → inner)
+  #                                     #   length must match number of stages
+  #   use_parameter_groups: true        # build AdamW groups with WD=0 on
+  #                                     #   bias/norm and per-group lr =
+  #                                     #   base_lr * lr_multiplier. Reads
+  #                                     #   weight_decay from this field, NOT
+  #                                     #   from the optimizer config.
+  #   weight_decay: 0.01                # WD used when use_parameter_groups=true
+  init_weights_range: null
+  lr_multipliers: null
+  use_parameter_groups: false
+  weight_decay: 0.0
 
 optimizer:
   _target_: torch.optim.AdamW

--- a/egomimic/models/hnet_nets/context.py
+++ b/egomimic/models/hnet_nets/context.py
@@ -6,7 +6,24 @@ to the stage tree. Stages read named tensors from ``cond_dict`` and append
 auxiliary information (e.g. boundary predictions for the ratio loss) via
 ``register_aux``. ``inference_params`` carries per-stage step-time state when
 running autoregressively; it is left None during teacher-forced forward.
+
+Packed mode (FlashAttention-style varlen):
+    Set ``cu_seqlens`` (LongTensor (B+1,), starts at 0) and ``max_seqlen``
+    (int) on the context. Stages will then drive their sub-modules in packed
+    mode: hidden states shaped ``(T_total, D)``, attention via varlen / SDPA
+    block-diagonal mask, routing/chunk/dechunk via their packed paths.
+    When ``cu_seqlens`` is None the stages fall back to padded mode with an
+    all-ones mask of shape ``(B, L)``.
+
+    The ``ChunkerStage`` saves and restores ``cu_seqlens`` / ``max_seqlen``
+    around the call into its inner stage (substituting the chunked-space
+    cu_seqlens for the recursion), so callers only ever set the *outer*
+    pack info on the context and don't manage it per-level.
+
+    In packed mode, ``cond_dict[cond_key]`` (when used) must be shaped
+    ``(T_total, d_cond)`` to align with the per-token packed stream.
 """
+
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -19,8 +36,9 @@ class HNetContext:
 
     Attributes:
         cond_dict: named conditioning tensors. The default "fused_cond" entry
-            (per-token cond of shape (B, T, d_cond)) is produced by
-            ``CondEncoderModule``; user-defined keys may be added alongside.
+            (per-token cond of shape (B, T, d_cond) padded / (T_total, d_cond)
+            packed) is produced by ``CondEncoderModule``; user-defined keys
+            may be added alongside.
         aux: each chunker stage's forward / step appends a dict here with at
             least ``{"bpred": RoutingModuleOutput, "target_ratio": float,
             "weight": float}``. The algo iterates this to compute the ratio
@@ -29,12 +47,22 @@ class HNetContext:
             during teacher-forced forward.
         extras: free-form scratch dict for callers that want to pass extra
             information down (and back up) through the stage tree.
+        cu_seqlens: optional (B+1,) long tensor with cumulative subseq lengths
+            (starts at 0). Setting this switches stages into packed mode.
+        max_seqlen: optional int — longest subseq length, required when
+            cu_seqlens is set (attention kernels need it).
     """
 
     cond_dict: Dict[str, torch.Tensor] = field(default_factory=dict)
     aux: List[Dict[str, Any]] = field(default_factory=list)
     inference_params: Optional[List[Any]] = None
     extras: Dict[str, Any] = field(default_factory=dict)
+    cu_seqlens: Optional[torch.Tensor] = None
+    max_seqlen: Optional[int] = None
+
+    @property
+    def packed(self) -> bool:
+        return self.cu_seqlens is not None
 
     def register_aux(self, item: Dict[str, Any]) -> None:
         self.aux.append(item)

--- a/egomimic/models/hnet_nets/hnet.py
+++ b/egomimic/models/hnet_nets/hnet.py
@@ -16,6 +16,7 @@ individual stages. It exists to:
 action_in / action_out / BOS / pos_emb / cond encoders live on the algo
 class (``HNetPolicy``), not here.
 """
+
 from typing import List
 
 import torch
@@ -23,6 +24,18 @@ import torch.nn as nn
 
 from egomimic.models.hnet_nets.context import HNetContext
 from egomimic.models.hnet_nets.stages import _BaseStage
+
+
+def apply_optimization_params(param: torch.Tensor, **kwargs) -> None:
+    """Annotate a parameter with optimizer kwargs (lr_multiplier, weight_decay).
+
+    Mirrors the upstream H-Net helper. ``HNet.parameter_groups`` later reads
+    each parameter's ``_optim`` dict to build AdamW param groups.
+    """
+    if hasattr(param, "_optim"):
+        param._optim.update(kwargs)
+    else:
+        param._optim = dict(kwargs)
 
 
 class HNet(nn.Module):
@@ -49,6 +62,7 @@ class HNet(nn.Module):
             # inner stage runs in the chunked space at output_hidden_dim
             # (after the explicit proj_in).
             from egomimic.models.hnet_nets.stages import ChunkerStage as _CS
+
             expected = (
                 stages[i].output_hidden_dim
                 if isinstance(stages[i], _CS)
@@ -56,7 +70,7 @@ class HNet(nn.Module):
             )
             if stages[i + 1].input_hidden_dim != expected:
                 raise ValueError(
-                    f"Hidden-dim mismatch: stages[{i+1}].input_hidden_dim "
+                    f"Hidden-dim mismatch: stages[{i + 1}].input_hidden_dim "
                     f"({stages[i + 1].input_hidden_dim}) does not match the "
                     f"inner working dim of stages[{i}] ({expected})."
                 )
@@ -103,9 +117,101 @@ class HNet(nn.Module):
         assert ctx.inference_params is not None, "Call allocate_inference_cache first."
         return self.root.step(x, ctx, ctx.inference_params[0])
 
-    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, device, dtype=torch.float32):
+    def allocate_inference_cache(
+        self, batch_size: int, max_seqlen: int, device, dtype=torch.float32
+    ):
         """Returns a list with a single entry: the root stage's nested state."""
         return [self.root._allocate(batch_size, max_seqlen, dtype, device)]
+
+    # ----- Training recipe (mirrors upstream hnet/models/hnet.py) ----- #
+
+    def init_weights(self, initializer_range: float = 0.02) -> None:
+        """Walk the stage chain and apply residual-stream-aware Linear init.
+
+        ``out_proj`` and ``fc2`` weights are scaled by
+        ``initializer_range / sqrt(n_residuals)`` where ``n_residuals`` is
+        the cumulative residual depth through the hierarchy. Modules flagged
+        ``_no_reinit`` (routing q/k, residual_proj, AdaLN) are skipped.
+        """
+        self.root._init_weights(initializer_range, parent_residuals=0)
+
+    def apply_lr_multiplier(self, lr_multipliers) -> None:
+        """Stamp every parameter with a per-stage ``lr_multiplier`` annotation.
+
+        ``lr_multipliers`` is a list with one entry per stage in the flat
+        list (outer first). Stage i's parameters get ``lr_multipliers[i]``.
+        Read by ``parameter_groups`` when building optimizer param groups.
+        """
+        self.root._apply_lr_multiplier(lr_multipliers, stage_idx=0)
+
+    def parameter_groups(self, weight_decay: float = 0.0) -> list:
+        """Build AdamW parameter groups from per-parameter ``_optim`` annotations.
+
+        Groups params by their ``_optim`` tuple. Sets ``weight_decay=0`` on
+        biases and norm weights regardless of any other annotation.
+        Returns ``list[dict]`` suitable for ``torch.optim.AdamW(params=...)``.
+
+        If ``apply_lr_multiplier`` was never called, params have no
+        ``_optim`` and end up in one group with ``lr_multiplier=1.0`` and the
+        passed ``weight_decay`` (bias/norm still get WD=0).
+        """
+        # First pass: stamp bias / norm params with weight_decay=0. Other
+        # params inherit the caller's ``weight_decay`` arg via the default
+        # group below.
+        for name, p in self.named_parameters():
+            if not p.requires_grad:
+                continue
+            if name.endswith(".bias") or ".norm" in name or "rmsnorm" in name.lower():
+                apply_optimization_params(p, weight_decay=0.0)
+
+        # Build group dict keyed by sorted-tuple of (key, value) items from _optim.
+        groups: dict = {}
+        for p in self.parameters():
+            if not p.requires_grad:
+                continue
+            optim = getattr(p, "_optim", {})
+            key = tuple(sorted(optim.items()))
+            entry = groups.setdefault(
+                key, {"params": [], "weight_decay": weight_decay, "lr_multiplier": 1.0}
+            )
+            entry["params"].append(p)
+            for k, v in optim.items():
+                entry[k] = v
+        return list(groups.values())
+
+
+def chunk_stats_from_aux(aux: List[dict]) -> dict:
+    """Per-chunker boundary stats for logging.
+
+    For each entry in ``aux`` (one per chunker stage), report:
+      - boundary_rate (F): fraction of tokens marked as boundaries.
+      - avg_chunk_len: average length of a chunk in tokens. Defined as
+        ``num_tokens / max(num_boundaries, 1)``; equals ``1 / F`` when F > 0
+        and ``num_tokens`` (one chunk covering everything) when F == 0.
+
+    Returns a dict with keys per chunker (``avg_chunk_len_0``,
+    ``boundary_rate_0``, ...) plus aggregate ``avg_chunk_len`` /
+    ``boundary_rate`` averaged across chunkers. All values are Python
+    floats — these are pure logging stats, not loss terms.
+    """
+    out: dict = {}
+    if not aux:
+        return out
+    rates = []
+    lens = []
+    for i, entry in enumerate(aux):
+        bm = entry["bpred"].boundary_mask
+        n = max(bm.numel(), 1)
+        n_b = int(bm.sum().item())
+        f = n_b / n
+        avg_len = n / max(n_b, 1)
+        out[f"boundary_rate_{i}"] = f
+        out[f"avg_chunk_len_{i}"] = avg_len
+        rates.append(f)
+        lens.append(avg_len)
+    out["boundary_rate"] = sum(rates) / len(rates)
+    out["avg_chunk_len"] = sum(lens) / len(lens)
+    return out
 
 
 def ratio_loss_from_aux(aux: List[dict], device=None) -> torch.Tensor:

--- a/egomimic/models/hnet_nets/routing.py
+++ b/egomimic/models/hnet_nets/routing.py
@@ -13,6 +13,7 @@ Packed mode (matches upstream's 2D convention so flash_attn varlen plugs in):
     max_seqlen:    int — longest subseq length (passed to attention modules)
     mask:          None
 """
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -23,7 +24,10 @@ import torch.nn.functional as F
 # Optional Mamba2 selective-scan kernel for the DeChunkLayer EMA.
 try:
     from einops import rearrange, repeat  # type: ignore
-    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined  # type: ignore
+    from mamba_ssm.ops.triton.ssd_combined import (
+        mamba_chunk_scan_combined,  # type: ignore
+    )
+
     _HAS_MAMBA_SCAN = True
 except Exception:
     mamba_chunk_scan_combined = None  # type: ignore
@@ -37,15 +41,17 @@ def has_mamba_scan() -> bool:
 
 @dataclass
 class RoutingModuleOutput:
-    boundary_prob: torch.Tensor   # padded: (B, L, 2); packed: (T_total, 2); step: (B, 2)
-    boundary_mask: torch.Tensor   # padded: (B, L);    packed: (T_total,);   step: (B,)
-    selected_probs: torch.Tensor  # padded: (B, L, 1); packed: (T_total, 1); step: (B, 1)
+    boundary_prob: torch.Tensor  # padded: (B, L, 2); packed: (T_total, 2); step: (B, 2)
+    boundary_mask: torch.Tensor  # padded: (B, L);    packed: (T_total,);   step: (B,)
+    selected_probs: (
+        torch.Tensor
+    )  # padded: (B, L, 1); packed: (T_total, 1); step: (B, 1)
 
 
 @dataclass
 class RoutingModuleState:
-    has_seen_tokens: torch.Tensor   # (B,) bool
-    last_hidden_state: torch.Tensor # (B, D)
+    has_seen_tokens: torch.Tensor  # (B,) bool
+    last_hidden_state: torch.Tensor  # (B, D)
 
 
 @dataclass
@@ -77,7 +83,9 @@ class RoutingModule(nn.Module):
         # max_seqlen kept for upstream signature parity (unused here).
         return RoutingModuleState(
             has_seen_tokens=torch.zeros(batch_size, device=device, dtype=torch.bool),
-            last_hidden_state=torch.zeros(batch_size, self.d_model, device=device, dtype=dtype),
+            last_hidden_state=torch.zeros(
+                batch_size, self.d_model, device=device, dtype=dtype
+            ),
         )
 
     def forward(
@@ -87,10 +95,13 @@ class RoutingModule(nn.Module):
         mask: Optional[torch.Tensor] = None,
         inference_params: Optional[RoutingModuleState] = None,
     ) -> RoutingModuleOutput:
-        assert (mask is not None) or (cu_seqlens is not None), \
-            "Either mask (padded) or cu_seqlens (packed) must be provided"
+        assert (mask is not None) or (
+            cu_seqlens is not None
+        ), "Either mask (padded) or cu_seqlens (packed) must be provided"
         if cu_seqlens is not None:
-            assert inference_params is None, "Packed mode does not support inference_params"
+            assert (
+                inference_params is None
+            ), "Packed mode does not support inference_params"
             return self._forward_packed(hidden_states, cu_seqlens)
         return self._forward_padded(hidden_states, mask, inference_params)
 
@@ -106,12 +117,16 @@ class RoutingModule(nn.Module):
             F.normalize(self.k_proj_layer(hidden_states[:, 1:]), dim=-1),
         )
         boundary_prob = torch.clamp(((1 - cos_sim) / 2), min=0.0, max=1.0)
-        boundary_prob = F.pad(boundary_prob, (1, 0), "constant", 1.0) # PAD Prob 1.0
+        boundary_prob = F.pad(boundary_prob, (1, 0), "constant", 1.0)  # PAD Prob 1.0
         boundary_prob = torch.stack(((1 - boundary_prob), boundary_prob), dim=-1)
 
-        selected_idx = torch.argmax(boundary_prob, dim=-1) 
-        boundary_mask = (selected_idx == 1) & mask # selected boundary not in valid token range is not chosen
-        selected_probs = boundary_prob.gather(dim=-1, index=selected_idx.unsqueeze(-1)) # equivalent confidence mentioned in the paper
+        selected_idx = torch.argmax(boundary_prob, dim=-1)
+        boundary_mask = (
+            selected_idx == 1
+        ) & mask  # selected boundary not in valid token range is not chosen
+        selected_probs = boundary_prob.gather(
+            dim=-1, index=selected_idx.unsqueeze(-1)
+        )  # equivalent confidence mentioned in the paper
 
         # Prefill update: stash last valid token per batch so subsequent step()s
         # continue from this prefix.
@@ -122,7 +137,9 @@ class RoutingModule(nn.Module):
             )
             last_idx = torch.clamp(mask.sum(dim=-1) - 1, min=0)
             B = hidden_states.shape[0]
-            last_h = hidden_states[torch.arange(B, device=hidden_states.device), last_idx]
+            last_h = hidden_states[
+                torch.arange(B, device=hidden_states.device), last_idx
+            ]
             inference_params.last_hidden_state.copy_(
                 torch.where(
                     has_mask.unsqueeze(-1),
@@ -150,19 +167,25 @@ class RoutingModule(nn.Module):
         boundary_prob = F.pad(boundary_prob, (1, 0), "constant", 1.0)
         # Force boundary at the first token of every subseq
         boundary_prob = boundary_prob.clone()
-        boundary_prob[cu_seqlens[:-1]] = 1.0 # PAD Prob 1.0 at subseq starts
+        boundary_prob[cu_seqlens[:-1]] = 1.0  # PAD Prob 1.0 at subseq starts
 
-        boundary_prob = torch.stack(((1 - boundary_prob), boundary_prob), dim=-1)  # (T_total, 2)
+        boundary_prob = torch.stack(
+            ((1 - boundary_prob), boundary_prob), dim=-1
+        )  # (T_total, 2)
         selected_idx = torch.argmax(boundary_prob, dim=-1)
         boundary_mask = selected_idx == 1  # (T_total,)
-        selected_probs = boundary_prob.gather(dim=-1, index=selected_idx.unsqueeze(-1)) # equivalent to confidence mentioned in the paper, (T_total, 1)
+        selected_probs = boundary_prob.gather(
+            dim=-1, index=selected_idx.unsqueeze(-1)
+        )  # equivalent to confidence mentioned in the paper, (T_total, 1)
         return RoutingModuleOutput(
             boundary_prob=boundary_prob,
             boundary_mask=boundary_mask,
             selected_probs=selected_probs,
         )
 
-    def step(self, hidden_states, inference_params: RoutingModuleState) -> RoutingModuleOutput:
+    def step(
+        self, hidden_states, inference_params: RoutingModuleState
+    ) -> RoutingModuleOutput:
         hidden_states = hidden_states.squeeze(1)
         cos_sim = torch.einsum(
             "b d, b d -> b",
@@ -170,9 +193,13 @@ class RoutingModule(nn.Module):
             F.normalize(self.k_proj_layer(hidden_states), dim=-1),
         )
         boundary_prob = torch.clamp(((1 - cos_sim) / 2), min=0.0, max=1.0)
-        inference_params.last_hidden_state.copy_(hidden_states.to(inference_params.last_hidden_state.dtype))
+        inference_params.last_hidden_state.copy_(
+            hidden_states.to(inference_params.last_hidden_state.dtype)
+        )
         boundary_prob = torch.where(
-            inference_params.has_seen_tokens, boundary_prob, torch.ones_like(boundary_prob)
+            inference_params.has_seen_tokens,
+            boundary_prob,
+            torch.ones_like(boundary_prob),
         )
         boundary_prob = torch.stack(((1 - boundary_prob), boundary_prob), dim=-1)
         inference_params.has_seen_tokens.fill_(True)
@@ -207,14 +234,18 @@ class ChunkLayer(nn.Module):
         next_max_seqlen = int(num_tokens.max())
 
         device = hidden_states.device
-        token_idx = torch.arange(L, device=device)[None, :] + (~boundary_mask).long() * L
+        token_idx = (
+            torch.arange(L, device=device)[None, :] + (~boundary_mask).long() * L
+        )
         seq_sorted_indices = torch.argsort(token_idx, dim=1)
         next_hidden_states = torch.gather(
             hidden_states,
             dim=1,
             index=seq_sorted_indices[:, :next_max_seqlen, None].expand(-1, -1, D),
         )
-        next_mask = torch.arange(next_max_seqlen, device=device)[None, :] < num_tokens[:, None]
+        next_mask = (
+            torch.arange(next_max_seqlen, device=device)[None, :] < num_tokens[:, None]
+        )
         # Upstream discards next_max_seqlen at the end of the padded path — the
         # downstream Isotropic uses next_mask instead.
         next_max_seqlen = None
@@ -252,15 +283,17 @@ class DeChunkLayer(nn.Module):
         self.dtype = dtype
         self.block_size = block_size
         self.headdim = headdim
-        assert d_model % self.headdim == 0, (
-            f"d_model ({d_model}) must be divisible by headdim ({self.headdim})."
-        )
+        assert (
+            d_model % self.headdim == 0
+        ), f"d_model ({d_model}) must be divisible by headdim ({self.headdim})."
         self.nheads = d_model // self.headdim
 
     def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype=None):
         # max_seqlen kept for upstream signature parity (unused here).
         return DeChunkState(
-            last_value=torch.zeros(batch_size, self.d_model, device=device, dtype=dtype),
+            last_value=torch.zeros(
+                batch_size, self.d_model, device=device, dtype=dtype
+            ),
         )
 
     def forward(
@@ -280,14 +313,21 @@ class DeChunkLayer(nn.Module):
             cu_seqlens is **chunked-space** cu_seqlens (matches upstream API).
         """
         if cu_seqlens is not None:
-            assert inference_params is None, "Packed mode does not support inference_params"
-            return self._forward_packed(hidden_states, boundary_mask, boundary_prob, cu_seqlens)
-        return self._forward_padded(hidden_states, boundary_mask, boundary_prob, inference_params)
+            assert (
+                inference_params is None
+            ), "Packed mode does not support inference_params"
+            return self._forward_packed(
+                hidden_states, boundary_mask, boundary_prob, cu_seqlens
+            )
+        return self._forward_padded(
+            hidden_states, boundary_mask, boundary_prob, inference_params
+        )
 
     # -------------- EMA backends --------------
 
-    def _ema_kernel(self, x_3d: torch.Tensor, p_2d: torch.Tensor,
-                    seq_idx: Optional[torch.Tensor]) -> torch.Tensor:
+    def _ema_kernel(
+        self, x_3d: torch.Tensor, p_2d: torch.Tensor, seq_idx: Optional[torch.Tensor]
+    ) -> torch.Tensor:
         """Parallel EMA via mamba_chunk_scan_combined.
 
         x_3d: (B, M, D), p_2d: (B, M), seq_idx: (B, M) int32 or None.
@@ -311,8 +351,12 @@ class DeChunkLayer(nn.Module):
         out = rearrange(out, "b l h p -> b l (h p)")
         return out.to(original_dtype)
 
-    def _ema_loop(self, x_3d: torch.Tensor, p_2d: torch.Tensor,
-                  seq_starts: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def _ema_loop(
+        self,
+        x_3d: torch.Tensor,
+        p_2d: torch.Tensor,
+        seq_starts: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """Sequential EMA fallback.
 
         x_3d: (B, M, D), p_2d: (B, M). When seq_starts is provided (1D long
@@ -329,14 +373,16 @@ class DeChunkLayer(nn.Module):
         for t in range(M):
             if t in starts_set:
                 prev = torch.zeros(B, D, device=x_3d.device, dtype=x_3d.dtype)
-            pt = p_2d[:, t:t + 1]
+            pt = p_2d[:, t : t + 1]
             prev = pt * x_3d[:, t] + (1 - pt) * prev
             out.append(prev)
         return torch.stack(out, dim=1)
 
     # -------------- Mode-specific forwards --------------
 
-    def _forward_padded(self, hidden_states, boundary_mask, boundary_prob, inference_params=None):
+    def _forward_padded(
+        self, hidden_states, boundary_mask, boundary_prob, inference_params=None
+    ):
         _, L = boundary_mask.shape
         D = hidden_states.shape[-1]
         device = hidden_states.device
@@ -344,7 +390,9 @@ class DeChunkLayer(nn.Module):
 
         # Gather boundary probs in chunked order (boundaries first within each row).
         p_full = torch.clamp(boundary_prob[..., -1], min=1e-4, max=1 - 1e-4)
-        token_idx = torch.arange(L, device=device)[None, :] + (~boundary_mask).long() * L
+        token_idx = (
+            torch.arange(L, device=device)[None, :] + (~boundary_mask).long() * L
+        )
         sorted_idx = torch.argsort(token_idx, dim=1)[:, :M]
         p = torch.gather(p_full, dim=1, index=sorted_idx)  # (B, M)
 
@@ -398,17 +446,32 @@ class DeChunkLayer(nn.Module):
         full = torch.gather(ema, dim=0, index=plug_back_idx.unsqueeze(-1).expand(-1, D))
         return full  # (T_total, D)
 
-    def step(self, hidden_states, boundary_mask, boundary_prob, inference_params: DeChunkState):
+    def step(
+        self,
+        hidden_states,
+        boundary_mask,
+        boundary_prob,
+        inference_params: DeChunkState,
+    ):
         B = boundary_mask.shape[0]
         D = inference_params.last_value.shape[-1]
         device = inference_params.last_value.device
 
         p = torch.zeros(B, device=device, dtype=inference_params.last_value.dtype)
-        p[boundary_mask] = boundary_prob[boundary_mask, -1].clamp(min=1e-4, max=1 - 1e-4)
+        # Cast the source to p's dtype so this works under autocast (e.g.
+        # bf16 forward where boundary_prob is bf16 but p stays fp32 from the
+        # inference cache).
+        p[boundary_mask] = (
+            boundary_prob[boundary_mask, -1].clamp(min=1e-4, max=1 - 1e-4).to(p.dtype)
+        )
 
-        new_vals = torch.zeros(B, D, device=device, dtype=inference_params.last_value.dtype)
+        new_vals = torch.zeros(
+            B, D, device=device, dtype=inference_params.last_value.dtype
+        )
         if hidden_states.numel() > 0:
-            new_vals[boundary_mask] = hidden_states.squeeze(1).to(inference_params.last_value.dtype)
+            new_vals[boundary_mask] = hidden_states.squeeze(1).to(
+                inference_params.last_value.dtype
+            )
 
         p_b = p.unsqueeze(-1)
         result = p_b * new_vals + (1 - p_b) * inference_params.last_value

--- a/egomimic/models/hnet_nets/stages.py
+++ b/egomimic/models/hnet_nets/stages.py
@@ -28,8 +28,9 @@ declares its ``input_hidden_dim`` and ``output_hidden_dim``. When the inner
 stage's expected input dim differs from this stage's working dim, the stage
 inserts a minimal ``nn.Linear`` projection. No padding-based bridging.
 """
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn
@@ -49,10 +50,10 @@ from egomimic.models.hnet_nets.routing import (
     RoutingModuleState,
 )
 
-
 # --------------------------------------------------------------------------- #
 # Inference-state dataclasses (one per stage type).
 # --------------------------------------------------------------------------- #
+
 
 @dataclass
 class EncoderDecoderStageState:
@@ -80,6 +81,7 @@ class ComputeStageState:
 # Straight-through estimator for the boundary mask (matches upstream HNet).
 # --------------------------------------------------------------------------- #
 
+
 class _STE(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x):
@@ -99,11 +101,14 @@ def _ste(x):
 # Reused (and slightly simplified) from the previous monolithic HNet.
 # --------------------------------------------------------------------------- #
 
+
 def _slice_iso_params(params: Optional[IsotropicInferenceParams], mask: torch.Tensor):
     if params is None:
         return None
     new = IsotropicInferenceParams(
-        layer_caches={}, max_seqlen=params.max_seqlen, batch_size=int(mask.sum().item()),
+        layer_caches={},
+        max_seqlen=params.max_seqlen,
+        batch_size=int(mask.sum().item()),
     )
     for k, c in params.layer_caches.items():
         if isinstance(c, KVCache):
@@ -190,14 +195,18 @@ def _scatter_state(state: Any, sub: Any, mask: torch.Tensor):
         return
     if isinstance(state, ChunkerStageState):
         if state.routing_state is not None and sub.routing_state is not None:
-            state.routing_state.has_seen_tokens[mask] = sub.routing_state.has_seen_tokens
+            state.routing_state.has_seen_tokens[mask] = (
+                sub.routing_state.has_seen_tokens
+            )
             state.routing_state.last_hidden_state[mask] = (
-                sub.routing_state.last_hidden_state.to(state.routing_state.last_hidden_state.dtype)
+                sub.routing_state.last_hidden_state.to(
+                    state.routing_state.last_hidden_state.dtype
+                )
             )
         _scatter_state(state.inner_state, sub.inner_state, mask)
         if state.dechunk_state is not None and sub.dechunk_state is not None:
-            state.dechunk_state.last_value[mask] = (
-                sub.dechunk_state.last_value.to(state.dechunk_state.last_value.dtype)
+            state.dechunk_state.last_value[mask] = sub.dechunk_state.last_value.to(
+                state.dechunk_state.last_value.dtype
             )
         return
     if isinstance(state, ComputeStageState):
@@ -211,6 +220,7 @@ def _scatter_state(state: Any, sub: Any, mask: torch.Tensor):
 # Shared base — handles inner_stage wiring assertion and the optional
 # input/output projections triggered only when input_hidden_dim != working dim.
 # --------------------------------------------------------------------------- #
+
 
 class _BaseStage(nn.Module):
     """Common scaffolding for stage classes."""
@@ -243,10 +253,53 @@ class _BaseStage(nn.Module):
     def allocate_inference_cache(self, batch_size: int, dtype, device):
         raise NotImplementedError
 
+    # ----- Training recipe hooks (mirror upstream hnet/models/hnet.py) ----- #
+
+    def _init_weights(self, initializer_range: float, parent_residuals: int) -> int:
+        """Initialize Linear weights in this stage using residual-stream-aware
+        scaling. Returns the cumulative ``n_residuals`` after this stage's
+        contribution (used by the parent's recursion into sibling stages).
+
+        Default behavior is no-op: subclasses override to scale their inner
+        Isotropic stacks' ``out_proj`` / ``fc2`` weights by
+        ``initializer_range / sqrt(n_residuals)`` and recurse into
+        ``inner_stage``.
+        """
+        return parent_residuals
+
+    def _apply_lr_multiplier(self, lr_multipliers, stage_idx: int) -> None:
+        """Stamp every parameter in this stage (and ``inner_stage``) with the
+        corresponding LR multiplier via ``apply_optimization_params``. The
+        outer stage gets ``lr_multipliers[stage_idx]``; ``inner_stage`` gets
+        ``stage_idx + 1``. Indexing past the list is a config error.
+        """
+        from egomimic.models.hnet_nets.hnet import apply_optimization_params
+
+        if stage_idx >= len(lr_multipliers):
+            raise IndexError(
+                f"lr_multipliers list has {len(lr_multipliers)} entries but "
+                f"stage tree wants index {stage_idx}; provide one multiplier "
+                f"per stage in the flat list passed to ``HNet([...])``."
+            )
+        mul = float(lr_multipliers[stage_idx])
+        for p in self.parameters(recurse=False):
+            apply_optimization_params(p, lr_multiplier=mul)
+        # Recurse into our own owned sub-modules (encoder/decoder/main_network),
+        # but skip ``inner_stage`` here — that's a sibling in the flat list and
+        # handled by its own _apply_lr_multiplier call at stage_idx+1.
+        for name, child in self.named_children():
+            if name == "inner_stage":
+                continue
+            for p in child.parameters():
+                apply_optimization_params(p, lr_multiplier=mul)
+        if self.inner_stage is not None:
+            self.inner_stage._apply_lr_multiplier(lr_multipliers, stage_idx + 1)
+
 
 # --------------------------------------------------------------------------- #
 # EncoderDecoderStage
 # --------------------------------------------------------------------------- #
+
 
 class EncoderDecoderStage(_BaseStage):
     """encoder → (optional inner_stage) → +encoder-residual → decoder.
@@ -295,17 +348,30 @@ class EncoderDecoderStage(_BaseStage):
 
     def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
         cond = self._get_cond(ctx)
-        # Padded mode: build an all-ones mask along T (causal already wired
-        # into the Isotropic). This matches the algo's BOS-prefixed teacher-
-        # forced input.
-        mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
-
-        x = self.encoder(x, mask=mask, cond=cond)
-        residual = x
-        if self.inner_stage is not None:
-            x = self.inner_stage(x, ctx)
-        x = x + residual
-        x = self.decoder(x, mask=mask, cond=cond)
+        if ctx.packed:
+            # Packed mode: x is (T_total, D); pass cu_seqlens/max_seqlen straight
+            # through. Both encoder and decoder operate at the outer pack.
+            x = self.encoder(
+                x, cu_seqlens=ctx.cu_seqlens, max_seqlen=ctx.max_seqlen, cond=cond
+            )
+            residual = x
+            if self.inner_stage is not None:
+                x = self.inner_stage(x, ctx)
+            x = x + residual
+            x = self.decoder(
+                x, cu_seqlens=ctx.cu_seqlens, max_seqlen=ctx.max_seqlen, cond=cond
+            )
+        else:
+            # Padded mode: build an all-ones mask along T (causal already wired
+            # into the Isotropic). This matches the algo's BOS-prefixed teacher-
+            # forced input.
+            mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
+            x = self.encoder(x, mask=mask, cond=cond)
+            residual = x
+            if self.inner_stage is not None:
+                x = self.inner_stage(x, ctx)
+            x = x + residual
+            x = self.decoder(x, mask=mask, cond=cond)
         return x
 
     def step(self, x: torch.Tensor, ctx: HNetContext, state: EncoderDecoderStageState):
@@ -319,25 +385,43 @@ class EncoderDecoderStage(_BaseStage):
         return x
 
     def allocate_inference_cache(self, batch_size, dtype, device):
-        max_seqlen = 1024  # generous: KVCache size; actual seqlen comes from algo
         # The algo will call HNet.allocate_inference_cache(batch_size, max_seqlen, ...)
         # which forwards max_seqlen through; for simplicity we keep a separate path.
-        raise NotImplementedError("Use _allocate(batch_size, max_seqlen, dtype, device).")
+        raise NotImplementedError(
+            "Use _allocate(batch_size, max_seqlen, dtype, device)."
+        )
 
     def _allocate(self, batch_size, max_seqlen, dtype, device):
         return EncoderDecoderStageState(
-            encoder_state=self.encoder.allocate_inference_cache(batch_size, max_seqlen, device, dtype),
+            encoder_state=self.encoder.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            ),
             inner_state=(
                 self.inner_stage._allocate(batch_size, max_seqlen, dtype, device)
-                if self.inner_stage is not None else None
+                if self.inner_stage is not None
+                else None
             ),
-            decoder_state=self.decoder.allocate_inference_cache(batch_size, max_seqlen, device, dtype),
+            decoder_state=self.decoder.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            ),
         )
+
+    def _init_weights(self, initializer_range: float, parent_residuals: int) -> int:
+        # Encoder + decoder both contribute to the residual stream of this
+        # stage. Inner stage runs at the same outer dim and contributes
+        # additional residuals which are passed through to its own init.
+        n_residuals = parent_residuals + self.encoder.height + self.decoder.height
+        _init_isotropic_linears(self.encoder, initializer_range, n_residuals)
+        _init_isotropic_linears(self.decoder, initializer_range, n_residuals)
+        if self.inner_stage is not None:
+            n_residuals = self.inner_stage._init_weights(initializer_range, n_residuals)
+        return n_residuals
 
 
 # --------------------------------------------------------------------------- #
 # ChunkerStage
 # --------------------------------------------------------------------------- #
+
 
 class ChunkerStage(_BaseStage):
     """RoutingModule → ChunkLayer → (optional inner_stage) → DeChunkLayer.
@@ -386,6 +470,11 @@ class ChunkerStage(_BaseStage):
         self.residual_proj.weight._no_reinit = True
 
     def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        if ctx.packed:
+            return self._forward_packed(x, ctx)
+        return self._forward_padded(x, ctx)
+
+    def _forward_padded(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
         # Padded mode (B, T, D_in).
         B, T, _ = x.shape
         mask = torch.ones(B, T, dtype=torch.bool, device=x.device)
@@ -394,7 +483,9 @@ class ChunkerStage(_BaseStage):
         residual = self.residual_proj(x.float())
 
         chunked, _next_cu, next_max, next_mask = self.chunk_layer(
-            x, bpred.boundary_mask, mask=mask,
+            x,
+            bpred.boundary_mask,
+            mask=mask,
         )
 
         # Project into inner-stage working dim if required.
@@ -408,13 +499,67 @@ class ChunkerStage(_BaseStage):
             chunked = self.proj_out(chunked)
 
         dechunked = self.dechunk_layer(
-            chunked, bpred.boundary_mask, bpred.boundary_prob, mask=mask,
+            chunked,
+            bpred.boundary_mask,
+            bpred.boundary_prob,
+            mask=mask,
         )
 
         # STE residual gating (fp32 like upstream).
-        out = (
-            dechunked.float() * _ste(bpred.selected_probs) + residual
-        ).to(x.dtype)
+        out = (dechunked.float() * _ste(bpred.selected_probs) + residual).to(x.dtype)
+
+        ctx.register_aux(
+            {
+                "bpred": bpred,
+                "target_ratio": self.target_compression_ratio,
+                "weight": self.ratio_loss_weight,
+            }
+        )
+        return out
+
+    def _forward_packed(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        # Packed mode: x is (T_total, D_in), routed/chunked/dechunked in 2D.
+        # All sub-modules' packed paths assume the outer cu_seqlens from ctx;
+        # the inner_stage runs with the chunked-space cu_seqlens (we substitute
+        # and restore around the call).
+        cu = ctx.cu_seqlens
+
+        bpred = self.routing_module(x, cu_seqlens=cu)
+        residual = self.residual_proj(x.float())
+
+        chunked, next_cu, next_max, _ = self.chunk_layer(
+            x,
+            bpred.boundary_mask,
+            cu_seqlens=cu,
+        )
+
+        if self.proj_in is not None:
+            chunked = self.proj_in(chunked)
+
+        if self.inner_stage is not None:
+            saved_cu, saved_max = ctx.cu_seqlens, ctx.max_seqlen
+            ctx.cu_seqlens, ctx.max_seqlen = next_cu, next_max
+            try:
+                chunked = self.inner_stage(chunked, ctx)
+            finally:
+                ctx.cu_seqlens, ctx.max_seqlen = saved_cu, saved_max
+
+        if self.proj_out is not None:
+            chunked = self.proj_out(chunked)
+
+        # DeChunkLayer in packed mode takes the **chunked-space** cu_seqlens.
+        dechunked = self.dechunk_layer(
+            chunked,
+            bpred.boundary_mask,
+            bpred.boundary_prob,
+            cu_seqlens=next_cu,
+        )
+
+        # STE residual gating (fp32 like upstream). Shapes in packed mode:
+        #   dechunked: (T_total, D_in)
+        #   selected_probs: (T_total, 1)  → STE returns ones_like → broadcasts.
+        #   residual: (T_total, D_in)
+        out = (dechunked.float() * _ste(bpred.selected_probs) + residual).to(x.dtype)
 
         ctx.register_aux(
             {
@@ -446,7 +591,10 @@ class ChunkerStage(_BaseStage):
             inner_out = inner_in  # empty tensor at outer dim already
 
         dechunked = self.dechunk_layer.step(
-            inner_out, bpred.boundary_mask, bpred.boundary_prob, state.dechunk_state,
+            inner_out,
+            bpred.boundary_mask,
+            bpred.boundary_prob,
+            state.dechunk_state,
         )
 
         # selected_probs at step has shape (B, 1); STE expects something
@@ -471,17 +619,35 @@ class ChunkerStage(_BaseStage):
             ),
             inner_state=(
                 self.inner_stage._allocate(batch_size, max_seqlen, dtype, device)
-                if self.inner_stage is not None else None
+                if self.inner_stage is not None
+                else None
             ),
             dechunk_state=self.dechunk_layer.allocate_inference_cache(
                 batch_size, max_seqlen, device, dtype
             ),
         )
 
+    def _init_weights(self, initializer_range: float, parent_residuals: int) -> int:
+        # ChunkerStage itself adds no transformer/MLP blocks to the residual
+        # stream — the routing q/k are identity-init (marked _no_reinit) and
+        # residual_proj is zero-init (also _no_reinit). proj_in / proj_out
+        # are dim-bridge Linears between outer and inner working dim; use
+        # the unscaled ``initializer_range`` (they're not in a residual
+        # stream context).
+        for m in (self.proj_in, self.proj_out):
+            if m is not None and not getattr(m.weight, "_no_reinit", False):
+                nn.init.normal_(m.weight, mean=0.0, std=initializer_range)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+        if self.inner_stage is not None:
+            return self.inner_stage._init_weights(initializer_range, parent_residuals)
+        return parent_residuals
+
 
 # --------------------------------------------------------------------------- #
 # ComputeStage
 # --------------------------------------------------------------------------- #
+
 
 class ComputeStage(_BaseStage):
     """A single Isotropic main_network. Terminal by default; an inner_stage
@@ -512,8 +678,16 @@ class ComputeStage(_BaseStage):
 
     def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
         cond = self._get_cond(ctx)
-        mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
-        x = self.main_network(x, mask=mask, cond=cond)
+        if ctx.packed:
+            x = self.main_network(
+                x,
+                cu_seqlens=ctx.cu_seqlens,
+                max_seqlen=ctx.max_seqlen,
+                cond=cond,
+            )
+        else:
+            mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
+            x = self.main_network(x, mask=mask, cond=cond)
         if self.inner_stage is not None:
             x = self.inner_stage(x, ctx)
         return x
@@ -532,6 +706,45 @@ class ComputeStage(_BaseStage):
             ),
             inner_state=(
                 self.inner_stage._allocate(batch_size, max_seqlen, dtype, device)
-                if self.inner_stage is not None else None
+                if self.inner_stage is not None
+                else None
             ),
         )
+
+    def _init_weights(self, initializer_range: float, parent_residuals: int) -> int:
+        n_residuals = parent_residuals + self.main_network.height
+        _init_isotropic_linears(self.main_network, initializer_range, n_residuals)
+        if self.inner_stage is not None:
+            n_residuals = self.inner_stage._init_weights(initializer_range, n_residuals)
+        return n_residuals
+
+
+# --------------------------------------------------------------------------- #
+# Shared init helper — mirrors upstream's named-module iteration.
+# --------------------------------------------------------------------------- #
+
+
+def _init_isotropic_linears(
+    isotropic, initializer_range: float, n_residuals: int
+) -> None:
+    """Initialize Linear weights inside an Isotropic stack.
+
+    Out-projection (attention ``out_proj``) and FFN second linear (``fc2``)
+    contribute to the residual stream and get scaled by
+    ``initializer_range / sqrt(n_residuals)`` so the residual norm stays
+    bounded with depth. All other Linears use ``initializer_range``.
+    Modules flagged ``_no_reinit`` (e.g. routing q/k = identity, residual
+    projections = zero-init, AdaLN = zero-init) are skipped.
+    """
+    scaled_std = initializer_range / max(n_residuals, 1) ** 0.5
+    for name, m in isotropic.named_modules():
+        if not isinstance(m, nn.Linear):
+            continue
+        if getattr(m.weight, "_no_reinit", False):
+            continue
+        if "out_proj" in name or "fc2" in name:
+            nn.init.normal_(m.weight, mean=0.0, std=scaled_std)
+        else:
+            nn.init.normal_(m.weight, mean=0.0, std=initializer_range)
+        if m.bias is not None:
+            nn.init.zeros_(m.bias)

--- a/egomimic/pl_utils/pl_model.py
+++ b/egomimic/pl_utils/pl_model.py
@@ -243,9 +243,28 @@ class ModelWrapper(LightningModule):
         config_tree = getattr(self.hparams, "config_tree", None)
         if config_tree is not None:
             cfg = self._as_config(config_tree)
+            # Optional hook: algos with custom parameter groups (e.g. H-Net's
+            # per-stage LR multipliers + WD=0 on biases/norms) can return a
+            # ``list[dict]`` here. Returning ``None`` falls back to flat
+            # ``self.trainer.model.parameters()``.
+            groups = None
+            param_groups_fn = getattr(self.model, "parameter_groups", None)
+            if callable(param_groups_fn):
+                try:
+                    base_lr = float(
+                        OmegaConf.select(cfg, "model.optimizer.lr", default=1e-4)
+                    )
+                    groups = param_groups_fn(base_lr=base_lr)
+                except TypeError:
+                    # Method exists but doesn't accept base_lr — skip.
+                    groups = None
+
+            params_arg = (
+                groups if groups is not None else self.trainer.model.parameters()
+            )
             optimizer = hydra.utils.instantiate(
                 cfg.model.optimizer,
-                params=self.trainer.model.parameters(),
+                params=params_arg,
             )
             if callable(optimizer):
                 optimizer = optimizer()
@@ -287,7 +306,8 @@ class ModelWrapper(LightningModule):
             )
             torch.distributed.barrier()
             print(
-                f"Rank {self.global_rank} on fit start, all ranks synchronized", flush=True
+                f"Rank {self.global_rank} on fit start, all ranks synchronized",
+                flush=True,
             )
 
     def on_train_epoch_start(self):

--- a/egomimic/rldb/embodiment/pushshapes.py
+++ b/egomimic/rldb/embodiment/pushshapes.py
@@ -52,14 +52,21 @@ def get_keymap(action_horizon: int = 32, **kwargs) -> dict:
     and ignored so that norm-stat collection doesn't crash by passing
     sentinel keys through to the inner key_map iteration.
     """
+    # Per-frame obs (obs_t aligned with action_t): give the obs keys the same
+    # horizon as actions so the dataloader returns (T, ...) windows rather than
+    # a single broadcast frame. CondEncoderModule.encode then skips its
+    # unsqueeze-and-expand branch (kicks in only when x.dim()==2 for state /
+    # ==4 for images), and AdaLN sees a true per-token cond.
     return {
         "front_img_1": {
             "key_type": "camera_keys",
             "zarr_key": "observations.images.front_img_1",
+            "horizon": int(action_horizon),
         },
         "state_agent_obj": {
             "key_type": "proprio_keys",
             "zarr_key": "observations.state",
+            "horizon": int(action_horizon),
         },
         "actions": {
             "key_type": "action_keys",

--- a/egomimic/rldb/zarr/zarr_dataset_multi.py
+++ b/egomimic/rldb/zarr/zarr_dataset_multi.py
@@ -879,12 +879,27 @@ class MultiDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def _iter_leaves(ds):
-        """Yield non-MultiDataset leaves from possibly nested wrappers."""
+        """Yield non-MultiDataset leaves from possibly nested wrappers.
+
+        Also descends into ``ZarrEpisodePackedDataset``, which owns the same
+        ``dict[str, ZarrDataset]`` shape as ``MultiDataset.datasets``. The
+        leaves carry ``.embodiment`` / ``.key_map`` and that's what
+        ``populate_from_datasets`` probes.
+        """
         if isinstance(ds, MultiDataset):
             for child in ds.datasets.values():
                 yield from MultiDataset._iter_leaves(child)
-        else:
-            yield ds
+            return
+        # Lazy import to avoid cycle.
+        from egomimic.rldb.zarr.zarr_dataset_packed import (
+            ZarrEpisodePackedDataset as _ZEP,
+        )
+
+        if isinstance(ds, _ZEP):
+            for child in ds.datasets.values():
+                yield from MultiDataset._iter_leaves(child)
+            return
+        yield ds
 
     def populate_from_datasets(self, datasets: dict | None = None) -> None:
         """
@@ -893,6 +908,10 @@ class MultiDataset(torch.utils.data.Dataset):
         ``self.datasets`` so the typical call is just ``mds.populate_from_datasets()``.
         """
         graph = datasets if datasets is not None else self.datasets
+        # Leaves under the same wrapper share the same embodiment / key_map,
+        # so probing one is enough — the rest produce identical info and
+        # ``leaf[0]`` is expensive (JPEG decode + horizon-window read).
+        probed_embodiments: set = set()
         for ds in graph.values():
             for leaf in self._iter_leaves(ds):
                 emb = getattr(leaf, "embodiment", None)
@@ -900,6 +919,9 @@ class MultiDataset(torch.utils.data.Dataset):
                 if emb is None or key_map is None:
                     continue
                 emb_id = emb if isinstance(emb, int) else get_embodiment_id(emb)
+                if emb_id in probed_embodiments:
+                    continue
+                probed_embodiments.add(emb_id)
                 self.embodiments.add(emb_id)
                 self.key_types.setdefault(emb_id, {})
                 self.zarr_keys.setdefault(emb_id, {})
@@ -1024,24 +1046,47 @@ class MultiDataset(torch.utils.data.Dataset):
                 )
                 return
 
+        # Packed datasets return variable-length per-episode tensors; default
+        # collate would torch.stack them and crash. Use pack_collate when the
+        # dataset is a ``ZarrEpisodePackedDataset``; in that case n_samples is
+        # interpreted as frames (since each packed batch contributes many
+        # frames at once via ``batch[zarr_key].shape[0] == T_total``).
+        from egomimic.rldb.zarr.zarr_dataset_packed import (
+            ZarrEpisodePackedDataset,
+            pack_collate,
+        )
+
+        is_packed = isinstance(dataset, ZarrEpisodePackedDataset)
+        collate_fn = pack_collate if is_packed else None
+
         loader = torch.utils.data.DataLoader(
             dataset,
             batch_size=batch_size,
             num_workers=num_workers,
             shuffle=True,
             generator=torch.Generator().manual_seed(seed),
+            collate_fn=collate_fn,
         )
         N = len(dataset)
         if N <= 0:
             raise ValueError("Dataset is empty")
-        n_samples = int(math.ceil(sample_frac * N))
-        n_samples = max(1, min(n_samples, N))
+        if is_packed:
+            # Frames, not episodes — sample_frac applies to the full frame budget.
+            total_frames = sum(end - start for _key, start, end in dataset.index)
+            n_samples = int(math.ceil(sample_frac * total_frames))
+            n_samples = max(1, min(n_samples, total_frames))
+        else:
+            n_samples = int(math.ceil(sample_frac * N))
+            n_samples = max(1, min(n_samples, N))
         if max_samples is not None:
             n_samples = min(n_samples, max_samples)
 
         logger.info(f"[MultiDataset] embodiment={embodiment} norm_keys={norm_keys}")
+        unit = "frames" if is_packed else "samples"
+        denom = total_frames if is_packed else N
         logger.info(
-            f"[MultiDataset] sampling {n_samples}/{N} (~{100 * sample_frac:.1f}%)"
+            f"[MultiDataset] sampling {n_samples}/{denom} {unit} "
+            f"(~{100 * sample_frac:.1f}%)"
         )
 
         loading_start = time.time()
@@ -1604,12 +1649,25 @@ class ZarrDataset(torch.utils.data.Dataset):
                 if zarr_key in self._image_keys:
                     jpeg_bytes = data[k]
                     try:
-                        decoded = simplejpeg.decode_jpeg(jpeg_bytes, colorspace="RGB")
+                        if horizon is not None and horizon > 1:
+                            # Windowed image read: jpeg_bytes is an array of
+                            # per-frame JPEG buffers. Decode each frame
+                            # individually (simplejpeg can't vectorize across
+                            # the buffer-array dtype). Matches _read_span.
+                            frames = []
+                            for buf in jpeg_bytes:
+                                decoded = simplejpeg.decode_jpeg(buf, colorspace="RGB")
+                                frames.append(np.transpose(decoded, (2, 0, 1)) / 255.0)
+                            data[k] = np.stack(frames, axis=0)
+                        else:
+                            decoded = simplejpeg.decode_jpeg(
+                                jpeg_bytes, colorspace="RGB"
+                            )
+                            data[k] = np.transpose(decoded, (2, 0, 1)) / 255.0
                     except Exception:
                         idx = _next("JPEG decode failed", key=k)
                         retry = True
                         break
-                    data[k] = np.transpose(decoded, (2, 0, 1)) / 255.0
                 elif zarr_key in self._json_keys:
                     if isinstance(data[k], np.ndarray):
                         data[k] = [self._decode_json_entry(v) for v in data[k]]

--- a/egomimic/rldb/zarr/zarr_dataset_packed.py
+++ b/egomimic/rldb/zarr/zarr_dataset_packed.py
@@ -195,6 +195,25 @@ class ZarrEpisodePackedDataset(Dataset):
         )
 
     # ------------------------------------------------------------------ #
+    # Norm-stat plumbing (trainHydra parity with MultiDataset)
+    # ------------------------------------------------------------------ #
+
+    def set_norm_stats_from(self, source) -> None:
+        """No-op compatibility hook.
+
+        ``MultiDataset.set_norm_stats_from`` wires per-key normalization
+        stats into the dataset so that ``__getitem__`` normalizes at read
+        time. The packed dataset deliberately keeps reads raw — normalization
+        for the algo's packed batches happens algo-side in
+        ``HNet.process_batch_for_training`` via ``norm_stats.normalize(...)``.
+
+        Implemented as a no-op so trainHydra's
+        ``for ds in datasets: ds.set_norm_stats_from(norm_stats)`` loop runs
+        uniformly across padded and packed datasets.
+        """
+        return None
+
+    # ------------------------------------------------------------------ #
     # Dataset protocol
     # ------------------------------------------------------------------ #
 


### PR DESCRIPTION
Packed-mode plumbing across the full stack so trainHydra can train H-Net
on full pushshapes episodes via cu_seqlens batching.

algo (egomimic/algo/hnet.py)
  - Remove legacy data_schematic param; use norm_stats (MultiDataset)
    for per-feature normalize/unnormalize and key topology.
  - Add HNetPolicy.forward_packed: per-sub-sequence BOS shift,
    per-sub-sequence pos_emb indexing, packed cond encoding.
  - Add HNet._ar_rollout_packed: per-episode policy.generate at exactly
    T_ep steps; results padded back to (B, T_max, action_dim).
  - process_batch_for_training detects packed batches via cu_seqlens
    and forwards meta keys unchanged.
  - forward_training / forward_eval dispatch on _packed.
  - HNetPolicy.generate gains optional T arg.
  - Wire chunk_stats_from_aux through compute_losses so avg_chunk_len /
    boundary_rate surface alongside losses.
  - bf16 dtype fixes in forward_packed (bos / pos_emb casts).
  - Training recipe opt-in knobs (default OFF): init_weights_range,
    lr_multipliers, use_parameter_groups, weight_decay. Algo exposes
    parameter_groups(base_lr) for the optimizer hook.

stage tree (egomimic/models/hnet_nets/{context,hnet,stages,routing}.py)
  - HNetContext gains cu_seqlens / max_seqlen + .packed property.
  - Each stage's forward branches on ctx.packed; ChunkerStage saves and
    restores ctx around the inner_stage call with chunked-space
    cu_seqlens.
  - Add apply_optimization_params, HNet.init_weights (1/sqrt(n_residuals)
    on out_proj/fc2), HNet.apply_lr_multiplier, HNet.parameter_groups.
  - Add chunk_stats_from_aux helper.
  - bf16 dtype fix in DeChunkLayer.step.

data path (egomimic/rldb/{zarr,embodiment})
  - ZarrDataset.__getitem__ loops per-frame on JPEG decode when
    horizon>1 on an image key (single-shot decode_jpeg crashed on the
    array of buffers; bounded resample loop then hung 400s).
  - MultiDataset._iter_leaves descends into ZarrEpisodePackedDataset;
    populate_from_datasets probes each embodiment exactly once.
  - MultiDataset.infer_norm_from_dataset uses pack_collate when the
    dataset is packed; sample_frac is now a frame budget.
  - ZarrEpisodePackedDataset.set_norm_stats_from added as no-op for
    trainHydra parity.
  - pushshapes.get_keymap puts horizon on obs keys so the padded path
    serves per-frame obs.

pl_model (egomimic/pl_utils/pl_model.py)
  - configure_optimizers calls algo.parameter_groups(base_lr) when the
    algo exposes it; falls back to flat .parameters().

evaluator (egomimic/eval/eval_hnet.py + configs)
  - HNetEvalVideo: masked MSE over valid positions per episode, viz
    via pushshapes.viz_gt_preds.
  - eval_hnet.yaml + logger/csv.yaml.

Hydra configs
  - tsimulation.yaml: switch to ZarrEpisodePackedDataset.from_resolver
    with chunking="none", batch_size=8, action_horizon=1024 (hard-coded
    in the keymap call since top-level keys hit MultiDataModuleWrapper).
  - hnet_pushshapes.yaml: drop data_schematic interpolation; bump
    action_horizon to 1024; expose training-recipe knobs (all OFF).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>