### PR TITLE
HNet variants: delta actions, cross-attn, fused tokens, bigger AdaLN

### DIFF
--- a/egomimic/algo/hnet.py
+++ b/egomimic/algo/hnet.py
@@ -228,6 +228,244 @@ class HNetPolicy(nn.Module):
         return actions
 
 
+class FlatFusedPolicy(nn.Module):
+    """Flat transformer with interleaved [c_t, a_t] tokens.
+
+    Drop-in replacement for ``HNetPolicy`` that bypasses the H-Net stage
+    hierarchy (no chunker, no ratio loss). Each timestep contributes TWO
+    tokens to the input sequence: a cond token and a (shifted) action token.
+    Causal masking means the model predicting ``a_t`` (at sequence position
+    2t+1) has seen ``c_0, BOS, c_1, a_0, c_2, a_1, ..., c_t, a_{t-1}``.
+
+    Input layout (length 2T):
+      x[:, 0]  = cond_in(c_0)         x[:, 1]  = BOS
+      x[:, 2]  = cond_in(c_1)         x[:, 3]  = action_in(a_0)
+      ...
+      x[:, 2t]   = cond_in(c_t)       x[:, 2t+1] = action_in(a_{t-1})
+
+    Output extraction:
+      pred[:, t] = action_out(out[:, 2t+1])
+
+    AR rollout walks the sequence one token at a time (2T model steps for T
+    actions). Each "outer" step emits one action prediction and adds two
+    tokens (the new cond + the new predicted action) to the cache.
+
+    Same ``forward(actions, obs)`` / ``forward_packed(...)`` / ``generate(...)``
+    contracts as ``HNetPolicy`` so the same ``HNet`` algo wrapper consumes
+    it. Aux is always ``[]`` (no chunker contributions).
+    """
+
+    def __init__(
+        self,
+        action_dim: int,
+        action_horizon: int,
+        d_model: int,
+        d_cond: int,
+        cond_encoder: CondEncoderModule,
+        arch_layout: str = "T8",
+        num_heads: int = 4,
+        d_intermediate: int = 512,
+    ):
+        super().__init__()
+        from egomimic.models.hnet_nets.isotropic_builder import build_isotropic
+
+        self.action_dim = action_dim
+        self.action_horizon = action_horizon
+        self.d_model = d_model
+        self.d_cond = d_cond
+        self.cond_encoder = cond_encoder
+
+        self.action_in = nn.Linear(action_dim, d_model)
+        self.action_out = nn.Linear(d_model, action_dim)
+        self.cond_in = nn.Linear(d_cond, d_model)
+        self.bos = nn.Parameter(torch.zeros(1, 1, d_model))
+        nn.init.normal_(self.bos, std=0.02)
+        # pos_emb covers the 2T-token interleaved sequence.
+        self.pos_emb = nn.Parameter(torch.zeros(1, 2 * action_horizon, d_model))
+        nn.init.normal_(self.pos_emb, std=0.02)
+
+        # Single Isotropic stack, causal, no per-block cond (the fusion happens
+        # at the input layer).
+        self.backbone = build_isotropic(
+            {
+                "arch_layout": arch_layout,
+                "d_model": d_model,
+                "d_intermediate": d_intermediate,
+                "num_heads": num_heads,
+                "cond": False,
+            },
+            d_cond=0,
+            causal=True,
+        )
+
+    def _encode_cond(self, obs: dict, T: int) -> torch.Tensor:
+        cond_dict = self.cond_encoder.encode(obs, T)
+        c = cond_dict.get("fused_cond")
+        if c is None:
+            raise KeyError(
+                "FlatFusedPolicy requires 'fused_cond' in cond_encoder output."
+            )
+        return c  # (B, T, d_cond)
+
+    def forward(self, actions: torch.Tensor, obs: dict):
+        """Padded teacher-forced forward.
+
+        actions: (B, T, action_dim)
+        obs:     dict of per-frame (B, T, ...) obs tensors.
+        Returns: (pred (B, T, action_dim), aux=[]).
+        """
+        B, T, _ = actions.shape
+        c = self._encode_cond(obs, T)  # (B, T, d_cond)
+        c_tok = self.cond_in(c)  # (B, T, d_model)
+        a_tok = self.action_in(actions)  # (B, T, d_model)
+        # Shift: BOS at position 0, a_0..a_{T-2} after.
+        a_shifted = torch.cat([self.bos.expand(B, -1, -1), a_tok[:, :-1]], dim=1)
+
+        # Interleave: x[:, 0::2] = c_tok, x[:, 1::2] = a_shifted.
+        x = torch.empty(
+            B, 2 * T, self.d_model, device=actions.device, dtype=a_tok.dtype
+        )
+        x[:, 0::2] = c_tok
+        x[:, 1::2] = a_shifted
+        x = x + self.pos_emb[:, : 2 * T].to(x.dtype)
+
+        x = self.backbone(x)  # (B, 2T, d_model)
+        pred = self.action_out(x[:, 1::2])  # (B, T, action_dim)
+        return pred, []
+
+    def forward_packed(
+        self,
+        actions_packed: torch.Tensor,
+        obs_packed: dict,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+    ):
+        """Packed-mode teacher-forced forward.
+
+        Builds a fused-token packed stream where each sub-sequence ``[s, e)``
+        becomes a length-``2*(e-s)`` interleaved chunk. Returns predictions
+        in packed format ``(T_total, action_dim)`` matching the input
+        ``actions_packed`` layout.
+        """
+        device = actions_packed.device
+        T_total = actions_packed.shape[0]
+        cu_seqlens = cu_seqlens.to(device=device, dtype=torch.long)
+        if max_seqlen > self.action_horizon:
+            raise ValueError(
+                f"max_seqlen={max_seqlen} exceeds action_horizon={self.action_horizon}"
+            )
+
+        # Encode cond. Feed obs as (1, T_total, ...) via cond_encoder.encode.
+        obs_for_encode = {k: v.unsqueeze(0) for k, v in obs_packed.items()}
+        cond_seq = self._encode_cond(obs_for_encode, T_total).squeeze(
+            0
+        )  # (T_total, d_cond)
+        c_tok = self.cond_in(cond_seq)  # (T_total, d_model)
+        a_tok = self.action_in(actions_packed)  # (T_total, d_model)
+
+        # Build BOS-shifted actions per sub-sequence.
+        a_shifted = torch.empty_like(a_tok)
+        bos = self.bos.squeeze(0).squeeze(0).to(a_tok.dtype)  # (d_model,)
+        a_shifted[cu_seqlens[:-1]] = bos
+        # For positions that aren't sub-seq starts, copy a_tok[t-1].
+        non_start = torch.ones(T_total, dtype=torch.bool, device=device)
+        non_start[cu_seqlens[:-1]] = False
+        # Indices of non-start positions:
+        idx_non_start = torch.nonzero(non_start, as_tuple=False).squeeze(-1)
+        a_shifted[idx_non_start] = a_tok[idx_non_start - 1]
+
+        # Build per-sub-seq position indices: 0, 1, ..., (e-s)-1 within each
+        # sub-seq. Then the 2-token interleave doubles to 2*(e-s).
+        pos = torch.arange(T_total, device=device)
+        seq_idx = (pos[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)
+        local_pos = pos - cu_seqlens[seq_idx]  # (T_total,)
+
+        # The interleaved stream has 2T_total tokens. cond_t at 2*local_pos
+        # within each sub-seq; action_t at 2*local_pos+1.
+        # Compute new cu_seqlens for the doubled stream.
+        sub_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+        new_lens = 2 * sub_lens
+        new_cu = torch.zeros(len(cu_seqlens), dtype=torch.long, device=device)
+        new_cu[1:] = torch.cumsum(new_lens, dim=0)
+        new_T_total = int(new_cu[-1].item())
+
+        # Build the packed interleaved stream and apply pos_emb based on
+        # 2*local_pos / 2*local_pos+1.
+        x = torch.empty(new_T_total, self.d_model, device=device, dtype=a_tok.dtype)
+        # For each t, write c_tok[t] at new_cu[seq_idx[t]] + 2*local_pos[t]
+        # and a_shifted[t] at the next position.
+        target_c = new_cu[seq_idx] + 2 * local_pos
+        target_a = target_c + 1
+        x[target_c] = c_tok
+        x[target_a] = a_shifted
+        # pos_emb indexing: doubled local positions within each sub-seq.
+        # pos_emb is (1, 2*action_horizon, d_model). Apply pos_emb[2*local_pos]
+        # to cond positions and pos_emb[2*local_pos+1] to action positions.
+        pos_c = (2 * local_pos).clamp(max=2 * self.action_horizon - 1)
+        pos_a = (2 * local_pos + 1).clamp(max=2 * self.action_horizon - 1)
+        x[target_c] = x[target_c] + self.pos_emb[0, pos_c].to(x.dtype)
+        x[target_a] = x[target_a] + self.pos_emb[0, pos_a].to(x.dtype)
+
+        # Run the backbone on the doubled packed stream.
+        out = self.backbone(
+            x,
+            cu_seqlens=new_cu,
+            max_seqlen=2 * int(max_seqlen),
+        )
+
+        # Predictions: out at action positions (target_a). action_out projects
+        # to (T_total, action_dim). Order matches actions_packed.
+        pred = self.action_out(out[target_a])
+        return pred, []
+
+    @torch.no_grad()
+    def generate(
+        self,
+        obs: dict,
+        batch_size: int,
+        device,
+        T: Optional[int] = None,
+    ) -> torch.Tensor:
+        """AR rollout for T action steps over a 2T-token interleaved stream.
+
+        Each AR outer step does TWO inner step() calls: one for the cond
+        token, one for the (predicted) action token. The output of the
+        action-step is the next action prediction.
+        """
+        if T is None:
+            T = self.action_horizon
+        if T > self.action_horizon:
+            raise ValueError(f"generate T={T} exceeds action_horizon")
+
+        cond_seq = self._encode_cond(obs, T)  # (B, T, d_cond)
+        c_tok = self.cond_in(cond_seq)  # (B, T, d_model)
+        dtype = c_tok.dtype
+
+        # Allocate the backbone's inference cache sized for the doubled stream.
+        params = self.backbone.allocate_inference_cache(
+            batch_size=batch_size,
+            max_seqlen=2 * T,
+            device=device,
+            dtype=dtype,
+        )
+
+        actions = torch.zeros(batch_size, T, self.action_dim, device=device)
+        a_prev = self.bos.expand(batch_size, -1, -1).to(dtype)  # (B, 1, d_model)
+        for t in range(T):
+            # Cond step.
+            x_c = c_tok[:, t : t + 1] + self.pos_emb[:, 2 * t : 2 * t + 1].to(dtype)
+            _ = self.backbone.step(x_c, params)
+            # Action step.
+            x_a = a_prev + self.pos_emb[:, 2 * t + 1 : 2 * t + 2].to(dtype)
+            h = self.backbone.step(x_a, params)
+            a_t = self.action_out(h)  # (B, 1, action_dim)
+            actions[:, t : t + 1] = a_t
+            # Prepare next-step's a_prev (a_t becomes a_{t-1} for the next outer step).
+            a_prev = self.action_in(a_t)
+
+        return actions
+
+
 class HNet(Algo):
     """
     H-Net policy Algo. Single-domain action-sequence model with per-frame
@@ -619,3 +857,92 @@ class HNet(Algo):
                 }
             )
         return groups
+
+
+class HNetFused(HNet):
+    """Flat-transformer (no chunker) variant: interleaved [c_t, a_t] tokens.
+
+    Same Algo contract as :class:`HNet`. Replaces the H-Net stage hierarchy
+    with a single :class:`FlatFusedPolicy` (one Isotropic stack over a 2T
+    interleaved input). ``aux`` is always ``[]`` so ratio_loss is 0 and
+    chunk_stats is empty; logging surfaces only action_loss.
+
+    Reuses HNet's ``process_batch_for_training`` / ``forward_training`` /
+    ``forward_eval`` / ``compute_losses`` / ``log_info`` /
+    ``_ar_rollout_packed`` unchanged because the policy interface matches
+    HNetPolicy verbatim.
+    """
+
+    def __init__(
+        self,
+        action_dim: int,
+        action_horizon: int,
+        d_model: int,
+        d_cond: int,
+        cond_encoder: CondEncoderModule,
+        norm_stats,
+        domains: list = None,
+        ac_keys: dict = None,
+        device=None,
+        arch_layout: str = "T8",
+        num_heads: int = 4,
+        d_intermediate: int = 512,
+        **kwargs,
+    ):
+        # Skip HNet.__init__ — it requires a HNetCore. We re-implement the
+        # tiny init here for the flat path.
+        Algo.__init__(self)
+        self.norm_stats = norm_stats
+        self.domains = list(domains or [])
+        self.ac_keys = dict(ac_keys or {})
+        self.action_horizon = action_horizon
+        self.d_cond = d_cond
+        self.device = device or torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self.use_parameter_groups = False
+        self.lr_multipliers = None
+        self.weight_decay = 0.0
+        self._hnet_core = None
+        self.action_dim = action_dim
+
+        policy = FlatFusedPolicy(
+            action_dim=action_dim,
+            action_horizon=action_horizon,
+            d_model=d_model,
+            d_cond=d_cond,
+            cond_encoder=cond_encoder,
+            arch_layout=arch_layout,
+            num_heads=num_heads,
+            d_intermediate=d_intermediate,
+        )
+        self.nets = nn.ModuleDict({"policy": policy})
+        self.nets = self.nets.float().to(self.device)
+
+        # Replicate HNet's key-resolution loop (norm_stats-based).
+        self.embodiment_ids = {}
+        self.proprio_keys = {}
+        self.lang_keys = {}
+        self.camera_keys = {}
+        self.resolved_ac_keys = {}
+        for emb in self.domains:
+            emb_id = get_embodiment_id(emb)
+            self.embodiment_ids[emb] = emb_id
+            self.proprio_keys[emb_id] = []
+            self.lang_keys[emb_id] = []
+            self.camera_keys[emb_id] = []
+            for key in norm_stats.keys_of_type("action_keys", emb_id):
+                if (
+                    norm_stats.is_key_with_embodiment(key, emb_id)
+                    and key == self.ac_keys[emb]
+                ):
+                    self.resolved_ac_keys[emb_id] = key
+            for key in norm_stats.keys_of_type("proprio_keys", emb_id):
+                if norm_stats.is_key_with_embodiment(key, emb_id):
+                    self.proprio_keys[emb_id].append(key)
+            for key in norm_stats.keys_of_type("lang_keys", emb_id):
+                if norm_stats.is_key_with_embodiment(key, emb_id):
+                    self.lang_keys[emb_id].append(key)
+            for key in norm_stats.keys_of_type("camera_keys", emb_id):
+                if norm_stats.is_key_with_embodiment(key, emb_id):
+                    self.camera_keys[emb_id].append(key)

--- a/egomimic/hydra_configs/data/tsimulation_delta.yaml
+++ b/egomimic/hydra_configs/data/tsimulation_delta.yaml
@@ -1,0 +1,51 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# tsimulation, but with a DeltaAction transform applied to ``actions`` so
+# the model learns per-step deltas (a[t] - a[t-1], a[0] = 0) instead of
+# absolute target positions. Same dataset and shapes as tsimulation.yaml;
+# only difference is the transform_list.
+#
+# Norm stats are recomputed against the delta-transformed actions, so the
+# precomputed_norm_path from absolute-action runs **MUST NOT** be reused
+# with this config (the action range collapses from [0, 511] to ~[-30, 30]).
+
+train_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/cedarp-dxu345-0/Tsim_datasets2/circle
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 1024
+      transform_list:
+        - _target_: egomimic.rldb.zarr.action_chunk_transforms.DeltaAction
+          input_key: actions
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: null
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/cedarp-dxu345-0/Tsim_datasets2/circle
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 1024
+      transform_list:
+        - _target_: egomimic.rldb.zarr.action_chunk_transforms.DeltaAction
+          input_key: actions
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: null
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 8
+    num_workers: 2
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 8
+    num_workers: 2

--- a/egomimic/hydra_configs/model/hnet_pushshapes_big.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_big.yaml
@@ -1,0 +1,94 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.HNet
+
+  # Scaled-up version of hnet_pushshapes.yaml:
+  #   - d_model 128 -> 256, num_heads 4 -> 8
+  #   - d_intermediate (MLP) 512 -> 1024 (enc/dec) and 768 -> 1536 (inner)
+  #   - chunked dim 192 -> 384 (kept proportional, 1.5x of outer)
+  # Expected param count: ~5.7M (baseline) -> ~22M (~4x).
+  action_dim: 2
+  action_horizon: 1024
+  d_model: 256
+  d_cond: 256
+
+  cond_encoder:
+    _target_: egomimic.models.hnet_nets.cond_encoders.CondEncoderModule
+    d_cond: 256
+    output_key: "fused_cond"
+    cond_proj_widths: [256, 256]
+    obs_specs:
+      state_agent_obj:
+        input_dim: 5
+        embed_dim: 128
+        widths: [256]
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv
+        in_channels: 3
+        channels: [32, 64, 128, 256]
+        kernel_size: 3
+        stride: 2
+        embed_dim: 256
+        norm_groups: 8
+
+  hnet:
+    _target_: egomimic.models.hnet_nets.hnet.HNet
+    stages:
+      - _target_: egomimic.models.hnet_nets.stages.EncoderDecoderStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: "fused_cond"
+        d_cond: 256
+        causal: true
+        encoder:
+          arch_layout: "T4"
+          d_model: 256
+          d_intermediate: 1024
+          num_heads: 8
+          cond: true
+        decoder:
+          arch_layout: "T4"
+          d_model: 256
+          d_intermediate: 1024
+          num_heads: 8
+          cond: true
+      - _target_: egomimic.models.hnet_nets.stages.ChunkerStage
+        input_hidden_dim: 256
+        output_hidden_dim: 384
+        target_compression_ratio: 8.0
+        ratio_loss_weight: 0.03
+        cond_key: "fused_cond"
+      - _target_: egomimic.models.hnet_nets.stages.ComputeStage
+        input_hidden_dim: 384
+        output_hidden_dim: 384
+        cond_key: "fused_cond"
+        d_cond: 256
+        causal: true
+        main_network:
+          arch_layout: "T4"
+          d_model: 384
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  init_weights_range: null
+  lr_multipliers: null
+  use_parameter_groups: false
+  weight_decay: 0.0
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/hydra_configs/model/hnet_pushshapes_crossattn.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_crossattn.yaml
@@ -1,0 +1,97 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.HNet
+
+  # Same arch / dims as hnet_pushshapes.yaml; the only difference is the
+  # encoder/decoder use ``cond_mode: cross_attn`` instead of AdaLN. Each
+  # transformer block in the encoder/decoder gets an extra cross-attn
+  # layer (Q from x, K/V from per-frame cond tokens) inserted between
+  # self-attn and the MLP. Causal masking constrains action token t to
+  # attend only to cond_<=t (training) / cond_0..t (AR step via KV cache).
+  action_dim: 2
+  action_horizon: 1024
+  d_model: 128
+  d_cond: 128
+
+  cond_encoder:
+    _target_: egomimic.models.hnet_nets.cond_encoders.CondEncoderModule
+    d_cond: 128
+    output_key: "fused_cond"
+    cond_proj_widths: [128, 128]
+    obs_specs:
+      state_agent_obj:
+        input_dim: 5
+        embed_dim: 64
+        widths: [128]
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv
+        in_channels: 3
+        channels: [32, 64, 128, 256]
+        kernel_size: 3
+        stride: 2
+        embed_dim: 128
+        norm_groups: 8
+
+  hnet:
+    _target_: egomimic.models.hnet_nets.hnet.HNet
+    stages:
+      - _target_: egomimic.models.hnet_nets.stages.EncoderDecoderStage
+        input_hidden_dim: 128
+        output_hidden_dim: 128
+        cond_key: "fused_cond"
+        d_cond: 128
+        causal: true
+        encoder:
+          arch_layout: "T4"
+          d_model: 128
+          d_intermediate: 512
+          num_heads: 4
+          cond: true
+          cond_mode: cross_attn      # <-- cross-attn instead of AdaLN
+        decoder:
+          arch_layout: "T4"
+          d_model: 128
+          d_intermediate: 512
+          num_heads: 4
+          cond: true
+          cond_mode: cross_attn      # <-- cross-attn instead of AdaLN
+      - _target_: egomimic.models.hnet_nets.stages.ChunkerStage
+        input_hidden_dim: 128
+        output_hidden_dim: 192
+        target_compression_ratio: 8.0
+        ratio_loss_weight: 0.03
+        cond_key: "fused_cond"
+      - _target_: egomimic.models.hnet_nets.stages.ComputeStage
+        input_hidden_dim: 192
+        output_hidden_dim: 192
+        cond_key: "fused_cond"
+        d_cond: 128
+        causal: true
+        main_network:
+          arch_layout: "T4"
+          d_model: 192
+          d_intermediate: 768
+          num_heads: 4
+          cond: false         # inner compute is unconditioned (same as baseline)
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  init_weights_range: null
+  lr_multipliers: null
+  use_parameter_groups: false
+  weight_decay: 0.0
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/hydra_configs/model/hnet_pushshapes_fused.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_fused.yaml
@@ -1,0 +1,55 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.HNetFused
+
+  # Fused-tokens variant: flat transformer over an interleaved
+  # [c_0, BOS, c_1, a_0, c_2, a_1, ...] sequence of length 2T. No chunker,
+  # no AdaLN — conditioning is fed in-band as obs tokens. Causal masking +
+  # action_out extraction at odd positions gives the per-step action
+  # predictions.
+  action_dim: 2
+  action_horizon: 1024
+  d_model: 128
+  d_cond: 128
+
+  cond_encoder:
+    _target_: egomimic.models.hnet_nets.cond_encoders.CondEncoderModule
+    d_cond: 128
+    output_key: "fused_cond"
+    cond_proj_widths: [128, 128]
+    obs_specs:
+      state_agent_obj:
+        input_dim: 5
+        embed_dim: 64
+        widths: [128]
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv
+        in_channels: 3
+        channels: [32, 64, 128, 256]
+        kernel_size: 3
+        stride: 2
+        embed_dim: 128
+        norm_groups: 8
+
+  # Flat backbone: 8 transformer layers w/ MLPs (T8). Roughly matches the
+  # encoder+decoder of the baseline (4+4 transformer blocks).
+  arch_layout: "T8"
+  num_heads: 4
+  d_intermediate: 512
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/models/hnet_nets/blocks.py
+++ b/egomimic/models/hnet_nets/blocks.py
@@ -17,9 +17,10 @@ Tensor shape conventions (match upstream):
     Padded mode: (B, L, D) with mask: (B, L).
     Packed mode: (T_total, D) with cu_seqlens: (B+1,) + max_seqlen: int.
 """
+
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -30,6 +31,7 @@ from egomimic.models.hnet_nets.config import HNetConfig, get_stage_cfg
 # Optional flash-attn varlen kernel.
 try:
     from flash_attn import flash_attn_varlen_func  # type: ignore
+
     _HAS_FLASH_ATTN = True
 except Exception:
     flash_attn_varlen_func = None  # type: ignore
@@ -38,6 +40,7 @@ except Exception:
 # Optional Mamba2 SSM block.
 try:
     from mamba_ssm.modules.mamba2 import Mamba2 as _Mamba2  # type: ignore
+
     _HAS_MAMBA = True
 except Exception:
     _Mamba2 = None  # type: ignore
@@ -55,9 +58,10 @@ def has_mamba() -> bool:
 @dataclass
 class KVCache:
     """Per-attention-layer K/V cache with per-batch-element fill counters."""
-    k: torch.Tensor          # (B, num_heads, max_seqlen, head_dim)
-    v: torch.Tensor          # (B, num_heads, max_seqlen, head_dim)
-    offsets: torch.Tensor    # (B,) long
+
+    k: torch.Tensor  # (B, num_heads, max_seqlen, head_dim)
+    v: torch.Tensor  # (B, num_heads, max_seqlen, head_dim)
+    offsets: torch.Tensor  # (B,) long
 
     def reset(self):
         self.k.zero_()
@@ -68,8 +72,9 @@ class KVCache:
 @dataclass
 class MambaCache:
     """Per-SSM-layer state for Mamba2 step inference."""
-    conv_state: torch.Tensor   # (B, conv_dim, d_conv - 1)
-    ssm_state: torch.Tensor    # (B, nheads, headdim, d_state)
+
+    conv_state: torch.Tensor  # (B, conv_dim, d_conv - 1)
+    ssm_state: torch.Tensor  # (B, nheads, headdim, d_state)
 
     def reset(self):
         self.conv_state.zero_()
@@ -82,6 +87,7 @@ LayerCache = Union[KVCache, MambaCache]
 @dataclass
 class IsotropicInferenceParams:
     """One per-layer cache (KV or Mamba) per layer index."""
+
     layer_caches: Dict[int, Any] = field(default_factory=dict)
     max_seqlen: int = 0
     batch_size: int = 0
@@ -169,7 +175,9 @@ class MultiHeadAttention(nn.Module):
             attn_mask = attn_mask & attn_mask.transpose(-1, -2)
 
         out = F.scaled_dot_product_attention(
-            q, k, v,
+            q,
+            k,
+            v,
             attn_mask=attn_mask,
             dropout_p=self.dropout if self.training else 0.0,
             is_causal=self.causal,
@@ -185,13 +193,19 @@ class MultiHeadAttention(nn.Module):
 
         if _HAS_FLASH_ATTN and x.is_cuda:
             cu_q = cu_seqlens.to(torch.int32)
-            ms = int(max_seqlen) if max_seqlen is not None else int(
-                (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
+            ms = (
+                int(max_seqlen)
+                if max_seqlen is not None
+                else int((cu_seqlens[1:] - cu_seqlens[:-1]).max().item())
             )
             out = flash_attn_varlen_func(
-                q, k, v,
-                cu_seqlens_q=cu_q, cu_seqlens_k=cu_q,
-                max_seqlen_q=ms, max_seqlen_k=ms,
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_q,
+                max_seqlen_q=ms,
+                max_seqlen_k=ms,
                 dropout_p=self.dropout if self.training else 0.0,
                 causal=self.causal,
             )
@@ -215,7 +229,10 @@ class MultiHeadAttention(nn.Module):
             attn_mask = same_seq[None, None]
 
         out = F.scaled_dot_product_attention(
-            q_, k_, v_, attn_mask=attn_mask,
+            q_,
+            k_,
+            v_,
+            attn_mask=attn_mask,
             dropout_p=self.dropout if self.training else 0.0,
             is_causal=False,
         )
@@ -225,10 +242,22 @@ class MultiHeadAttention(nn.Module):
 
     def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
         return KVCache(
-            k=torch.zeros(batch_size, self.num_heads, max_seqlen, self.head_dim,
-                          device=device, dtype=dtype),
-            v=torch.zeros(batch_size, self.num_heads, max_seqlen, self.head_dim,
-                          device=device, dtype=dtype),
+            k=torch.zeros(
+                batch_size,
+                self.num_heads,
+                max_seqlen,
+                self.head_dim,
+                device=device,
+                dtype=dtype,
+            ),
+            v=torch.zeros(
+                batch_size,
+                self.num_heads,
+                max_seqlen,
+                self.head_dim,
+                device=device,
+                dtype=dtype,
+            ),
             offsets=torch.zeros(batch_size, device=device, dtype=torch.long),
         )
 
@@ -251,10 +280,132 @@ class MultiHeadAttention(nn.Module):
         attn_mask = pos[None, :] < cache.offsets[:, None]
         attn_mask = attn_mask[:, None, None, :]
 
-        out = F.scaled_dot_product_attention(
-            q, cache.k, cache.v, attn_mask=attn_mask
-        )
+        out = F.scaled_dot_product_attention(q, cache.k, cache.v, attn_mask=attn_mask)
         out = out.transpose(1, 2).reshape(B, 1, D)
+        return self.out_proj(out)
+
+
+class CrossMultiHeadAttention(nn.Module):
+    """Cross-attention: queries from x, keys/values from cond_tokens.
+
+    For our use case, x is the action token sequence (B, T, d_model) and
+    cond_tokens is the per-frame conditioning sequence (B, T, d_cond) — same
+    T, with `cond_t` derived from the obs at step t. ``causal=True`` lets the
+    action token at position t attend only to cond_<=t (matching teacher-
+    forcing semantics in training).
+    """
+
+    def __init__(self, d_model, d_cond, num_heads, causal=False):
+        super().__init__()
+        assert d_model % num_heads == 0
+        self.d_model = d_model
+        self.d_cond = d_cond
+        self.num_heads = num_heads
+        self.head_dim = d_model // num_heads
+        self.causal = causal
+        self.q_proj = nn.Linear(d_model, d_model, bias=True)
+        self.kv_proj = nn.Linear(d_cond, 2 * d_model, bias=True)
+        self.out_proj = nn.Linear(d_model, d_model, bias=True)
+
+    def forward(self, x, cond_tokens, cu_seqlens=None, max_seqlen=None):
+        if cu_seqlens is not None:
+            return self._forward_packed(x, cond_tokens, cu_seqlens, max_seqlen)
+        return self._forward_padded(x, cond_tokens)
+
+    def _forward_padded(self, x, cond_tokens):
+        B, T_q, _ = x.shape
+        T_k = cond_tokens.shape[1]
+        q = (
+            self.q_proj(x)
+            .reshape(B, T_q, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        kv = self.kv_proj(cond_tokens).reshape(B, T_k, 2, self.num_heads, self.head_dim)
+        k, v = kv.unbind(dim=2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        is_causal = self.causal and (T_q == T_k)
+        out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
+        out = out.transpose(1, 2).reshape(B, T_q, self.d_model)
+        return self.out_proj(out)
+
+    def _forward_packed(self, x, cond_tokens, cu_seqlens, max_seqlen):
+        T_total = x.shape[0]
+        q = self.q_proj(x).reshape(T_total, self.num_heads, self.head_dim)
+        kv = self.kv_proj(cond_tokens).reshape(
+            T_total, 2, self.num_heads, self.head_dim
+        )
+        k, v = kv.unbind(dim=1)
+
+        q_ = q.transpose(0, 1).unsqueeze(0)
+        k_ = k.transpose(0, 1).unsqueeze(0)
+        v_ = v.transpose(0, 1).unsqueeze(0)
+
+        pos = torch.arange(T_total, device=x.device)
+        seq_idx = (pos[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)
+        same_seq = seq_idx[:, None] == seq_idx[None, :]
+        if self.causal:
+            causal_mask = pos[:, None] >= pos[None, :]
+            attn_mask = (same_seq & causal_mask)[None, None]
+        else:
+            attn_mask = same_seq[None, None]
+
+        out = F.scaled_dot_product_attention(q_, k_, v_, attn_mask=attn_mask)
+        out = out.squeeze(0).transpose(0, 1).reshape(T_total, self.d_model)
+        return self.out_proj(out)
+
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
+        """Allocate a KV cache for cond-token attention during AR rollout.
+
+        Mirrors ``MultiHeadAttention.allocate_inference_cache`` but the cache
+        accumulates one new K/V pair per AR step (the current step's cond).
+        """
+        return KVCache(
+            k=torch.zeros(
+                batch_size,
+                self.num_heads,
+                max_seqlen,
+                self.head_dim,
+                device=device,
+                dtype=dtype,
+            ),
+            v=torch.zeros(
+                batch_size,
+                self.num_heads,
+                max_seqlen,
+                self.head_dim,
+                device=device,
+                dtype=dtype,
+            ),
+            offsets=torch.zeros(batch_size, device=device, dtype=torch.long),
+        )
+
+    def step(self, x, cond_curr, cache: "KVCache"):
+        """Cross-attn at AR step time, with KV cache.
+
+        ``x``: (B, 1, d_model) — current step's action token (Q source).
+        ``cond_curr``: (B, 1, d_cond) — current step's cond (K/V source).
+        ``cache``: KV cache accumulating one cond token per AR step. The
+        cache is updated in-place; the Q from ``x`` attends against all
+        cached K/V (positions 0..t inclusive).
+        """
+        B = x.shape[0]
+        # Compute K/V from this step's cond and scatter into the cache.
+        kv = self.kv_proj(cond_curr).reshape(B, 1, 2, self.num_heads, self.head_dim)
+        k_new, v_new = kv.unbind(dim=2)  # each (B, 1, H, Dh)
+        batch_idx = torch.arange(B, device=x.device)
+        cache.k[batch_idx, :, cache.offsets] = k_new.squeeze(1).to(cache.k.dtype)
+        cache.v[batch_idx, :, cache.offsets] = v_new.squeeze(1).to(cache.v.dtype)
+        cache.offsets = cache.offsets + 1
+
+        # Q from x, attend against valid cached K/V positions.
+        q = self.q_proj(x).reshape(B, 1, self.num_heads, self.head_dim).transpose(1, 2)
+        max_T = cache.k.shape[2]
+        pos = torch.arange(max_T, device=x.device)
+        attn_mask = (pos[None, :] < cache.offsets[:, None])[:, None, None, :]
+        out = F.scaled_dot_product_attention(q, cache.k, cache.v, attn_mask=attn_mask)
+        out = out.transpose(1, 2).reshape(B, 1, self.d_model)
         return self.out_proj(out)
 
 
@@ -270,48 +421,131 @@ class SwiGLU(nn.Module):
 
 
 class TransformerBlock(nn.Module):
-    """Pre-norm transformer block with optional MLP and optional AdaLN cond."""
+    """Pre-norm transformer block.
 
-    def __init__(self, d_model, num_heads, d_intermediate=0, causal=False, d_cond=0):
+    Conditioning mode (``cond_mode``):
+      - ``"adaln"`` (default): cond is consumed as per-token modulation
+        (scale/shift on each pre-norm output). The block expects ``cond`` to
+        be per-token: (B, T, d_cond) padded or (T_total, d_cond) packed.
+      - ``"cross_attn"``: an extra cross-attention layer between self-attn
+        and the MLP. Queries from x, keys/values from cond tokens. Same
+        per-token shape contract as adaln. ``causal=True`` constrains the
+        action token at position t to attend only to cond_<=t (matching
+        teacher-forcing semantics).
+    """
+
+    def __init__(
+        self,
+        d_model,
+        num_heads,
+        d_intermediate=0,
+        causal=False,
+        d_cond=0,
+        cond_mode: str = "adaln",
+    ):
         super().__init__()
         self.has_mlp = d_intermediate > 0
         self.has_cond = d_cond > 0
         self.causal = causal
+        self.cond_mode = cond_mode if self.has_cond else "none"
+        if self.cond_mode not in ("adaln", "cross_attn", "none"):
+            raise ValueError(f"Unknown cond_mode: {self.cond_mode}")
         self.norm1 = RMSNorm(d_model)
         self.mixer = MultiHeadAttention(d_model, num_heads, causal=causal)
         if self.has_mlp:
             self.norm2 = RMSNorm(d_model)
             self.mlp = SwiGLU(d_model, d_intermediate)
-        if self.has_cond:
+        if self.cond_mode == "adaln":
             self.adaln1 = AdaLNModulation(d_cond, d_model)
             if self.has_mlp:
                 self.adaln2 = AdaLNModulation(d_cond, d_model)
+        elif self.cond_mode == "cross_attn":
+            self.cross_norm = RMSNorm(d_model)
+            self.cross_attn = CrossMultiHeadAttention(
+                d_model=d_model, d_cond=d_cond, num_heads=num_heads, causal=causal
+            )
 
     def forward(self, x, mask=None, cond=None, cu_seqlens=None, max_seqlen=None):
+        # Self-attention.
         h = self.norm1(x)
-        if self.has_cond and cond is not None:
+        if self.cond_mode == "adaln" and cond is not None:
             s, b = self.adaln1(cond)
             h = _adaln(h, s, b)
         x = x + self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
 
+        # Cross-attention (if enabled).
+        if self.cond_mode == "cross_attn" and cond is not None:
+            h = self.cross_norm(x)
+            x = x + self.cross_attn(
+                h, cond, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+
+        # MLP.
         if self.has_mlp:
             h = self.norm2(x)
-            if self.has_cond and cond is not None:
+            if self.cond_mode == "adaln" and cond is not None:
                 s, b = self.adaln2(cond)
                 h = _adaln(h, s, b)
             x = x + self.mlp(h)
         return x
 
-    def step(self, x, cache: KVCache, cond: Optional[torch.Tensor] = None):
+    def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
+        """Allocate self-attn KVCache + (optional) cross-attn KVCache.
+
+        Returns a single cache for ``cond_mode!="cross_attn"`` (matches the
+        upstream single-cache convention); a tuple ``(self_cache,
+        cross_cache)`` when cross-attn is enabled.
+        """
+        self_cache = self.mixer.allocate_inference_cache(
+            batch_size, max_seqlen, device, dtype
+        )
+        if self.cond_mode == "cross_attn":
+            cross_cache = self.cross_attn.allocate_inference_cache(
+                batch_size, max_seqlen, device, dtype
+            )
+            return (self_cache, cross_cache)
+        return self_cache
+
+    def step(self, x, cache, cond: Optional[torch.Tensor] = None):
+        """AR step.
+
+        Cond contract by ``cond_mode``:
+          - ``"adaln"``: cond is (B, d_cond) — current step's cond.
+          - ``"cross_attn"``: cond is (B, 1, d_cond) — current step's cond
+            (the cross_attn block's KV cache accumulates the history).
+
+        Cache contract:
+          - ``"adaln"`` / ``"none"``: cache is the self-attn ``KVCache``.
+          - ``"cross_attn"``: cache is ``(self_cache, cross_cache)``.
+        """
+        if isinstance(cache, tuple):
+            self_cache, cross_cache = cache
+        else:
+            self_cache, cross_cache = cache, None
+
+        # Self-attention.
         h = self.norm1(x)
-        if self.has_cond and cond is not None:
+        if self.cond_mode == "adaln" and cond is not None:
             s, b = self.adaln1(cond)
             h = _adaln(h, s, b)
-        x = x + self.mixer.step(h, cache)
+        x = x + self.mixer.step(h, self_cache)
 
+        # Cross-attention.
+        if self.cond_mode == "cross_attn" and cond is not None:
+            assert (
+                cross_cache is not None
+            ), "cond_mode=cross_attn requires a cross-attn cache"
+            # Accept both (B, d_cond) and (B, 1, d_cond) — the per-step cond
+            # slice from the policy comes through as 2D; cross_attn.step wants
+            # an explicit time dim.
+            cond_curr = cond.unsqueeze(1) if cond.dim() == 2 else cond
+            h = self.cross_norm(x)
+            x = x + self.cross_attn.step(h, cond_curr, cross_cache)
+
+        # MLP.
         if self.has_mlp:
             h = self.norm2(x)
-            if self.has_cond and cond is not None:
+            if self.cond_mode == "adaln" and cond is not None:
                 s, b = self.adaln2(cond)
                 h = _adaln(h, s, b)
             x = x + self.mlp(h)
@@ -370,7 +604,9 @@ class Mamba2Mixer(nn.Module):
 
     def step(self, x, cache: MambaCache):
         # x: (B, 1, D). Mamba2.step returns (out, conv_state, ssm_state).
-        out, conv_state, ssm_state = self.mamba.step(x, cache.conv_state, cache.ssm_state)
+        out, conv_state, ssm_state = self.mamba.step(
+            x, cache.conv_state, cache.ssm_state
+        )
         cache.conv_state.copy_(conv_state)
         cache.ssm_state.copy_(ssm_state)
         return out
@@ -397,8 +633,9 @@ class MambaBlock(nn.Module):
         self.has_mlp = d_intermediate > 0
         self.has_cond = d_cond > 0
         self.norm1 = RMSNorm(d_model)
-        self.mixer = Mamba2Mixer(d_model, layer_idx=layer_idx, ssm_cfg=ssm_cfg,
-                                  device=device, dtype=dtype)
+        self.mixer = Mamba2Mixer(
+            d_model, layer_idx=layer_idx, ssm_cfg=ssm_cfg, device=device, dtype=dtype
+        )
         if self.has_mlp:
             self.norm2 = RMSNorm(d_model)
             self.mlp = SwiGLU(d_model, d_intermediate)
@@ -449,13 +686,19 @@ class Isotropic(nn.Module):
         d_cond: int = 0,
         cond_here: bool = False,
         causal: bool = False,
+        cond_mode: str = "adaln",
     ):
         super().__init__()
         self.stage_idx = stage_idx
         self.d_model = config.d_model[stage_idx]
+        self.cond_mode = cond_mode
         attn_cfg = get_stage_cfg(config.attn_cfg, stage_idx)
         num_heads = attn_cfg.get("num_heads", 8)
-        ssm_cfg = get_stage_cfg(config.ssm_cfg, stage_idx) if hasattr(config, "ssm_cfg") else {}
+        ssm_cfg = (
+            get_stage_cfg(config.ssm_cfg, stage_idx)
+            if hasattr(config, "ssm_cfg")
+            else {}
+        )
 
         layout = config.arch_layout
         for _ in range(stage_idx):
@@ -482,6 +725,7 @@ class Isotropic(nn.Module):
                         d_intermediate=d_int,
                         causal=causal,
                         d_cond=d_cond if cond_here else 0,
+                        cond_mode=cond_mode,
                     )
                 else:  # 'm' or 'M'
                     blk = MambaBlock(
@@ -508,20 +752,34 @@ class Isotropic(nn.Module):
         max_seqlen: Optional[int] = None,
     ):
         for blk in self.layers:
-            x = blk(x, mask=mask, cond=cond, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            x = blk(
+                x, mask=mask, cond=cond, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
         return self.final_norm(x)
 
     def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
         params = IsotropicInferenceParams(
-            layer_caches={}, max_seqlen=max_seqlen, batch_size=batch_size,
+            layer_caches={},
+            max_seqlen=max_seqlen,
+            batch_size=batch_size,
         )
         for i, blk in enumerate(self.layers):
-            params.layer_caches[i] = blk.mixer.allocate_inference_cache(
-                batch_size, max_seqlen, device, dtype
-            )
+            # Prefer block-level allocate (handles both self-attn and
+            # cross-attn caches in one call); fall back to mixer.allocate
+            # for blocks that don't define their own.
+            if hasattr(blk, "allocate_inference_cache"):
+                params.layer_caches[i] = blk.allocate_inference_cache(
+                    batch_size, max_seqlen, device, dtype
+                )
+            else:
+                params.layer_caches[i] = blk.mixer.allocate_inference_cache(
+                    batch_size, max_seqlen, device, dtype
+                )
         return params
 
-    def step(self, x, params: IsotropicInferenceParams, cond: Optional[torch.Tensor] = None):
+    def step(
+        self, x, params: IsotropicInferenceParams, cond: Optional[torch.Tensor] = None
+    ):
         for i, blk in enumerate(self.layers):
             x = blk.step(x, params.layer_caches[i], cond=cond)
         return self.final_norm(x)

--- a/egomimic/models/hnet_nets/isotropic_builder.py
+++ b/egomimic/models/hnet_nets/isotropic_builder.py
@@ -17,7 +17,8 @@ A spec dict looks like::
       "ssm_cfg": {...},          # optional, only used for m/M arch
     }
 """
-from typing import Any, Dict, Optional
+
+from typing import Any, Dict
 
 from egomimic.models.hnet_nets.blocks import Isotropic
 from egomimic.models.hnet_nets.config import AttnConfig, HNetConfig, SSMConfig
@@ -30,14 +31,21 @@ def build_isotropic(
 ) -> Isotropic:
     """Construct an Isotropic stack from a flat spec dict.
 
-    ``d_cond`` is the algo-level conditioning width; AdaLN is wired only when
-    ``spec.get("cond", False)`` is True AND ``d_cond > 0``.
+    ``d_cond`` is the algo-level conditioning width; conditioning is wired
+    only when ``spec.get("cond", False)`` is True AND ``d_cond > 0``.
+
+    ``spec.get("cond_mode", "adaln")`` selects the conditioning mechanism
+    inside each TransformerBlock:
+      - ``"adaln"`` (default): per-token scale/shift modulation.
+      - ``"cross_attn"``: extra cross-attention layer (queries from x,
+        keys/values from cond tokens).
     """
     arch_layout = spec["arch_layout"]
     d_model = int(spec["d_model"])
     d_intermediate = int(spec.get("d_intermediate", 0))
     num_heads = int(spec.get("num_heads", 8))
     cond_here = bool(spec.get("cond", False))
+    cond_mode = str(spec.get("cond_mode", "adaln"))
     ssm_kwargs = spec.get("ssm_cfg", {}) or {}
 
     # Wrap the per-stage scalars into the list-indexed config Isotropic expects.
@@ -55,4 +63,5 @@ def build_isotropic(
         d_cond=d_cond if cond_here else 0,
         cond_here=cond_here,
         causal=causal,
+        cond_mode=cond_mode,
     )

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -366,6 +366,30 @@ class DeleteKeys(Transform):
         return batch
 
 
+class DeltaAction(Transform):
+    """Per-step delta: ``out[t] = arr[t] - arr[t-1]``, with ``out[0] = 0``.
+
+    Operates on any tensor-like ``(T, ...)`` value where time is the leading
+    dim. Used to convert absolute action targets into velocity-style targets
+    so the model learns small smooth quantities. To recover absolute actions
+    at inference, integrate (cumulative sum) the predicted deltas and add the
+    initial state.
+    """
+
+    def __init__(self, input_key: str, output_key: str | None = None):
+        self.input_key = input_key
+        self.output_key = output_key or input_key
+
+    def transform(self, batch: dict) -> dict:
+        arr = np.asarray(batch[self.input_key])
+        delta = np.empty_like(arr)
+        delta[0] = 0
+        if arr.shape[0] > 1:
+            delta[1:] = arr[1:] - arr[:-1]
+        batch[self.output_key] = delta
+        return batch
+
+
 class XYZWXYZ_to_XYZYPR(Transform):
     """Convert listed keys from xyz+quat(wxyz) to xyz+ypr in-place."""
 


### PR DESCRIPTION
Four new variants for ablating the H-Net conditioning architecture on
pushshapes packed training:

1. **Delta actions** (data-side):
   - New ``DeltaAction`` transform that converts absolute action targets
     to per-step deltas (``out[t] = arr[t] - arr[t-1]``, ``out[0] = 0``).
   - New ``data/tsimulation_delta.yaml`` wiring the transform onto the
     packed pushshapes dataset.

2. **Cross-attention** (block-side):
   - New ``CrossMultiHeadAttention`` in ``blocks.py`` — queries from x,
     keys/values from cond tokens. Padded + packed forward + step (with
     its own KV cache that accumulates cond tokens across AR steps).
   - ``TransformerBlock.cond_mode`` selects "adaln" (default) or
     "cross_attn"; the cross-attn variant inserts an extra cross-attn
     layer between self-attn and MLP.
   - ``Isotropic`` threads ``cond_mode`` through to each block;
     ``build_isotropic`` reads it from the spec dict.
   - New ``model/hnet_pushshapes_crossattn.yaml``.

3. **Fused tokens** (policy-side):
   - New ``FlatFusedPolicy`` + ``HNetFused`` algo in ``algo/hnet.py``.
     Bypasses the H-Net stage hierarchy; instead, builds a single causal
     transformer stack and feeds an interleaved sequence
     ``[c_0, BOS, c_1, a_0, c_2, a_1, ...]`` of length 2T. Action
     predictions are extracted from odd positions.
   - Supports forward (padded + packed) and AR generate.
   - New ``model/hnet_pushshapes_fused.yaml``.

4. **Bigger AdaLN** (capacity-only):
   - New ``model/hnet_pushshapes_big.yaml``: same baseline arch but
     d_model 128->256, d_intermediate doubled, num_heads 4->8.

All implementations pass CPU instantiation + forward/generate/packed
smoke tests; the existing 57 hnet_nets unit tests still pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>