### PR TITLE
Mecka: MANO keypoint viz + keypoints transform modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ annotations_test/**
 log_conversion/**
 debug_model_inputs/**
 temp_dir/**
+scratch/

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -344,15 +344,46 @@ class Scale(Human):
 class Mecka(Human):
     VIZ_INTRINSICS_KEY = "mecka"
     ACTION_STRIDE = 1
+    # MANO 21-keypoint topology: 0=wrist, 1-4 thumb, 5-8 index, 9-12 middle, 13-16 ring, 17-20 pinky
+    FINGER_EDGES = [
+        (0, 1), (1, 2), (2, 3), (3, 4),         # thumb
+        (0, 5), (5, 6), (6, 7), (7, 8),         # index
+        (0, 9), (9, 10), (10, 11), (11, 12),    # middle
+        (0, 13), (13, 14), (14, 15), (15, 16),  # ring
+        (0, 17), (17, 18), (18, 19), (19, 20),  # pinky
+    ]
+    FINGER_COLORS = {
+        "thumb": (255, 100, 100),
+        "index": (100, 255, 100),
+        "middle": (100, 100, 255),
+        "ring": (255, 255, 100),
+        "pinky": (255, 100, 255),
+    }
+    FINGER_EDGE_RANGES = [
+        ("thumb", 0, 4),
+        ("index", 4, 8),
+        ("middle", 8, 12),
+        ("ring", 12, 16),
+        ("pinky", 16, 20),
+    ]
+    DOT_COLOR = (255, 165, 0)
 
     @classmethod
     def get_transform_list(
         cls,
-        mode: Literal["cartesian",],
+        mode: Literal["cartesian", "keypoints_headframe_ypr", "keypoints_headframe_quat"],
     ) -> list[Transform]:
         if mode == "cartesian":
             return _build_aria_cartesian_bimanual_transform_list(
                 stride=cls.ACTION_STRIDE
+            )
+        elif mode == "keypoints_headframe_ypr":
+            return _build_aria_keypoints_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE, is_quat=False
+            )
+        elif mode == "keypoints_headframe_quat":
+            return _build_aria_keypoints_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE, is_quat=True
             )
 
     @classmethod

--- a/egomimic/scripts/tutorials/mecka_keypoints_viz.py
+++ b/egomimic/scripts/tutorials/mecka_keypoints_viz.py
@@ -1,0 +1,65 @@
+"""Fetch first mecka episode and render full-episode MANO keypoint overlay mp4."""
+
+from pathlib import Path
+
+import imageio_ffmpeg
+import mediapy as mpy
+import torch
+
+from egomimic.rldb.embodiment.human import Mecka
+from egomimic.rldb.filters import DatasetFilter
+from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset, S3EpisodeResolver
+from egomimic.utils.aws.aws_data_utils import load_env
+from egomimic.utils.aws.aws_sql import create_default_engine, episode_table_to_df
+
+mpy.set_ffmpeg(imageio_ffmpeg.get_ffmpeg_exe())
+
+REPO_ROOT = Path(__file__).resolve().parents[2].parent
+SCRATCH_DIR = REPO_ROOT / "scratch"
+CACHE_DIR = SCRATCH_DIR / "mecka_viz_cache"
+OUT_MP4 = SCRATCH_DIR / "mecka_keypoints.mp4"
+SCRATCH_DIR.mkdir(parents=True, exist_ok=True)
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> None:
+    load_env()
+
+    engine = create_default_engine()
+    df = episode_table_to_df(engine)
+    mecka_df = df[df["embodiment"].str.startswith("mecka", na=False)]
+    if len(mecka_df) == 0:
+        raise RuntimeError("No mecka episodes found in the episode table")
+    episode_hash = mecka_df.iloc[0]["episode_hash"]
+    print(f"Using mecka episode: {episode_hash} (of {len(mecka_df)} candidates)")
+
+    key_map = Mecka.get_keymap(mode="keypoints")
+    transform_list = Mecka.get_transform_list(mode="keypoints_headframe_ypr")
+
+    resolver = S3EpisodeResolver(
+        str(CACHE_DIR), key_map=key_map, transform_list=transform_list
+    )
+    filters = DatasetFilter(
+        filter_lambdas=[f"lambda row: row['episode_hash'] == {episode_hash!r}"]
+    )
+    dataset = MultiDataset._from_resolver(
+        resolver, filters=filters, sync_from_s3=True, mode="total"
+    )
+    loader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=False)
+
+    frames = []
+    for i, batch in enumerate(loader):
+        vis = Mecka.viz_transformed_batch(
+            batch, mode="keypoints", viz_batch_key="actions_keypoints"
+        )
+        frames.append(vis)
+        if i % 50 == 0:
+            print(f"  frame {i}")
+    print(f"Rendered {len(frames)} frames")
+
+    mpy.write_video(str(OUT_MP4), frames, fps=30)
+    print(f"Wrote {OUT_MP4}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add FINGER_EDGES/COLORS/EDGE_RANGES/DOT_COLOR to Mecka using canonical MANO
  21-keypoint topology (0=wrist, 1-4 thumb, 5-8 index, 9-12 middle, 13-16 ring,
  17-20 pinky).
- Extend Mecka.get_transform_list with keypoints_headframe_{ypr,quat} modes that
  reuse the Aria builder with stride=Mecka.ACTION_STRIDE.
- Add egomimic/scripts/tutorials/mecka_keypoints_viz.py: pulls first mecka
  episode via SQL, builds MultiDataset, writes MANO-overlay mp4 to scratch/.
- gitignore scratch/.