### PR TITLE
HNet packed training: smoke scripts

### DIFF
--- a/scripts/debug_full_episode_mem.py
+++ b/scripts/debug_full_episode_mem.py
@@ -1,0 +1,373 @@
+"""
+A40 memory probe: packed-mode forward+backward on a single full pushT episode
+through the current H-Net pushshapes arch. No episode chunking
+(``chunking='none'``); the full episode flows as one packed sub-sequence with
+``cu_seqlens=[0, T]``, exercising the new ``ctx.packed`` plumbing through the
+entire stage tree.
+
+What this script does NOT do: go through ``HNetPolicy.forward`` (which is
+still padded-only). The action tokenizer / BOS-shift / pos_emb steps are
+inlined here so the model side of the call sees true packed shapes. This is
+intentional for the probe; the algo-level packed forward is a separate piece
+of plumbing.
+
+Run:
+    python scripts/debug_full_episode_mem.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import zarr
+
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
+from egomimic.models.hnet_nets.context import HNetContext
+from egomimic.models.hnet_nets.hnet import HNet as HNetCore
+from egomimic.models.hnet_nets.hnet import ratio_loss_from_aux
+from egomimic.models.hnet_nets.image_encoders import SimpleConv
+from egomimic.models.hnet_nets.stages import (
+    ChunkerStage,
+    ComputeStage,
+    EncoderDecoderStage,
+)
+from egomimic.rldb.embodiment.pushshapes import get_keymap
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
+DEFAULT_FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets2/circle"
+
+
+def find_longest_episode_len(folder: Path) -> int:
+    best = 0
+    for p in sorted(folder.iterdir()):
+        if not p.name.endswith(".zarr"):
+            continue
+        try:
+            g = zarr.open_group(str(p), mode="r")
+            best = max(best, int(g["actions"].shape[0]))
+        except Exception:
+            continue
+    return best
+
+
+def build_model(d_model: int, d_cond: int, action_dim: int, max_pos: int):
+    """Construct the pushshapes arch: action tokenizer + cond_encoder + HNet.
+
+    Returns (action_in, action_out, bos, pos_emb, cond_encoder, hnet). Kept as
+    individual modules (not a HNetPolicy) so we can drive them in packed mode
+    without going through HNetPolicy.forward (which is padded-only today).
+    """
+    action_in = nn.Linear(action_dim, d_model)
+    action_out = nn.Linear(d_model, action_dim)
+    bos = nn.Parameter(torch.zeros(1, 1, d_model))
+    nn.init.normal_(bos, std=0.02)
+    pos_emb = nn.Parameter(torch.zeros(1, max_pos, d_model))
+    nn.init.normal_(pos_emb, std=0.02)
+
+    img_enc = SimpleConv(
+        in_channels=3,
+        channels=[32, 64, 128, 256],
+        kernel_size=3,
+        stride=2,
+        embed_dim=128,
+        norm_groups=8,
+    )
+    cond_encoder = CondEncoderModule(
+        d_cond=d_cond,
+        obs_specs={"state_agent_obj": dict(input_dim=5, embed_dim=64, widths=[128])},
+        img_encoders={"front_img_1": img_enc},
+        cond_proj_widths=[128, 128],
+        output_key="fused_cond",
+    )
+    hnet = HNetCore(
+        [
+            EncoderDecoderStage(
+                input_hidden_dim=d_model,
+                output_hidden_dim=d_model,
+                encoder=dict(
+                    arch_layout="T4",
+                    d_model=d_model,
+                    d_intermediate=512,
+                    num_heads=4,
+                    cond=True,
+                ),
+                decoder=dict(
+                    arch_layout="T4",
+                    d_model=d_model,
+                    d_intermediate=512,
+                    num_heads=4,
+                    cond=True,
+                ),
+                cond_key="fused_cond",
+                d_cond=d_cond,
+                causal=True,
+            ),
+            ChunkerStage(
+                input_hidden_dim=d_model,
+                output_hidden_dim=192,
+                target_compression_ratio=8.0,
+                ratio_loss_weight=0.03,
+                cond_key="fused_cond",
+            ),
+            ComputeStage(
+                input_hidden_dim=192,
+                output_hidden_dim=192,
+                main_network=dict(
+                    arch_layout="T4",
+                    d_model=192,
+                    d_intermediate=768,
+                    num_heads=4,
+                    cond=False,
+                ),
+                cond_key="fused_cond",
+                d_cond=0,
+                causal=True,
+            ),
+        ]
+    )
+
+    bundle = nn.ModuleDict(
+        {
+            "action_in": action_in,
+            "action_out": action_out,
+            "cond_encoder": cond_encoder,
+            "hnet": hnet,
+        }
+    )
+    bundle.bos = bos
+    bundle.pos_emb = pos_emb
+    return bundle
+
+
+def fmt_mem(n_bytes: int) -> str:
+    return f"{n_bytes / (1024 ** 3):.2f} GiB"
+
+
+def _patch_router_to_all_boundaries(router):
+    """Force every token to be a boundary so the inner ComputeStage sees the
+    full T. This is the worst-case "no compression at all" memory footprint.
+
+    Saves the original forward and returns a function that restores it.
+    """
+
+    from egomimic.models.hnet_nets.routing import RoutingModuleOutput
+
+    original_forward = router.forward
+
+    def forced_forward(
+        hidden_states, cu_seqlens=None, mask=None, inference_params=None
+    ):
+        # Run the real cos-sim so boundary_prob still has gradient flow.
+        out = original_forward(
+            hidden_states,
+            cu_seqlens=cu_seqlens,
+            mask=mask,
+            inference_params=inference_params,
+        )
+        # Override boundary_mask: every position is a boundary.
+        bm = torch.ones_like(out.boundary_mask, dtype=torch.bool)
+        # selected_probs is gathered from boundary_prob along the chosen branch;
+        # forcing all-boundary means we want boundary_prob[..., 1] everywhere.
+        if out.selected_probs.dim() == 3:
+            sp = out.boundary_prob[..., 1:2]
+        else:
+            sp = out.boundary_prob[..., 1:2]
+        return RoutingModuleOutput(
+            boundary_prob=out.boundary_prob,
+            boundary_mask=bm,
+            selected_probs=sp,
+        )
+
+    router.forward = forced_forward
+    return lambda: setattr(router, "forward", original_forward)
+
+
+def _run_one(model, build_inputs, actions_packed, cu, max_seqlen, device, label):
+    """build_inputs() returns (x_packed, cond_packed). Called fresh per run so
+    the input subgraph is rebuilt (otherwise the second .backward() would try
+    to traverse freed tensors from action_in / cond_encoder)."""
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    for p in model.parameters():
+        if p.grad is not None:
+            p.grad = None
+
+    x_packed, cond_packed = build_inputs()
+    ctx = HNetContext(
+        cond_dict=cond_packed,
+        aux=[],
+        inference_params=None,
+        cu_seqlens=cu,
+        max_seqlen=max_seqlen,
+    )
+    t0 = time.perf_counter()
+    h = model["hnet"](x_packed, ctx)
+    pred = model["action_out"](h)
+    torch.cuda.synchronize()
+    fwd_time = time.perf_counter() - t0
+    fwd_peak = torch.cuda.max_memory_allocated()
+
+    bm = ctx.aux[0]["bpred"].boundary_mask
+    boundary_rate = bm.float().mean().item()
+
+    loss = torch.nn.functional.mse_loss(pred, actions_packed) + ratio_loss_from_aux(
+        ctx.aux, device=device
+    )
+
+    t0 = time.perf_counter()
+    loss.backward()
+    torch.cuda.synchronize()
+    bwd_time = time.perf_counter() - t0
+    bwd_peak = torch.cuda.max_memory_allocated()
+
+    print(
+        f"[{label}] boundary_rate={boundary_rate:.3f}  "
+        f"fwd {fwd_time*1000:.0f}ms ({fmt_mem(fwd_peak)})  "
+        f"bwd {bwd_time*1000:.0f}ms ({fmt_mem(bwd_peak)})  "
+        f"loss={loss.item():.3e}"
+    )
+    return fwd_peak, bwd_peak, boundary_rate
+
+
+def main(folder: str = DEFAULT_FOLDER) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    assert device.type == "cuda", "This probe only makes sense on CUDA."
+    folder_path = Path(folder)
+
+    max_len = find_longest_episode_len(folder_path)
+    print(f"[data] folder = {folder_path}")
+    print(f"[data] longest episode = {max_len} frames")
+
+    dataset = ZarrEpisodePackedDataset.from_local_folder(
+        folder_path=str(folder_path),
+        key_map=get_keymap(action_horizon=max_len),
+        max_seq_len=None,
+        chunking="none",
+        transform_list=None,
+    )
+    print(f"[data] dataset entries = {len(dataset)}")
+
+    # Pick the longest entry actually present in the packed-dataset index. The
+    # raw zarr action array can be slightly longer than what the dataset
+    # exposes (the index uses min-length across all key types), so we trust
+    # the dataset's view.
+    lengths = [(end - start, i) for i, (_k, start, end) in enumerate(dataset.index)]
+    lengths.sort(reverse=True)
+    longest_idx = lengths[0][1]
+    print(
+        f"[data] dataset.index longest: {lengths[0][0]} frames " f"(idx={longest_idx})"
+    )
+
+    sample = dataset[longest_idx]
+    batch = pack_collate([sample])
+    cu = batch["cu_seqlens"].to(device)
+    max_seqlen = int(batch["max_seq_len"])
+    T = int(batch["seq_lens"][0].item())
+    print(
+        f"[data] episode '{sample.get('episode_key', '?')}' "
+        f"T={T}, cu_seqlens={cu.tolist()}"
+    )
+
+    # Packed tensors: (T_total, ...). For B=1 single episode T_total == T.
+    actions_packed = batch["actions"].to(device)  # (T, 2)
+    state_packed = batch["state_agent_obj"].float().to(device)  # (T, 5)
+    img_packed = batch["front_img_1"].float().to(device)  # (T, 3, H, W)
+    print(
+        f"[data] actions {tuple(actions_packed.shape)}, "
+        f"state {tuple(state_packed.shape)}, "
+        f"img {tuple(img_packed.shape)}"
+    )
+
+    model = build_model(d_model=128, d_cond=128, action_dim=2, max_pos=T)
+    model = model.to(device).train()
+
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"[model] params = {n_params/1e6:.2f}M")
+    print(
+        f"[device] {torch.cuda.get_device_name(0)} "
+        f"({torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GiB total)"
+    )
+
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    base_mem = torch.cuda.memory_allocated()
+    print(f"[mem] baseline after model+inputs on device: {fmt_mem(base_mem)}")
+
+    def build_inputs():
+        """Per-run input subgraph: action tokenizer + BOS-shift + pos_emb +
+        per-token cond. Called fresh each run so backward doesn't trip on
+        freed saved tensors from a prior call."""
+        a_emb = model["action_in"](actions_packed)  # (T, d_model)
+        bos = model.bos.squeeze(0)  # (1, d_model)
+        x_shifted = torch.cat([bos, a_emb[:-1]], dim=0)  # (T, d_model)
+        pos = model.pos_emb.squeeze(0)[:T]  # (T, d_model)
+        x = x_shifted + pos  # (T, d_model)
+
+        obs_padded = {
+            "state_agent_obj": state_packed.unsqueeze(0),
+            "front_img_1": img_packed.unsqueeze(0),
+        }
+        cond_padded = model["cond_encoder"].encode(obs_padded, T_action=T)
+        cond = {k: v.squeeze(0) for k, v in cond_padded.items()}  # (T, d_cond)
+        return x, cond
+
+    # --- Run 1: default chunker (boundary firing rate depends on init) ---
+    print(f"\n=== T={T}, packed cu_seqlens=[0,{T}] ===")
+    fwd1, bwd1, br1 = _run_one(
+        model,
+        build_inputs,
+        actions_packed,
+        cu,
+        max_seqlen,
+        device,
+        label="default chunker",
+    )
+
+    # --- Run 2: force all-boundaries (worst case: zero compression) ---
+    router = model["hnet"].stages[1].routing_module
+    restore = _patch_router_to_all_boundaries(router)
+    try:
+        fwd2, bwd2, br2 = _run_one(
+            model,
+            build_inputs,
+            actions_packed,
+            cu,
+            max_seqlen,
+            device,
+            label="ALL boundaries (no compression)",
+        )
+    finally:
+        restore()
+
+    print("\n=== SUMMARY (packed, single full episode, no chunking) ===")
+    print(f"T (episode len)       : {T}")
+    print(f"cu_seqlens            : {cu.tolist()}")
+    print(f"params                : {n_params/1e6:.2f}M")
+    print(
+        f"A40 total memory      : "
+        f"{torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GiB"
+    )
+    print("")
+    print("default chunker:")
+    print(f"  boundary rate     : {br1:.3f}  (inner stage sees ~{int(br1*T)} tokens)")
+    print(f"  peak after fwd    : {fmt_mem(fwd1)}")
+    print(f"  peak after bwd    : {fmt_mem(bwd1)}")
+    print("")
+    print("all-boundary worst case (no compression):")
+    print(f"  boundary rate     : {br2:.3f}  (inner stage sees {T} tokens)")
+    print(f"  peak after fwd    : {fmt_mem(fwd2)}")
+    print(f"  peak after bwd    : {fmt_mem(bwd2)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--folder", default=DEFAULT_FOLDER)
+    args = parser.parse_args()
+    main(folder=args.folder)

--- a/scripts/smoke_packed_dataset.py
+++ b/scripts/smoke_packed_dataset.py
@@ -48,7 +48,7 @@ KEY_MAP = {
     },
 }
 
-DATA_FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets/test_demos"
+DATA_FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets2/circle"
 OUT_DIR = Path("./packed_smoke_out")
 N_EPISODES_TO_SAVE_VIDEOS = 2  # cap on per-episode MP4 dumps
 VIDEO_FPS = 30

--- a/scripts/smoke_packed_norm_stats.py
+++ b/scripts/smoke_packed_norm_stats.py
@@ -1,0 +1,77 @@
+"""
+Smoke test: end-to-end norm-stats collection from the packed pushshapes
+dataset, mirroring what trainHydra runs at startup.
+
+Verifies that:
+  - MultiDataset._iter_leaves descends into ZarrEpisodePackedDataset.
+  - populate_from_datasets registers the pushshapes_sim key types.
+  - infer_norm_from_dataset uses pack_collate (default_collate would crash
+    on variable-length episodes) and reinterprets sample_frac as a frame
+    count in packed mode.
+
+Run:
+    python scripts/smoke_packed_norm_stats.py
+"""
+
+import logging
+import sys
+import time
+
+from egomimic.rldb.embodiment.pushshapes import get_keymap
+from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset
+from egomimic.rldb.zarr.zarr_dataset_packed import ZarrEpisodePackedDataset
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", stream=sys.stderr)
+
+
+def main():
+    t0 = time.perf_counter()
+    ds = ZarrEpisodePackedDataset.from_local_folder(
+        folder_path="/coc/cedarp-dxu345-0/Tsim_datasets2/circle",
+        key_map=get_keymap(action_horizon=1024),
+        max_seq_len=None,
+        chunking="none",
+        min_seq_len=64,
+        transform_list=None,
+    )
+    print(
+        f"[1] dataset: {len(ds)} entries  ({time.perf_counter()-t0:.1f}s)", flush=True
+    )
+
+    t0 = time.perf_counter()
+    norm_stats = MultiDataset(state={}, norm_mode="quantile")
+    norm_stats.populate_from_datasets({"pushshapes_sim": ds})
+    print(
+        f"[2] populate: key_types={dict(norm_stats.key_types)}  "
+        f"({time.perf_counter()-t0:.1f}s)",
+        flush=True,
+    )
+
+    t0 = time.perf_counter()
+    norm_stats.infer_shapes_from_batch(ds[0])
+    print(f"[3] infer_shapes done  ({time.perf_counter()-t0:.1f}s)", flush=True)
+
+    t0 = time.perf_counter()
+    norm_stats.infer_norm_from_dataset(
+        ds,
+        "pushshapes_sim",
+        sample_frac=0.05,
+        num_workers=0,
+        batch_size=4,
+    )
+    print(f"[4] infer_norm done  ({time.perf_counter()-t0:.1f}s)", flush=True)
+
+    print()
+    print("=== Collected stats ===")
+    for emb_id, by_key in norm_stats.norm_stats.items():
+        if not by_key:
+            continue
+        print(f"emb={emb_id}")
+        for k, stats in by_key.items():
+            mean = list(round(float(x), 3) for x in stats["mean"].ravel())
+            std = list(round(float(x), 3) for x in stats["std"].ravel())
+            print(f"  {k:25s}  mean={mean}  std={std}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_packed_training.py
+++ b/scripts/smoke_packed_training.py
@@ -1,0 +1,223 @@
+"""
+End-to-end smoke test for packed training of the H-Net pushshapes policy.
+
+Builds the packed dataset + dataloader directly (skipping Lightning and the
+data_schematic normalization layer for simplicity), then runs one batch
+through ``HNetPolicy.forward_packed`` + MSE + ratio loss + backward, and
+reports memory + boundary stats.
+
+This is the assertion that the new packed plumbing works end-to-end:
+    [packed dataset] -> pack_collate -> forward_packed -> backward.
+
+Run:
+    python scripts/smoke_packed_training.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+from torch.utils.data import DataLoader
+
+from egomimic.algo.hnet import HNetPolicy
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
+from egomimic.models.hnet_nets.hnet import (
+    HNet as HNetCore,
+)
+from egomimic.models.hnet_nets.hnet import (
+    chunk_stats_from_aux,
+    ratio_loss_from_aux,
+)
+from egomimic.models.hnet_nets.image_encoders import SimpleConv
+from egomimic.models.hnet_nets.stages import (
+    ChunkerStage,
+    ComputeStage,
+    EncoderDecoderStage,
+)
+from egomimic.rldb.embodiment.pushshapes import get_keymap
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
+FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets2/circle"
+BATCH_SIZE = 8
+ACTION_HORIZON = 1024  # >= longest episode (958 frames in this dataset)
+D_MODEL = 128
+D_COND = 128
+
+
+def build_policy() -> HNetPolicy:
+    img_enc = SimpleConv(
+        in_channels=3,
+        channels=[32, 64, 128, 256],
+        kernel_size=3,
+        stride=2,
+        embed_dim=128,
+        norm_groups=8,
+    )
+    cond_encoder = CondEncoderModule(
+        d_cond=D_COND,
+        obs_specs={"state_agent_obj": dict(input_dim=5, embed_dim=64, widths=[128])},
+        img_encoders={"front_img_1": img_enc},
+        cond_proj_widths=[128, 128],
+        output_key="fused_cond",
+    )
+    hnet = HNetCore(
+        [
+            EncoderDecoderStage(
+                input_hidden_dim=D_MODEL,
+                output_hidden_dim=D_MODEL,
+                encoder=dict(
+                    arch_layout="T4",
+                    d_model=D_MODEL,
+                    d_intermediate=512,
+                    num_heads=4,
+                    cond=True,
+                ),
+                decoder=dict(
+                    arch_layout="T4",
+                    d_model=D_MODEL,
+                    d_intermediate=512,
+                    num_heads=4,
+                    cond=True,
+                ),
+                cond_key="fused_cond",
+                d_cond=D_COND,
+                causal=True,
+            ),
+            ChunkerStage(
+                input_hidden_dim=D_MODEL,
+                output_hidden_dim=192,
+                target_compression_ratio=8.0,
+                ratio_loss_weight=0.03,
+                cond_key="fused_cond",
+            ),
+            ComputeStage(
+                input_hidden_dim=192,
+                output_hidden_dim=192,
+                main_network=dict(
+                    arch_layout="T4",
+                    d_model=192,
+                    d_intermediate=768,
+                    num_heads=4,
+                    cond=False,
+                ),
+                cond_key="fused_cond",
+                d_cond=0,
+                causal=True,
+            ),
+        ]
+    )
+    return HNetPolicy(
+        action_dim=2,
+        action_horizon=ACTION_HORIZON,
+        d_model=D_MODEL,
+        cond_encoder=cond_encoder,
+        hnet=hnet,
+    )
+
+
+def fmt_mem(n: int) -> str:
+    return f"{n / 1024**3:.2f} GiB"
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    assert device.type == "cuda", "Packed training smoke needs CUDA."
+
+    dataset = ZarrEpisodePackedDataset.from_local_folder(
+        folder_path=FOLDER,
+        key_map=get_keymap(action_horizon=ACTION_HORIZON),
+        max_seq_len=None,
+        chunking="none",
+        min_seq_len=64,
+        transform_list=None,
+    )
+    print(f"[data] dataset entries = {len(dataset)}")
+
+    loader = DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+        collate_fn=pack_collate,
+        num_workers=0,
+    )
+    batch = next(iter(loader))
+    cu = batch["cu_seqlens"]
+    seq_lens = batch["seq_lens"]
+    max_seqlen = int(batch["max_seq_len"])
+    print(
+        f"[batch] B={BATCH_SIZE}  seq_lens={seq_lens.tolist()}  "
+        f"max_seqlen={max_seqlen}  T_total={int(cu[-1])}"
+    )
+
+    actions_packed = batch["actions"].to(device)  # (T_total, 2)
+    obs_packed = {
+        "state_agent_obj": batch["state_agent_obj"].float().to(device),  # (T_total, 5)
+        "front_img_1": batch["front_img_1"].float().to(device),  # (T_total, 3, H, W)
+    }
+    cu = cu.to(device)
+
+    policy = build_policy().to(device).train()
+    n_params = sum(p.numel() for p in policy.parameters())
+    print(f"[model] params = {n_params/1e6:.2f}M, action_horizon = {ACTION_HORIZON}")
+    print(
+        f"[device] {torch.cuda.get_device_name(0)} "
+        f"({torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GiB)"
+    )
+
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+
+    t0 = time.perf_counter()
+    pred, aux = policy.forward_packed(actions_packed, obs_packed, cu, max_seqlen)
+    torch.cuda.synchronize()
+    fwd_time = time.perf_counter() - t0
+    fwd_peak = torch.cuda.max_memory_allocated()
+    print(
+        f"[forward] pred {tuple(pred.shape)}  time {fwd_time*1000:.0f} ms  "
+        f"peak {fmt_mem(fwd_peak)}"
+    )
+
+    stats = chunk_stats_from_aux(aux)
+    print(
+        f"[chunker] boundary_rate={stats['boundary_rate']:.3f}  "
+        f"avg_chunk_len={stats['avg_chunk_len']:.1f}  "
+        f"(target avg_chunk_len = 8.0)"
+    )
+
+    mse = torch.nn.functional.mse_loss(pred, actions_packed)
+    rloss = ratio_loss_from_aux(aux, device=device)
+    loss = mse + rloss
+    print(
+        f"[loss] mse={mse.item():.3e}  ratio={rloss.item():.4f}  total={loss.item():.3e}"
+    )
+
+    t0 = time.perf_counter()
+    loss.backward()
+    torch.cuda.synchronize()
+    bwd_time = time.perf_counter() - t0
+    bwd_peak = torch.cuda.max_memory_allocated()
+    print(f"[backward] time {bwd_time*1000:.0f} ms  peak {fmt_mem(bwd_peak)}")
+
+    # Sanity: every parameter that received gradient should be finite.
+    for n, p in policy.named_parameters():
+        if p.grad is None:
+            continue
+        if not torch.isfinite(p.grad).all():
+            print(f"[bad-grad] {n}")
+            return
+    print(
+        f"[grad] all finite (covered {sum(1 for _, p in policy.named_parameters() if p.grad is not None)} params)"
+    )
+    print("\n=== SMOKE PASSED ===")
+    print(
+        f"B={BATCH_SIZE}, T_total={int(cu[-1])}, peak={fmt_mem(bwd_peak)} "
+        f"(A40 {torch.cuda.get_device_properties(0).total_memory / 1024**3:.0f} GiB)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_packed_training_e2e.py
+++ b/scripts/smoke_packed_training_e2e.py
@@ -1,0 +1,259 @@
+"""
+End-to-end packed training smoke through the actual algo path.
+
+Unlike ``smoke_packed_training.py`` (which calls ``HNetPolicy.forward_packed``
+directly), this script wires the full Lightning-style flow:
+
+    pack_collate -> HNet.process_batch_for_training (incl. normalize via
+    norm_stats) -> HNet.forward_training -> HNet.compute_losses -> backward.
+
+This is the assertion that the legacy ``data_schematic`` removal didn't break
+anything: ``process_batch_for_training`` now resolves keys via
+``norm_stats.zarr_key_to_keyname`` and normalization runs via
+``norm_stats.normalize`` (per-feature, packed-shape-safe).
+
+Run:
+    python scripts/smoke_packed_training_e2e.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import torch
+from torch.utils.data import DataLoader
+
+from egomimic.algo.hnet import HNet as HNetAlgo
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
+from egomimic.models.hnet_nets.hnet import (
+    HNet as HNetCore,
+)
+from egomimic.models.hnet_nets.image_encoders import SimpleConv
+from egomimic.models.hnet_nets.stages import (
+    ChunkerStage,
+    ComputeStage,
+    EncoderDecoderStage,
+)
+from egomimic.rldb.embodiment.pushshapes import get_keymap
+from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
+FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets2/circle"
+BATCH_SIZE = 4  # smaller than smoke_packed_training to keep this snappy
+ACTION_HORIZON = 1024
+
+
+def _build_hnet_core(d_model: int, d_cond: int) -> HNetCore:
+    return HNetCore(
+        [
+            EncoderDecoderStage(
+                input_hidden_dim=d_model,
+                output_hidden_dim=d_model,
+                encoder=dict(
+                    arch_layout="T2",
+                    d_model=d_model,
+                    d_intermediate=256,
+                    num_heads=4,
+                    cond=True,
+                ),
+                decoder=dict(
+                    arch_layout="T2",
+                    d_model=d_model,
+                    d_intermediate=256,
+                    num_heads=4,
+                    cond=True,
+                ),
+                cond_key="fused_cond",
+                d_cond=d_cond,
+                causal=True,
+            ),
+            ChunkerStage(
+                input_hidden_dim=d_model,
+                output_hidden_dim=d_model,
+                target_compression_ratio=8.0,
+                ratio_loss_weight=0.03,
+                cond_key="fused_cond",
+            ),
+            ComputeStage(
+                input_hidden_dim=d_model,
+                output_hidden_dim=d_model,
+                main_network=dict(
+                    arch_layout="T2",
+                    d_model=d_model,
+                    d_intermediate=256,
+                    num_heads=4,
+                    cond=False,
+                ),
+                cond_key="fused_cond",
+                d_cond=0,
+                causal=True,
+            ),
+        ]
+    )
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    assert device.type == "cuda", "Packed training smoke needs CUDA."
+
+    # 1. Build the packed dataset + dataloader (what tsimulation.yaml resolves to).
+    t0 = time.perf_counter()
+    dataset = ZarrEpisodePackedDataset.from_local_folder(
+        folder_path=FOLDER,
+        key_map=get_keymap(action_horizon=ACTION_HORIZON),
+        max_seq_len=None,
+        chunking="none",
+        min_seq_len=64,
+        transform_list=None,
+    )
+    print(f"[data] dataset entries = {len(dataset)}  ({time.perf_counter()-t0:.1f}s)")
+
+    # 2. Build the norm_stats (mirrors trainHydra: populate -> infer_shapes ->
+    #    infer_norm). With our fixes, this works on packed datasets.
+    t0 = time.perf_counter()
+    norm_stats = MultiDataset(state={}, norm_mode="quantile")
+    norm_stats.populate_from_datasets({"pushshapes_sim": dataset})
+    norm_stats.infer_shapes_from_batch(dataset[0])
+    norm_stats.infer_norm_from_dataset(
+        dataset,
+        "pushshapes_sim",
+        sample_frac=0.05,
+        num_workers=0,
+        batch_size=4,
+    )
+    # Crucial: trainHydra also calls set_norm_stats_from so the training
+    # MultiDataset sees the stats. ZarrEpisodePackedDataset doesn't have that
+    # method (normalization runs on the algo side, not at dataset __getitem__),
+    # so we just hand norm_stats to the algo directly.
+    print(f"[norm_stats] populated  ({time.perf_counter()-t0:.1f}s)")
+    for emb_id, by_key in norm_stats.norm_stats.items():
+        if by_key:
+            for k, stats in by_key.items():
+                print(f"  emb{emb_id} {k:25s} mean={list(stats['mean'].round(2))}")
+
+    loader = DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+        collate_fn=pack_collate,
+        num_workers=0,
+    )
+
+    # 3. Build the algo (HNet), passing norm_stats — mirrors pl_model.
+    img_enc = SimpleConv(
+        in_channels=3,
+        channels=[32, 64, 128, 256],
+        kernel_size=3,
+        stride=2,
+        embed_dim=128,
+        norm_groups=8,
+    )
+    cond_encoder = CondEncoderModule(
+        d_cond=128,
+        obs_specs={"state_agent_obj": dict(input_dim=5, embed_dim=64, widths=[128])},
+        img_encoders={"front_img_1": img_enc},
+        cond_proj_widths=[128, 128],
+        output_key="fused_cond",
+    )
+    algo = HNetAlgo(
+        action_dim=2,
+        action_horizon=ACTION_HORIZON,
+        d_model=128,
+        d_cond=128,
+        cond_encoder=cond_encoder,
+        hnet=_build_hnet_core(128, 128),
+        norm_stats=norm_stats,
+        domains=["pushshapes_sim"],
+        ac_keys={"pushshapes_sim": "actions"},
+        device=device,
+    )
+    algo.nets.train()
+    n_params = sum(p.numel() for p in algo.nets.parameters())
+    print(f"[algo] params = {n_params/1e6:.2f}M, device = {device}")
+
+    # 4. One training step through the full path.
+    raw_batch = next(iter(loader))
+    print(
+        f"[batch] B={BATCH_SIZE}  seq_lens={raw_batch['seq_lens'].tolist()}  "
+        f"T_total={int(raw_batch['cu_seqlens'][-1])}"
+    )
+
+    # process_batch_for_training expects the dict keyed by embodiment name.
+    batch = {"pushshapes_sim": raw_batch}
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+
+    t0 = time.perf_counter()
+    processed = algo.process_batch_for_training(batch)
+    t_proc = time.perf_counter() - t0
+
+    # Sanity: processed should be keyed by embodiment_id, with packed keys.
+    emb_id = next(iter(processed.keys()))
+    pkeys = set(processed[emb_id].keys())
+    print(
+        f"[process_batch] {t_proc*1000:.0f} ms  "
+        f"emb={emb_id}  keys={sorted(k for k in pkeys if not k.startswith('_'))}"
+    )
+    assert "actions" in pkeys, pkeys
+    assert "state_agent_obj" in pkeys, pkeys
+    assert "front_img_1" in pkeys, pkeys
+    assert "cu_seqlens" in pkeys, pkeys
+    assert processed[emb_id]["_packed"] is True
+
+    # Verify normalization actually happened on actions: mean should be ~0.
+    a_mean = processed[emb_id]["actions"].mean().item()
+    a_std = processed[emb_id]["actions"].std().item()
+    print(
+        f"[normalize] normalized actions  mean={a_mean:.3f}  std={a_std:.3f}  "
+        f"(expect mean ~0, std ~1)"
+    )
+    assert abs(a_mean) < 1.0, f"normalize did nothing? mean={a_mean}"
+
+    t0 = time.perf_counter()
+    predictions = algo.forward_training(processed)
+    torch.cuda.synchronize()
+    t_fwd = time.perf_counter() - t0
+    fwd_peak = torch.cuda.max_memory_allocated()
+
+    avg_len = predictions[f"{emb_id}_avg_chunk_len"].item()
+    boundary_rate = predictions[f"{emb_id}_boundary_rate"].item()
+    print(
+        f"[forward] {t_fwd*1000:.0f} ms  peak={fwd_peak/1024**3:.2f} GiB  "
+        f"avg_chunk_len={avg_len:.1f}  boundary_rate={boundary_rate:.3f}"
+    )
+
+    losses = algo.compute_losses(predictions, processed)
+    print(f"[losses] keys: {[k for k in losses.keys() if not k.startswith('_')][:6]}")
+    total = losses["action_loss"]
+    print(
+        f"  action_loss={total.item():.4f}  "
+        f"(includes ratio_loss + mse averaged across embodiments)"
+    )
+
+    t0 = time.perf_counter()
+    total.backward()
+    torch.cuda.synchronize()
+    t_bwd = time.perf_counter() - t0
+    bwd_peak = torch.cuda.max_memory_allocated()
+    n_with_grad = sum(1 for p in algo.nets.parameters() if p.grad is not None)
+    print(
+        f"[backward] {t_bwd*1000:.0f} ms  peak={bwd_peak/1024**3:.2f} GiB  "
+        f"{n_with_grad} params with grad"
+    )
+
+    for n, p in algo.nets.named_parameters():
+        if p.grad is None:
+            continue
+        if not torch.isfinite(p.grad).all():
+            print(f"[bad-grad] {n}")
+            sys.exit(1)
+
+    print("\n=== END-TO-END SMOKE PASSED ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_packed_validation.py
+++ b/scripts/smoke_packed_validation.py
@@ -1,0 +1,202 @@
+"""
+Validation smoke for packed H-Net training: runs one validation batch through
+``HNet.process_batch_for_training`` + ``HNet.forward_eval`` (per-episode AR
+rollout) + the new ``HNetEvalVideo.compute_metrics_and_viz``. Verifies that
+predicted-vs-GT MSE comes back finite, viz images are produced, and the
+graph doesn't crash on packed obs.
+
+Per-episode AR rollout uses ``policy.generate(..., T=T_ep)`` for each
+sub-sequence in the pack. With B=2 short-ish episodes this should finish in
+under a minute on a single A40 even with the pure-Python EMA fallback.
+
+Run:
+    python scripts/smoke_packed_validation.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+from torch.utils.data import DataLoader
+
+from egomimic.algo.hnet import HNet as HNetAlgo
+from egomimic.eval.eval_hnet import HNetEvalVideo
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
+from egomimic.models.hnet_nets.hnet import HNet as HNetCore
+from egomimic.models.hnet_nets.image_encoders import SimpleConv
+from egomimic.models.hnet_nets.stages import (
+    ChunkerStage,
+    ComputeStage,
+    EncoderDecoderStage,
+)
+from egomimic.rldb.embodiment.pushshapes import get_keymap, viz_gt_preds
+from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
+FOLDER = "/coc/cedarp-dxu345-0/Tsim_datasets2/circle"
+BATCH_SIZE = 2  # AR rollout per episode is slow → keep tiny for smoke
+ACTION_HORIZON = 1024
+
+
+def build_algo(norm_stats):
+    img_enc = SimpleConv(
+        in_channels=3,
+        channels=[32, 64, 128, 256],
+        kernel_size=3,
+        stride=2,
+        embed_dim=128,
+        norm_groups=8,
+    )
+    cond_encoder = CondEncoderModule(
+        d_cond=128,
+        obs_specs={"state_agent_obj": dict(input_dim=5, embed_dim=64, widths=[128])},
+        img_encoders={"front_img_1": img_enc},
+        cond_proj_widths=[128, 128],
+        output_key="fused_cond",
+    )
+    hnet = HNetCore(
+        [
+            EncoderDecoderStage(
+                input_hidden_dim=128,
+                output_hidden_dim=128,
+                encoder=dict(
+                    arch_layout="T2",
+                    d_model=128,
+                    d_intermediate=256,
+                    num_heads=4,
+                    cond=True,
+                ),
+                decoder=dict(
+                    arch_layout="T2",
+                    d_model=128,
+                    d_intermediate=256,
+                    num_heads=4,
+                    cond=True,
+                ),
+                cond_key="fused_cond",
+                d_cond=128,
+                causal=True,
+            ),
+            ChunkerStage(
+                input_hidden_dim=128,
+                output_hidden_dim=128,
+                target_compression_ratio=8.0,
+                ratio_loss_weight=0.03,
+                cond_key="fused_cond",
+            ),
+            ComputeStage(
+                input_hidden_dim=128,
+                output_hidden_dim=128,
+                main_network=dict(
+                    arch_layout="T2",
+                    d_model=128,
+                    d_intermediate=256,
+                    num_heads=4,
+                    cond=False,
+                ),
+                cond_key="fused_cond",
+                d_cond=0,
+                causal=True,
+            ),
+        ]
+    )
+    return HNetAlgo(
+        action_dim=2,
+        action_horizon=ACTION_HORIZON,
+        d_model=128,
+        d_cond=128,
+        cond_encoder=cond_encoder,
+        hnet=hnet,
+        norm_stats=norm_stats,
+        domains=["pushshapes_sim"],
+        ac_keys={"pushshapes_sim": "actions"},
+    )
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    assert device.type == "cuda"
+
+    dataset = ZarrEpisodePackedDataset.from_local_folder(
+        folder_path=FOLDER,
+        key_map=get_keymap(action_horizon=ACTION_HORIZON),
+        max_seq_len=None,
+        chunking="none",
+        min_seq_len=64,
+        transform_list=None,
+    )
+    print(f"[data] {len(dataset)} entries")
+
+    norm_stats = MultiDataset(state={}, norm_mode="quantile")
+    norm_stats.populate_from_datasets({"pushshapes_sim": dataset})
+    norm_stats.infer_shapes_from_batch(dataset[0])
+    norm_stats.infer_norm_from_dataset(
+        dataset,
+        "pushshapes_sim",
+        sample_frac=0.02,
+        num_workers=0,
+        batch_size=4,
+    )
+
+    loader = DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=False,
+        collate_fn=pack_collate,
+        num_workers=0,
+    )
+
+    algo = build_algo(norm_stats)
+    algo.nets.eval()
+    print(f"[algo] {sum(p.numel() for p in algo.nets.parameters())/1e6:.2f}M params")
+
+    raw_batch = next(iter(loader))
+    seq_lens = raw_batch["seq_lens"].tolist()
+    print(
+        f"[batch] B={BATCH_SIZE}  seq_lens={seq_lens}  T_total={int(raw_batch['cu_seqlens'][-1])}"
+    )
+
+    batch = {"pushshapes_sim": raw_batch}
+    processed = algo.process_batch_for_training(batch)
+
+    # Build the evaluator (minimal — no Lightning trainer). Plug in the
+    # pushshapes viz function manually since we're not going through Hydra.
+    eval_video = HNetEvalVideo.__new__(HNetEvalVideo)
+    eval_video.trainer = None
+    eval_video.model = algo
+    eval_video.viz_func = {
+        "pushshapes_sim": (lambda preds, batch: viz_gt_preds(preds, batch)),
+    }
+    eval_video.val_image_buffer = {}
+    eval_video.val_counter = {}
+
+    t0 = time.perf_counter()
+    metrics, images_dict = eval_video.compute_metrics_and_viz(processed)
+    elapsed = time.perf_counter() - t0
+    print(f"[eval] {elapsed:.1f}s")
+
+    print("[metrics]")
+    for k, v in metrics.items():
+        val = v.item() if torch.is_tensor(v) else v
+        print(f"  {k:60s} {val:.4f}")
+
+    for emb_id, imgs in images_dict.items():
+        print(f"[viz] emb={emb_id} images shape={imgs.shape} dtype={imgs.dtype}")
+        # Sanity: should be (B, H, W, 3) uint8.
+        assert imgs.ndim == 4 and imgs.shape[-1] == 3
+        assert imgs.dtype.kind == "u" and imgs.dtype.itemsize == 1
+
+    # Sanity: predictions and GT should both be finite.
+    assert all(
+        torch.isfinite(v).all() if torch.is_tensor(v) else True
+        for v in metrics.values()
+    )
+    print("\n=== VALIDATION SMOKE PASSED ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- smoke_packed_dataset.py (updated): ZarrEpisodePackedDataset byte-match
  vs direct zarr reads; writes per-episode MP4s and actions plot with
  cu_seqlens verticals.
- smoke_packed_norm_stats.py (new): end-to-end norm-stats collection
  on the packed dataset (catches _iter_leaves, pack_collate,
  populate_from_datasets bugs).
- smoke_packed_training.py (new): direct fwd+bwd through HNet stage
  tree with a packed batch — bypasses algo, exercises stage plumbing.
- smoke_packed_training_e2e.py (new): goes through algo path
  (process_batch_for_training → forward_training → compute_losses →
  backward); includes normalize.
- smoke_packed_validation.py (new): per-episode AR rollout via
  HNetEvalVideo.compute_metrics_and_viz; metrics + viz frame per ep.
- debug_full_episode_mem.py (new): A40 memory probe — fwd+bwd on
  longest episode (T=958), both default and forced-all-boundary worst
  case. Prints peak GiB.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>