### PR TITLE
HPT pushshapes: fp64 cast, packed passthrough, sim_predict_step, input_slice; in-mem zarr loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,13 @@ curation_results/**
 
 # One-off plot artifacts.
 /variant_comparison.png
+external_ckpts/
+_hnet_migration_bak/
+*.bak
+*.bak_*
+.micromamba
+cuda-12.4/
+__pycache__/
+sim_smoke_out/
+*.materialized
+*.bak[0-9]*

--- a/egomimic/algo/hnet.py
+++ b/egomimic/algo/hnet.py
@@ -26,7 +26,21 @@ from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
 from egomimic.models.hnet_nets.context import HNetContext
 from egomimic.models.hnet_nets.hnet import HNet as HNetCore
 from egomimic.models.hnet_nets.hnet import chunk_stats_from_aux, ratio_loss_from_aux
-from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
+
+
+def _apply_token_dropout(x, bos, p, training):
+    """Anti-copy-cheat: replace prev-action tokens with BOS at rate ``p`` during
+    training so the model cannot copy the previous action and must predict from
+    obs (like HPT). Handles (B, T, D) and packed (T_total, D); ``bos`` is (D,).
+    p=1.0 drops every action token (pure obs-conditioned)."""
+    if (not training) or p <= 0:
+        return x
+    lead = tuple(x.shape[:-1])
+    D = x.shape[-1]
+    drop = torch.rand(*(lead + (1,)), device=x.device) < p
+    bos_b = bos.reshape((1,) * len(lead) + (D,)).to(x.dtype).expand_as(x)
+    return torch.where(drop, bos_b, x)
 
 
 class HNetPolicy(nn.Module):
@@ -54,8 +68,12 @@ class HNetPolicy(nn.Module):
         self.action_out = nn.Linear(d_model, action_dim)
         self.bos = nn.Parameter(torch.zeros(1, 1, d_model))
         nn.init.normal_(self.bos, std=0.02)
-        self.pos_emb = nn.Parameter(torch.zeros(1, action_horizon, d_model))
-        nn.init.normal_(self.pos_emb, std=0.02)
+        # F6: positional information is now carried by RoPE inside each
+        # MultiHeadAttention (q/k rotation), matching upstream
+        # ``goombalab/hnet/hnet/modules/mha.py``. The previous learned
+        # absolute ``pos_emb = nn.Parameter(zeros(1, action_horizon,
+        # d_model))`` capped episodes at ``action_horizon`` and added a
+        # second positional signal on top of RoPE; both are gone.
 
         self.cond_encoder = cond_encoder
         self.hnet = hnet
@@ -86,7 +104,11 @@ class HNetPolicy(nn.Module):
         B, T, _ = actions.shape
         x = self.action_in(actions)
         x = torch.cat([self.bos.expand(B, -1, -1), x[:, :-1]], dim=1)
-        x = x + self.pos_emb[:, :T]
+        x = _apply_token_dropout(
+            x, self.bos.reshape(-1), getattr(self, "token_dropout_p", 0.0), self.training
+        )
+        # F6: no outer pos_emb — RoPE inside the attention modules handles
+        # positional information.
 
         ctx = self._build_ctx(obs)
         h = self.hnet(x, ctx)
@@ -122,12 +144,10 @@ class HNetPolicy(nn.Module):
             cu_seqlens = torch.tensor(cu_seqlens, device=device, dtype=torch.long)
         else:
             cu_seqlens = cu_seqlens.to(device=device, dtype=torch.long)
-        if max_seqlen > self.action_horizon:
-            raise ValueError(
-                f"max_seqlen={max_seqlen} exceeds pos_emb length "
-                f"action_horizon={self.action_horizon}; increase action_horizon "
-                f"or chunk episodes to <= action_horizon frames."
-            )
+        # F6: with RoPE handling positions inside each MHA, there is no
+        # hard ``action_horizon`` ceiling anymore — the old check on
+        # ``max_seqlen > self.action_horizon`` was tied to the size of
+        # ``self.pos_emb`` and is removed.
 
         # 1. Tokenize, then global shift-right by 1, then overwrite each
         #    subseq's first slot with BOS. Under autocast (e.g. bf16) the
@@ -146,16 +166,14 @@ class HNetPolicy(nn.Module):
         x_shifted = x_shifted.clone()
         x_shifted[starts] = bos
 
-        # 2. Per-sub-sequence pos_emb: position t in subseq [s, e) gets index t-s.
-        #    Build seq_idx (which subseq each token belongs to), then subtract
-        #    that subseq's start to get the local position index.
-        pos_t = torch.arange(T_total, device=device)
-        # seq_idx[t] = number of subseq starts strictly less-than-or-equal to t
-        # Same as: (cu_seqlens[1:] <= t).sum() ... but easier:
-        seq_idx = (pos_t[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)  # (T_total,)
-        local_pos = pos_t - cu_seqlens[seq_idx]  # (T_total,)
-        pos = self.pos_emb.squeeze(0)[local_pos].to(x_shifted.dtype)  # (T_total, D)
-        x_packed = x_shifted + pos
+        # F6: no outer per-subseq pos_emb add — the MHA RoPE applies per-subseq
+        # rotary positions inside attention. ``cu_seqlens`` is threaded into
+        # ``HNetContext`` below and re-derived in ``_forward_packed`` of
+        # ``MultiHeadAttention``.
+        x_packed = x_shifted
+        x_packed = _apply_token_dropout(
+            x_packed, bos, getattr(self, "token_dropout_p", 0.0), self.training
+        )
 
         # 3. Packed cond. ``cond_encoder.encode`` expects (B, T, ...); for a
         #    packed stream the simplest path is to feed (1, T_total, ...) and
@@ -192,11 +210,10 @@ class HNetPolicy(nn.Module):
         works."""
         if T is None:
             T = self.action_horizon
-        if T > self.action_horizon:
-            raise ValueError(
-                f"generate T={T} exceeds pos_emb length action_horizon="
-                f"{self.action_horizon}"
-            )
+        # F6: no upper bound on T from a learned pos_emb anymore — RoPE
+        # handles arbitrary positions inside the MHA. The previous check
+        # `T > self.action_horizon` is removed. ``action_horizon`` is still
+        # consulted as a *default rollout length* when ``T`` is None.
         cond_dict = self.cond_encoder.encode(obs, T)
         actions = torch.zeros(batch_size, T, self.action_dim, device=device)
         dtype = next(self.parameters()).dtype
@@ -213,7 +230,9 @@ class HNetPolicy(nn.Module):
         def slice_cond(t: int) -> dict:
             return {k: v[:, t] if v.dim() == 3 else v for k, v in cond_dict.items()}
 
-        cur = self.bos.expand(batch_size, -1, -1) + self.pos_emb[:, 0:1]
+        # F6: no outer pos_emb add; RoPE inside MHA reads positions from each
+        # KVCache's ``offsets`` (set by ``MultiHeadAttention.step``).
+        cur = self.bos.expand(batch_size, -1, -1)
         for t in range(T):
             ctx = HNetContext(
                 cond_dict=slice_cond(t),
@@ -224,7 +243,7 @@ class HNetPolicy(nn.Module):
             a_t = self.action_out(h)
             actions[:, t : t + 1] = a_t
             if t < T - 1:
-                cur = self.action_in(a_t) + self.pos_emb[:, t + 1 : t + 2]
+                cur = self.action_in(a_t)
         return actions
 
     # ----- Single-step inference API for closed-loop rollout -----
@@ -235,7 +254,10 @@ class HNetPolicy(nn.Module):
         rollouts of at most ``T_max`` steps. The state is opaque to the
         caller; pass it back to :meth:`step` along with the current obs.
         """
-        T_max = int(min(T_max, self.action_horizon))
+        # F6: T_max is no longer clamped by self.action_horizon — RoPE
+        # handles arbitrary positions. We still need ``T_max`` to size the
+        # KV cache allocations.
+        T_max = int(T_max)
         dtype = dtype or next(self.parameters()).dtype
         params = self.hnet.allocate_inference_cache(
             batch_size=batch_size,
@@ -243,9 +265,8 @@ class HNetPolicy(nn.Module):
             device=device,
             dtype=dtype,
         )
-        cur = (self.bos.expand(batch_size, 1, self.d_model) + self.pos_emb[:, 0:1]).to(
-            dtype
-        )
+        # F6: BOS only — no outer pos_emb add. RoPE applies inside the MHA.
+        cur = self.bos.expand(batch_size, 1, self.d_model).to(dtype)
         return {
             "params": params,
             "cur": cur,
@@ -274,11 +295,10 @@ class HNetPolicy(nn.Module):
         h = self.hnet.step(state["cur"], ctx)
         a_t_norm = self.action_out(h)
 
-        t_next = t + 1
-        if t_next < self.action_horizon:
-            state["cur"] = (
-                self.action_in(a_t_norm) + self.pos_emb[:, t_next : t_next + 1]
-            ).to(state["dtype"])
+        # F6: no per-step pos_emb add; the next-token input is just the
+        # projected predicted action. RoPE is applied inside each MHA.step
+        # using cache.offsets as the position.
+        state["cur"] = self.action_in(a_t_norm).to(state["dtype"])
         return a_t_norm
 
 
@@ -319,6 +339,8 @@ class FlatFusedPolicy(nn.Module):
         arch_layout: str = "T8",
         num_heads: int = 4,
         d_intermediate: int = 512,
+        dropout: float = 0.0,
+        resid_dropout: float = 0.0,
     ):
         super().__init__()
         from egomimic.models.hnet_nets.isotropic_builder import build_isotropic
@@ -347,6 +369,8 @@ class FlatFusedPolicy(nn.Module):
                 "d_intermediate": d_intermediate,
                 "num_heads": num_heads,
                 "cond": False,
+                "dropout": dropout,
+                "resid_dropout": resid_dropout,
             },
             d_cond=0,
             causal=True,
@@ -374,6 +398,9 @@ class FlatFusedPolicy(nn.Module):
         a_tok = self.action_in(actions)  # (B, T, d_model)
         # Shift: BOS at position 0, a_0..a_{T-2} after.
         a_shifted = torch.cat([self.bos.expand(B, -1, -1), a_tok[:, :-1]], dim=1)
+        a_shifted = _apply_token_dropout(
+            a_shifted, self.bos.reshape(-1), getattr(self, "token_dropout_p", 0.0), self.training
+        )
 
         # Interleave: x[:, 0::2] = c_tok, x[:, 1::2] = a_shifted.
         x = torch.empty(
@@ -427,6 +454,9 @@ class FlatFusedPolicy(nn.Module):
         # Indices of non-start positions:
         idx_non_start = torch.nonzero(non_start, as_tuple=False).squeeze(-1)
         a_shifted[idx_non_start] = a_tok[idx_non_start - 1]
+        a_shifted = _apply_token_dropout(
+            a_shifted, bos, getattr(self, "token_dropout_p", 0.0), self.training
+        )
 
         # Build per-sub-seq position indices: 0, 1, ..., (e-s)-1 within each
         # sub-seq. Then the 2-token interleave doubles to 2*(e-s).
@@ -640,6 +670,14 @@ class HNet(Algo):
             cond_encoder=cond_encoder,
             hnet=hnet,
         )
+        policy.token_dropout_p = float(kwargs.get("token_dropout_p", 0.0) or 0.0)
+        self.train_mode = str(kwargs.get("train_mode", "tf"))
+        self.ss_prob = float(kwargs.get("ss_prob", 0.5) or 0.5)
+        _win = int(kwargs.get("window_size", 0) or 0)
+        if _win > 0:
+            for _m in policy.modules():
+                if _m.__class__.__name__ == "MultiHeadAttention":
+                    _m.window = _win
         # Apply opt-in training recipe BEFORE moving to device so the init
         # writes hit cpu params (matches upstream's pattern of init pre-move).
         if init_weights_range is not None:
@@ -720,22 +758,24 @@ class HNet(Algo):
                     processed[emb_id][key_name] = value
 
             ac_key = self.resolved_ac_keys[emb_id]
-            if is_packed:
-                # Packed actions are (T_total, action_dim). No pad_mask needed
-                # since variable-length is expressed via cu_seqlens.
-                processed[emb_id]["pad_mask"] = None
-                processed[emb_id]["_packed"] = True
-            else:
-                B, S, _ = processed[emb_id][ac_key].shape
-                processed[emb_id]["pad_mask"] = torch.ones(
-                    B, S, 1, device=processed[emb_id][ac_key].device
-                )
-                processed[emb_id]["_packed"] = False
+            # F5: H-Net does NOT consume ``pad_mask`` — variable-length is
+            # carried by ``cu_seqlens`` in packed mode and by the full-length
+            # convention in padded mode. The previous code populated an
+            # all-ones ``pad_mask`` (or None) here as a vestige from the
+            # ACT/HPT algos; no downstream H-Net code reads it. Don't
+            # re-introduce it: if you need a true valid-token mask, plumb
+            # it through ``HNetContext`` instead.
+            processed[emb_id]["_packed"] = is_packed
             # Per-feature normalization via MultiDataset stats: each tensor
             # gets ``(x - mean) / std`` (or quantile equivalent) broadcast
             # against (action_dim,) / (proprio_dim,) stats. Works for both
             # padded ``(B, T, D)`` and packed ``(T_total, D)`` shapes.
             processed[emb_id] = self.norm_stats.normalize(processed[emb_id], emb_id)
+            # Preserve goal_pose (goal_keys type) for the sim evaluator:
+            # norm_stats.zarr_key_to_keyname returns None for it, so the
+            # keyname loop above drops it. The closed-loop env init needs it.
+            if "goal_pose" in _batch:
+                processed[emb_id]["goal_pose"] = _batch["goal_pose"]
             processed[emb_id]["embodiment"] = torch.tensor(
                 [emb_id], device=self.device, dtype=torch.int64
             )
@@ -767,12 +807,28 @@ class HNet(Algo):
             actions = _batch[ac_key]
             obs = self._build_obs(_batch, emb_id)
 
-            if _batch.get("_packed", False):
-                cu_seqlens = _batch["cu_seqlens"]
-                max_seqlen = int(_batch["max_seq_len"])
-                pred, aux = policy.forward_packed(actions, obs, cu_seqlens, max_seqlen)
+            is_packed = _batch.get("_packed", False)
+            cu_seqlens = _batch["cu_seqlens"] if is_packed else None
+            max_seqlen = int(_batch["max_seq_len"]) if is_packed else None
+
+            def _fwd(acts):
+                if is_packed:
+                    return policy.forward_packed(acts, obs, cu_seqlens, max_seqlen)
+                return policy(acts, obs)
+
+            if getattr(self, "train_mode", "tf") == "ar":
+                # Scheduled-sampling AR training: pass 1 teacher-forced (no grad)
+                # gives the model's own action predictions; pass 2 substitutes
+                # them for the GT prev-action inputs at rate ss_prob so the model
+                # learns to recover from its own errors. Loss target stays GT.
+                with torch.no_grad():
+                    pred1, _ = _fwd(actions)
+                _ss = float(getattr(self, "ss_prob", 0.5))
+                _mask = torch.rand(actions.shape[:-1] + (1,), device=actions.device) < _ss
+                mixed = torch.where(_mask, pred1.detach(), actions)
+                pred, aux = _fwd(mixed)
             else:
-                pred, aux = policy(actions, obs)
+                pred, aux = _fwd(actions)
 
             mse = nn.functional.mse_loss(pred, actions)
             rloss = ratio_loss_from_aux(aux, device=mse.device)
@@ -953,21 +1009,41 @@ class HNet(Algo):
             log[k] = v.item()
         return log
 
-    # ----- Sim eval hooks (SimRolloutEval calls these) ----- #
-    # Thin routers — the policy class owns the actual step semantics
-    # (KV cache lifecycle, BOS/pos_emb threading, two-token interleaving
-    # for the flat-fused variant). See ``HNetPolicy.init_step_state`` /
-    # ``FlatFusedPolicy.init_step_state``.
+    # ----- Sim eval hook (SimRolloutEval.inference_step contract) ----- #
+    # Single entry point. t=0 is the universal reset signal (allocates a
+    # fresh AR state); t>0 steps against the cached state. The eval class
+    # never touches model state — it lives entirely in self._sim_state.
 
     @torch.no_grad()
-    def sim_init_state(self, batch_size: int, T_max: int, device, emb_id: int) -> dict:
-        return self.nets["policy"].init_step_state(batch_size, T_max, device)
+    def inference_step(
+        self, obs_zarr: dict, t: int, emb_id: int
+    ) -> "np.ndarray":
+        """One closed-loop sim step.
 
-    @torch.no_grad()
-    def sim_predict_step(
-        self, state: dict, obs_norm: dict, t: int, emb_id: int
-    ) -> torch.Tensor:
-        return self.nets["policy"].step(state, obs_norm, t)
+        Args:
+            obs_zarr: env obs in canonical zarr-key dict (already on device).
+            t: timestep within the rollout. t=0 resets state.
+            emb_id: embodiment id.
+
+        Returns:
+            absolute-frame action as np.float32 of shape (action_dim,).
+        """
+        import numpy as np
+        policy = self.nets["policy"]
+        if t == 0:
+            device = next(self.nets["policy"].parameters()).device
+            T_max = int(getattr(policy, "action_horizon", 1024))
+            self._sim_state = policy.init_step_state(
+                batch_size=1, T_max=T_max, device=device
+            )
+        embodiment_name = get_embodiment(emb_id).lower()
+        ac_key = self.ac_keys[embodiment_name] if embodiment_name in self.ac_keys else self.ac_keys[emb_id]
+        obs_norm = self.norm_stats.normalize(obs_zarr, emb_id)
+        action_norm = policy.step(self._sim_state, obs_norm, t)
+        action_unnorm = self.norm_stats.unnormalize(
+            {ac_key: action_norm.squeeze(0).squeeze(0)}, emb_id,
+        )[ac_key]
+        return action_unnorm.detach().cpu().numpy().reshape(-1).astype(np.float32)
 
     # ----- Optional training recipe hook for pl_model.configure_optimizers ----- #
 
@@ -1051,6 +1127,8 @@ class HNetFused(HNet):
         arch_layout: str = "T8",
         num_heads: int = 4,
         d_intermediate: int = 512,
+        dropout: float = 0.0,
+        resid_dropout: float = 0.0,
         **kwargs,
     ):
         # Skip HNet.__init__ — it requires a HNetCore. We re-implement the
@@ -1079,7 +1157,17 @@ class HNetFused(HNet):
             arch_layout=arch_layout,
             num_heads=num_heads,
             d_intermediate=d_intermediate,
+            dropout=dropout,
+            resid_dropout=resid_dropout,
         )
+        policy.token_dropout_p = float(kwargs.get("token_dropout_p", 0.0) or 0.0)
+        self.train_mode = str(kwargs.get("train_mode", "tf"))
+        self.ss_prob = float(kwargs.get("ss_prob", 0.5) or 0.5)
+        _win = int(kwargs.get("window_size", 0) or 0)
+        if _win > 0:
+            for _m in policy.modules():
+                if _m.__class__.__name__ == "MultiHeadAttention":
+                    _m.window = _win
         self.nets = nn.ModuleDict({"policy": policy})
         self.nets = self.nets.float().to(self.device)
 

--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -994,6 +994,26 @@ class HPT(Algo):
         processed_batch = {}
         for embodiment_name, _batch in batch.items():
             embodiment_id = get_embodiment_id(embodiment_name)
+            # Packed eval batches (SimRolloutEval) carry cu_seqlens + flat
+            # (T_total, ...) per-frame streams. The per-frame train path below
+            # asserts a (B, S, D) action shape and would crash; pass packed
+            # batches through instead (remap embodiment, keep bookkeeping, cast
+            # floats to model dtype, flag _packed so the evaluator picks it up).
+            if "cu_seqlens" in _batch:
+                _dtype = next(self.nets.parameters()).dtype
+                pb = {}
+                for key, value in _batch.items():
+                    if isinstance(value, torch.Tensor):
+                        value = value.to(self.device)
+                        if value.is_floating_point():
+                            value = value.to(_dtype)
+                    pb[key] = value
+                pb["_packed"] = True
+                pb["embodiment"] = torch.tensor(
+                    [embodiment_id], device=self.device, dtype=torch.int64
+                )
+                processed_batch[embodiment_id] = pb
+                continue
             processed_batch[embodiment_id] = {}
             for key, value in _batch.items():
                 key_name = self.norm_stats.zarr_key_to_keyname(key, embodiment_id)
@@ -1260,6 +1280,7 @@ class HPT(Algo):
                 policy_module.heads[embodiment_name].infer_ac_dims[embodiment_name]
                 if hasattr(policy_module, "heads")
                 and embodiment_name in policy_module.heads
+                and hasattr(policy_module.heads[embodiment_name], "infer_ac_dims")
                 else 2  # pushshapes default
             )
             robo_batch[ac_key] = torch.zeros(

--- a/egomimic/eval/eval_composite.py
+++ b/egomimic/eval/eval_composite.py
@@ -1,24 +1,18 @@
 """
-EvalList — composite evaluator that runs multiple sub-evals on the same
-validation batch.
+Composite evaluators.
 
-Two flavours:
+* :class:`EvalList` (inherits from :class:`Eval`): pure runner — calls
+  each sub-eval's lifecycle hooks in turn and merges their metrics.
+  Has NO video machinery of its own. Use this as the top-level
+  orchestrator combining heterogeneous sub-evals (e.g. one teacher-forced
+  composite video + one closed-loop sim eval), each of which writes its
+  own outputs independently.
 
-* :class:`EvalList` (base): runs each sub-eval in turn, merges their
-  metrics, and returns the **union** of their image dicts. Each sub-eval
-  emits its own .mp4 to its own buffer / output directory, so the saved
-  validation videos are independent per sub-eval. Use this when the
-  sub-evals don't share a common timeline or you just want separate
-  diagnostics videos.
-
-* :class:`EvalListSideBySide` (subclass): in addition to running each
-  sub-eval, concatenates per-embodiment image arrays along width so the
-  saved composite .mp4 plays the panels side-by-side. Requires all
-  sub-evals to emit the same number of frames per embodiment and uses
-  ``pad_h`` to reconcile differing panel heights.
-
-Each sub-eval must satisfy the ``EvalVideo.compute_metrics_and_viz``
-contract: ``(metrics_dict, {emb_id: (N, H, W, 3) uint8})``.
+* :class:`EvalVideoList` (inherits from :class:`EvalVideo`): composite
+  video — runs N ``EvalVideo`` sub-evals and concatenates their per-step
+  panels along width into ONE side-by-side mp4. Sub-evals MUST inherit
+  from EvalVideo (the contract is that they produce ``(N, H, W, 3)``
+  uint8 arrays per embodiment).
 """
 
 from __future__ import annotations
@@ -28,34 +22,17 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 import torch
 
+from egomimic.eval.eval import Eval
 from egomimic.eval.eval_video import EvalVideo
 
 
-class EvalList(EvalVideo):
-    """Run a list of sub-evals on each val batch. Metrics merge; each
-    sub-eval's images get forwarded unmodified.
+class EvalList(Eval):
+    """Pure list-runner. No own video output; each sub-eval writes its
+    own outputs. Sub-evals can be any ``Eval`` (video or not)."""
 
-    Args (yaml):
-      evals: list of pre-instantiated sub-evals (each is an EvalVideo).
-      limit_val_batches: inherited from EvalVideo — caps how many val
-        batches the parent strategy processes.
-    """
-
-    def __init__(
-        self,
-        evals: list[EvalVideo] | None = None,
-        limit_val_batches: int = 4,
-        viz_func: dict | None = None,
-        transform_lists: dict | None = None,
-    ):
-        super().__init__(
-            limit_val_batches=limit_val_batches,
-            viz_func=viz_func,
-            transform_lists=transform_lists,
-        )
-        self.evals: list[EvalVideo] = list(evals or [])
-
-    # ------------------------------------------------------------------ #
+    def __init__(self, evals: list | None = None):
+        super().__init__()
+        self.evals: list = list(evals or [])
 
     def _wire_subevals(self):
         for ev in self.evals:
@@ -66,22 +43,12 @@ class EvalList(EvalVideo):
         self._wire_subevals()
         for ev in self.evals:
             ev.on_validation_start()
-        # Skip the parent's video-dir mkdir; this composite has no buffer
-        # of its own. Each sub-eval owns its directory.
 
     def on_validation_end(self):
         for ev in self.evals:
             ev.on_validation_end()
 
     def on_validation_step(self, batch, batch_idx, dataloader_idx=0):
-        """Delegate to each sub-eval's own ``on_validation_step``.
-
-        Each sub-eval owns its own ``val_image_buffer`` (inherited from
-        ``EvalVideo``), writes its own ``.mp4``, and logs its own metrics.
-        The composite class doesn't keep a buffer or write any video —
-        if you want the panels combined into one .mp4, use
-        :class:`EvalListSideBySide` instead.
-        """
         self._wire_subevals()
         for ev in self.evals:
             ev.on_validation_step(batch, batch_idx, dataloader_idx)
@@ -89,57 +56,99 @@ class EvalList(EvalVideo):
     def compute_metrics_and_viz(
         self, batch: Dict[int, Dict[str, Any]]
     ) -> Tuple[Dict[str, torch.Tensor], Dict[int, np.ndarray]]:
-        """Plain pass-through: run each sub-eval, merge metrics, collect
-        their image dicts into ``self.last_per_eval_images`` for the
-        side-by-side subclass. Returns an empty image dict so the
-        ``EvalVideo`` parent path doesn't try to write a composite video.
-        """
+        """Run each sub-eval, merge metrics. Returns empty image dict —
+        each sub-eval owns its own video buffer / output directory."""
         self._wire_subevals()
         all_metrics: Dict[str, torch.Tensor] = {}
-        self.last_per_eval_images: List[Dict[int, np.ndarray]] = []
         for ev in self.evals:
-            m, ims = ev.compute_metrics_and_viz(batch)
+            m, _ = ev.compute_metrics_and_viz(batch)
             all_metrics.update(m)
-            self.last_per_eval_images.append(ims)
         return all_metrics, {}
 
 
-class EvalListSideBySide(EvalList):
-    """Side-by-side composite. Each sub-eval emits ``(N, H, W, 3)`` for the
-    same ``N`` (frame count); we concatenate the panels along ``W``.
+class EvalVideoList(EvalVideo):
+    """Composite video evaluator.
 
-    ``pad_h``: ``"min"`` crops each panel to the shortest height;
-    ``"max"`` zero-pads each to the tallest. Default ``"min"`` produces
-    a clean composite frame.
+    Runs N EvalVideo sub-evals on the same batch and concatenates their
+    ``(N, H, W, 3)`` panels along WIDTH (per embodiment) into one mp4.
+    All sub-evals MUST inherit from EvalVideo and produce the same
+    number of frames ``N`` per embodiment (or shorter panels get
+    zero-padded to ``max`` N).
+
+    pad_h: how to reconcile differing panel heights.
+      min: crop each panel to the shortest height.
+      max: zero-pad each to the tallest. Use this when sub-evals
+      legitimately have different heights (e.g. PCA fig is taller than
+      boundary strip).
     """
 
-    def __init__(self, pad_h: str = "min", **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        evals: list[EvalVideo] | None = None,
+        pad_h: str = "min",
+        limit_val_batches: int = 4,
+        viz_func: dict | None = None,
+        transform_lists: dict | None = None,
+        max_videos: int | None = None,
+    ):
+        super().__init__(
+            limit_val_batches=limit_val_batches,
+            viz_func=viz_func,
+            transform_lists=transform_lists,
+            max_videos=max_videos,
+        )
         if pad_h not in {"min", "max"}:
             raise ValueError(f"pad_h must be 'min' or 'max', got {pad_h!r}")
         self.pad_h = pad_h
 
+        evals_list: list[EvalVideo] = list(evals or [])
+        # Enforce the EvalVideo-only contract: every sub-eval must emit
+        # frames (otherwise the width-concat has nothing to stack).
+        for ev in evals_list:
+            if not isinstance(ev, EvalVideo):
+                raise TypeError(
+                    f"EvalVideoList sub-evals must inherit from EvalVideo "
+                    f"(got {type(ev).__name__!r}). Use EvalList for non-video sub-evals."
+                )
+        self.evals: list[EvalVideo] = evals_list
+
+    def _wire_subevals(self):
+        for ev in self.evals:
+            ev.trainer = self.trainer
+            ev.model = self.model
+
     def on_validation_start(self):
-        # Re-enable the parent's video-dir mkdir; this composite DOES own
-        # an output buffer (the merged side-by-side .mp4).
         self._wire_subevals()
         for ev in self.evals:
             ev.on_validation_start()
-        # Skip parent (EvalList) implementation that suppresses mkdir;
-        # walk up to EvalVideo for the buffer setup.
-        EvalVideo.on_validation_start(self)
+        # ALSO set up our own image buffer + video dir — the composite
+        # mp4 is written through THIS class's buffer.
+        super().on_validation_start()
+
+    def on_validation_end(self):
+        for ev in self.evals:
+            ev.on_validation_end()
+        super().on_validation_end()
 
     def on_validation_step(self, batch, batch_idx, dataloader_idx=0):
-        # Use the parent ``EvalVideo`` path so the merged images_dict
-        # produced by ``compute_metrics_and_viz`` below ends up in
-        # ``self.val_image_buffer`` and flushes as ONE composite .mp4.
-        EvalVideo.on_validation_step(self, batch, batch_idx, dataloader_idx)
+        """Standard EvalVideo step path: compute_metrics_and_viz (below)
+        returns the merged side-by-side frames, EvalVideo's machinery
+        then buffers + flushes them to ONE mp4."""
+        self._wire_subevals()
+        super().on_validation_step(batch, batch_idx, dataloader_idx)
 
     def compute_metrics_and_viz(
         self, batch: Dict[int, Dict[str, Any]]
     ) -> Tuple[Dict[str, torch.Tensor], Dict[int, np.ndarray]]:
-        all_metrics, _ = super().compute_metrics_and_viz(batch)
-        per_eval_images = self.last_per_eval_images
+        self._wire_subevals()
+        all_metrics: Dict[str, torch.Tensor] = {}
+        per_eval_images: List[Dict[int, np.ndarray]] = []
+        for ev in self.evals:
+            m, ims = ev.compute_metrics_and_viz(batch)
+            all_metrics.update(m)
+            per_eval_images.append(ims)
+
+        # Concatenate sub-eval panels along width per embodiment.
         merged: Dict[int, np.ndarray] = {}
         if not per_eval_images:
             return all_metrics, merged
@@ -161,6 +170,7 @@ class EvalListSideBySide(EvalList):
                 else:
                     pad = np.zeros((N, target_h - H, W, C), dtype=p.dtype)
                     aligned.append(np.concatenate([p, pad], axis=1))
+            # Pad N (frame count) so all panels share the same time axis.
             target_N = max(a.shape[0] for a in aligned)
             for i, a in enumerate(aligned):
                 if a.shape[0] < target_N:
@@ -170,8 +180,7 @@ class EvalListSideBySide(EvalList):
                     )
                     aligned[i] = np.concatenate([a, pad], axis=0)
             stacked = np.concatenate(aligned, axis=2)
-            # libx264 requires both spatial dims to be divisible by 2.
-            # Right-pad / bottom-pad a single black row/col if needed.
+            # libx264 needs both spatial dims even — pad odd by one row/col.
             N, H, W, C = stacked.shape
             if H % 2 == 1:
                 stacked = np.concatenate(
@@ -184,3 +193,8 @@ class EvalListSideBySide(EvalList):
                 )
             merged[emb_id] = stacked
         return all_metrics, merged
+
+
+# Backwards-compat alias — old yamls / scripts may still reference this name.
+# Will be removed in a follow-up after all yamls are updated.
+EvalListSideBySide = EvalVideoList

--- a/egomimic/eval/eval_hnet.py
+++ b/egomimic/eval/eval_hnet.py
@@ -142,7 +142,9 @@ class HNetEvalVideo(EvalVideo):
             n_loss += 1
 
             if self.viz_func is not None and embodiment_name in self.viz_func:
-                ims = self.viz_func[embodiment_name](viz_preds, viz_batch)
+                ims = self.viz_func[embodiment_name](
+                    viz_preds, viz_batch, max_videos=self.max_videos
+                )
                 images_dict[emb_id] = ims
 
         if total_loss is not None and n_loss > 0:

--- a/egomimic/eval/eval_sim.py
+++ b/egomimic/eval/eval_sim.py
@@ -7,6 +7,7 @@ inference to the algo's ``sim_init_state`` + ``sim_predict_step``.
 """
 
 from __future__ import annotations
+import os
 
 from typing import Any, Dict, List, Tuple
 
@@ -45,6 +46,23 @@ def _state_to_init(state: np.ndarray) -> tuple:
     return (float(state[0]), float(state[1])), (float(state[2]), float(state[3]), float(state[4]))
 
 
+from collections import deque as _deque_te
+
+
+def _temporal_ensemble(chunk_buf, t, horizon, m):
+    """ACT-style temporal ensemble. chunk_buf: deque of (pred_time, chunk (H,A)).
+    Returns the (1,A) weighted-average of all overlapping chunks' predictions for
+    step t, weights exp(-m*age) oldest->newest. Drops chunks older than horizon.
+    Shared by the HPT chunk rollout and the H-Net chunk_te rollout."""
+    while chunk_buf and chunk_buf[0][0] <= t - horizon:
+        chunk_buf.popleft()
+    preds = [ch[t - pt] for (pt, ch) in chunk_buf if 0 <= t - pt < ch.shape[0]]
+    preds = torch.stack(preds, dim=0)
+    w = torch.exp(-m * torch.arange(preds.shape[0], device=preds.device, dtype=preds.dtype))
+    w = w / w.sum()
+    return (preds * w[:, None]).sum(dim=0, keepdim=True)
+
+
 class SimRolloutEval(EvalVideo):
     """Closed-loop sim rollout eval. Algo-agnostic."""
 
@@ -61,6 +79,12 @@ class SimRolloutEval(EvalVideo):
         max_videos: int | None = None,
         viz_func: dict | None = None,
         transform_lists: dict | None = None,
+        temporal_ensemble: bool = True,
+        te_m: float = 0.01,
+        delta_action: bool = False,
+        rollout_mode: str = "ar",
+        chunk_k: int = 32,
+        goal_in_obs: bool = False,
     ):
         super().__init__(
             limit_val_batches=limit_val_batches,
@@ -85,6 +109,15 @@ class SimRolloutEval(EvalVideo):
         self._target_emb_id = get_embodiment_id(self.embodiment_name)
         self._env = None
         self._init_counter = 0
+        # Rollout-mode knobs (config-driven; no env-vars):
+        #   temporal_ensemble / te_m -> HPT chunk rollout (base _rollout_one)
+        #   delta_action             -> H-Net delta integration (HNetSimEval)
+        self.temporal_ensemble = bool(temporal_ensemble)
+        self.te_m = float(te_m)
+        self.delta_action = bool(delta_action)
+        self.rollout_mode = str(rollout_mode)   # 'ar' (single-step) | 'chunk_te'
+        self.chunk_k = int(chunk_k)
+        self.goal_in_obs = bool(goal_in_obs)    # feed goal_obs to a goal-conditioned model
 
     def _get_env(self):
         if self._env is None:
@@ -101,10 +134,12 @@ class SimRolloutEval(EvalVideo):
             if state_seq is None:
                 raise KeyError("init_mode='replay' requires 'state_agent_obj' in batch")
 
-            unnorm = self.model.norm_stats.unnormalize(
-                {"state_agent_obj": state_seq}, emb_id
-            )
-            frame0 = unnorm["state_agent_obj"][0].detach().cpu().numpy()
+            # The packed eval dataset returns RAW world-coord state (it does not
+            # normalize like the per-frame train loader). Use it directly for
+            # env init; unnormalizing raw values double-scales them into garbage
+            # (agent ~46k instead of ~210), placing the object off-screen so
+            # coverage is always 0.
+            frame0 = state_seq[0].detach().cpu().numpy()
             agent_pos, object_pose = _state_to_init(frame0)
 
             goal_pose = None
@@ -114,6 +149,11 @@ class SimRolloutEval(EvalVideo):
                     float(x) for x in goal_seq[0].detach().cpu().numpy().reshape(-1)[:3]
                 )
 
+            print(
+                f"[ROLLOUT_DBG] sample_keys={list(sample.keys())} "
+                f"goal_pose={goal_pose} agent={agent_pos} obj={object_pose}",
+                flush=True,
+            )
             env.reset(seed=_REPLAY_RESET_SEED)
             env.set_state(
                 agent_pos=agent_pos,
@@ -162,13 +202,36 @@ class SimRolloutEval(EvalVideo):
         actions_taken: List[np.ndarray] = []
         last_coverage = 0.0
 
+        # The model is trained on obs WINDOWS of length action_horizon (32):
+        # front_img_1 (B,32,3,96,96), state (B,32,5). A single-frame rollout obs
+        # gives temporal dim 1, which mismatches training. Maintain a rolling
+        # buffer of the last `horizon` env observations and feed the window.
+        from collections import deque as _deque
+        _H = 32
+        _m = self.te_m                  # temporal-ensemble decay (config-driven)
+        _te = self.temporal_ensemble    # ensemble on/off (config-driven)
+        chunk_buf = _deque()                                   # (pred_time, chunk (H,A) norm)
+
         for t in range(T):
             obs_raw = obs_formatter(obs_env, device)
             obs_norm = algo.norm_stats.normalize(obs_raw, emb_id)
-
-            a_t_norm = algo.sim_predict_step(state, obs_norm, t, emb_id)
+            # Fresh chunk every step (sim_predict_step stores it in
+            # state["action_chunk"]); then TEMPORAL-ENSEMBLE (ACT-style):
+            # weighted-average the predictions for the current step from all
+            # recent overlapping chunks. Smooths the trajectory and blends in
+            # earlier confident forward-motion predictions, so the policy
+            # escapes the "stay put" fixed point single-action execution falls
+            # into.
+            state["action_chunk"] = None
+            state["chunk_idx"] = 0
+            a_t_single = algo.sim_predict_step(state, obs_norm, t, emb_id)  # (1,1,A)
+            if _te:
+                chunk_buf.append((t, state["action_chunk"][0].detach()))   # (H,A) norm
+                a_t_norm = _temporal_ensemble(chunk_buf, t, _H, _m)
+            else:
+                a_t_norm = a_t_single.squeeze(0)
             a_t_world = (
-                algo.norm_stats.unnormalize({ac_key: a_t_norm.squeeze(0)}, emb_id)[ac_key]
+                algo.norm_stats.unnormalize({ac_key: a_t_norm}, emb_id)[ac_key]
                 .detach().cpu().numpy().reshape(-1)
             )
             action_xy = np.array(
@@ -186,6 +249,16 @@ class SimRolloutEval(EvalVideo):
             if terminated:
                 break
 
+        if actions_taken:
+            _a = np.asarray(actions_taken)
+            _first = [[round(float(x), 1) for x in p] for p in actions_taken[:6]]
+            print(
+                f"[ROLLOUT_DBG] ep={ep_idx} steps={len(actions_taken)} "
+                f"act_x[{_a[:, 0].min():.1f},{_a[:, 0].max():.1f}] "
+                f"act_y[{_a[:, 1].min():.1f},{_a[:, 1].max():.1f}] "
+                f"first6={_first} final_cov={last_coverage:.3f}",
+                flush=True,
+            )
         return last_coverage, frames, actions_taken
 
     def compute_metrics_and_viz(
@@ -206,21 +279,33 @@ class SimRolloutEval(EvalVideo):
             cu = _batch["cu_seqlens"]
             seq_lens = _batch["seq_lens"]
             B = int(seq_lens.shape[0])
-            B_render = min(B, self.max_videos) if self.max_videos is not None else B
+            # Fixed-seed eval: roll out exactly len(init_seeds) reproducible
+            # envs (identical scenes for every model). Reset the counter so each
+            # eval deterministically uses seeds[0..N-1].
+            if self.init_mode == "seeds":
+                n_rollouts = len(self.init_seeds)
+                self._init_counter = 0
+            else:
+                n_rollouts = B
+            B_render = min(n_rollouts, self.max_videos) if self.max_videos is not None else n_rollouts
             ep_coverages: list[float] = []
             ep_successes: list[float] = []
             ep_frames_for_video: list[np.ndarray] = []
 
-            for b in range(B):
-                s = int(cu[b].item())
-                e = int(cu[b + 1].item())
-                T_ep = e - s
-                sample: dict = {}
-                for k, v in _batch.items():
-                    if not torch.is_tensor(v):
-                        continue
-                    if v.dim() >= 1 and v.shape[0] == int(cu[-1].item()):
-                        sample[k] = v[s:e]
+            for b in range(n_rollouts):
+                if self.init_mode == "seeds":
+                    sample = {}
+                    T_ep = self.max_steps if self.max_steps is not None else 300
+                else:
+                    s = int(cu[b].item())
+                    e = int(cu[b + 1].item())
+                    T_ep = e - s
+                    sample = {}
+                    for k, v in _batch.items():
+                        if not torch.is_tensor(v):
+                            continue
+                        if v.dim() >= 1 and v.shape[0] == int(cu[-1].item()):
+                            sample[k] = v[s:e]
                 coverage, frames, _ = self._rollout_one(
                     sample, seq_len=T_ep, emb_id=emb_id, ep_idx=b,
                 )
@@ -242,3 +327,180 @@ class SimRolloutEval(EvalVideo):
                 images_dict[emb_id] = np.stack(ep_frames_for_video, axis=0)
 
         return metrics, images_dict
+
+
+class HNetSimEval(SimRolloutEval):
+    """Closed-loop sim rollout for the autoregressive H-Net.
+
+    HPT predicts an ``action_horizon`` chunk per step and is temporally
+    ensembled in the base ``_rollout_one``. H-Net is natively single-step
+    autoregressive: it feeds its own predicted action back through a KV
+    cache, so chunk/TE semantics do not apply. We override ``_rollout_one``
+    to drive the algo's ``inference_step`` (t=0 allocates a fresh AR/KV
+    state, t>0 steps the cached state) one env frame at a time.
+
+    Everything else — replay init, goal set, packed-batch parsing, coverage
+    metric, video assembly — is inherited from ``SimRolloutEval`` unchanged,
+    so HPT and H-Net are compared on an identical env / init / metric and
+    differ only in the rollout inference each architecture actually uses.
+    """
+
+    @torch.no_grad()
+    def _rollout_one(self, sample, seq_len, emb_id, ep_idx):
+        if getattr(self, "rollout_mode", "ar") == "chunk_te":
+            return self._rollout_chunk_te(sample, seq_len, emb_id, ep_idx)
+        algo = self.model
+        env = self._get_env()
+        # mode=train validation hands us a NORMALIZED batch (the algo's
+        # process_batch_for_training ran first). The env init needs raw
+        # world-coord state, so un-normalize state_agent_obj here. goal_pose
+        # is carried through un-normalized by process_batch, use it as-is.
+        sample = dict(sample)
+        if "state_agent_obj" in sample:
+            sample["state_agent_obj"] = algo.norm_stats.unnormalize(
+                {"state_agent_obj": sample["state_agent_obj"]}, emb_id
+            )["state_agent_obj"]
+        obs_env = self._init_env(env, sample, ep_seed_offset=ep_idx, emb_id=emb_id)
+        T_eff = self.max_steps if self.max_steps is not None else int(seq_len)
+        # Both H-Net variants cap at action_horizon: fused pos_emb has
+        # length 2*action_horizon and inference_step sizes the KV cache to
+        # action_horizon. Rolling out past it overflows pos_emb / the cache.
+        _policy = algo.nets["policy"]
+        _ah = int(getattr(_policy, "action_horizon", 0) or 0)
+        if _ah > 0:
+            T_eff = min(T_eff, _ah)
+
+        if not hasattr(algo, "inference_step"):
+            raise RuntimeError(
+                f"Algo {type(algo).__name__} has no inference_step; HNetSimEval "
+                "needs the autoregressive single-step rollout hook."
+            )
+        device = self.trainer.lightning_module.device
+        obs_formatter = _OBS_FORMATTERS[self.embodiment_name]
+
+        frames: List[np.ndarray] = []
+        actions_taken: List[np.ndarray] = []
+        last_coverage = 0.0
+
+        # Delta-action rollout: the model was trained on per-step deltas, so
+        # integrate predictions onto a running absolute cursor seeded from the
+        # env's initial agent position. delta_action=true (config) enables it.
+        _delta = self.delta_action
+        abs_xy = None
+        if _delta:
+            # Seed from the recorded initial cursor action[0] (carried raw as
+            # init_action), NOT agent_pos -- the pusher and cursor can start
+            # 200-400px apart, which would shift the whole integrated path off
+            # screen. Fall back to agent_pos only if init_action is absent.
+            _ia = sample.get("init_action")
+            if _ia is not None:
+                _ia0 = _ia[0]
+                if hasattr(_ia0, "detach"):
+                    _ia0 = _ia0.detach().cpu().numpy()
+                abs_xy = np.asarray(_ia0, dtype=np.float64).reshape(-1)[:2]
+            else:
+                abs_xy = np.asarray(
+                    obs_env["agent_pos"], dtype=np.float64
+                ).reshape(-1)[:2]
+
+        for t in range(T_eff):
+            obs_raw = obs_formatter(obs_env, device)
+            if self.goal_in_obs and "goal_pose" in obs_env:
+                obs_raw["goal_obs"] = torch.as_tensor(
+                    np.asarray(obs_env["goal_pose"], dtype=np.float32).reshape(-1)[:3],
+                    device=device,
+                ).reshape(1, 3)
+            # inference_step: t=0 allocates a fresh AR/KV state; t>0 steps the
+            # cached state. Returns the model's frame action as np.ndarray
+            # (absolute, or a delta when delta_action=true).
+            a_world = np.asarray(algo.inference_step(obs_raw, t, emb_id)).reshape(-1)
+            if _delta:
+                abs_xy = abs_xy + a_world[:2]
+                action_xy = np.array(
+                    [float(abs_xy[0]), float(abs_xy[1])], dtype=np.float64
+                )
+            else:
+                action_xy = np.array(
+                    [float(a_world[0]), float(a_world[1])], dtype=np.float64
+                )
+
+            obs_env, _, terminated, _, info = env.step(action_xy)
+            last_coverage = float(info.get("coverage", 0.0))
+            actions_taken.append(action_xy)
+
+            frame = env.render()
+            if frame is not None:
+                frames.append(np.ascontiguousarray(frame))
+            if terminated:
+                break
+
+        if actions_taken:
+            _a = np.asarray(actions_taken)
+            _first = [[round(float(x), 1) for x in p] for p in actions_taken[:6]]
+            print(
+                f"[HNET_ROLLOUT_DBG] ep={ep_idx} steps={len(actions_taken)} "
+                f"act_x[{_a[:, 0].min():.1f},{_a[:, 0].max():.1f}] "
+                f"act_y[{_a[:, 1].min():.1f},{_a[:, 1].max():.1f}] "
+                f"first6={_first} final_cov={last_coverage:.3f}",
+                flush=True,
+            )
+        return last_coverage, frames, actions_taken
+
+    @torch.no_grad()
+    def _rollout_chunk_te(self, sample, seq_len, emb_id, ep_idx):
+        """H-Net chunk + temporal-ensemble rollout (HPT-style, H4 test). At each
+        env step, generate a K-step plan from the current obs and temporally
+        ensemble overlapping plans. No retrain; eval-only on the AR checkpoint."""
+        algo = self.model
+        policy = algo.nets["policy"]
+        env = self._get_env()
+        sample = dict(sample)
+        if "state_agent_obj" in sample:
+            sample["state_agent_obj"] = algo.norm_stats.unnormalize(
+                {"state_agent_obj": sample["state_agent_obj"]}, emb_id
+            )["state_agent_obj"]
+        obs_env = self._init_env(env, sample, ep_seed_offset=ep_idx, emb_id=emb_id)
+        T_eff = self.max_steps if self.max_steps is not None else int(seq_len)
+        _ah = int(getattr(policy, "action_horizon", 0) or 0)
+        if _ah > 0:
+            T_eff = min(T_eff, _ah)
+        device = self.trainer.lightning_module.device
+        ac_key = getattr(algo, "resolved_ac_keys", algo.ac_keys)[emb_id]
+        obs_formatter = _OBS_FORMATTERS[self.embodiment_name]
+        K = max(1, int(getattr(self, "chunk_k", 32)))
+        chunk_buf = _deque_te()
+        frames: List[np.ndarray] = []
+        actions_taken: List[np.ndarray] = []
+        last_coverage = 0.0
+        for t in range(T_eff):
+            obs_raw = obs_formatter(obs_env, device)
+            if self.goal_in_obs and "goal_pose" in obs_env:
+                obs_raw["goal_obs"] = torch.as_tensor(
+                    np.asarray(obs_env["goal_pose"], dtype=np.float32).reshape(-1)[:3],
+                    device=device,
+                ).reshape(1, 3)
+            obs_norm = algo.norm_stats.normalize(obs_raw, emb_id)
+            chunk = policy.generate(obs_norm, batch_size=1, device=device, T=min(K, T_eff - t))
+            chunk_buf.append((t, chunk[0].detach()))            # (K, A) normalized
+            a_norm = _temporal_ensemble(chunk_buf, t, K, self.te_m)
+            a_world = (
+                algo.norm_stats.unnormalize({ac_key: a_norm}, emb_id)[ac_key]
+                .detach().cpu().numpy().reshape(-1)
+            )
+            action_xy = np.array([float(a_world[0]), float(a_world[1])], dtype=np.float64)
+            obs_env, _, terminated, _, info = env.step(action_xy)
+            last_coverage = float(info.get("coverage", 0.0))
+            actions_taken.append(action_xy)
+            frame = env.render()
+            if frame is not None:
+                frames.append(np.ascontiguousarray(frame))
+            if terminated:
+                break
+        if actions_taken:
+            _a = np.asarray(actions_taken)
+            print(
+                f"[HNET_CHUNKTE_DBG] ep={ep_idx} steps={len(actions_taken)} "
+                f"act_x[{_a[:,0].min():.1f},{_a[:,0].max():.1f}] final_cov={last_coverage:.3f}",
+                flush=True,
+            )
+        return last_coverage, frames, actions_taken

--- a/egomimic/eval/eval_video.py
+++ b/egomimic/eval/eval_video.py
@@ -20,6 +20,7 @@ class EvalVideo(Eval):
         limit_val_batches: int = 400,
         viz_func: dict = None,
         transform_lists: dict | None = None,
+        max_videos: int | None = None,
     ):
         super().__init__()
         self.trainer = None
@@ -29,6 +30,7 @@ class EvalVideo(Eval):
         # the model's wrist-frame actions back into cam (head) frame. Reused for
         # both cam-frame MSE and the viz video so we don't transform twice.
         self.transform_lists = transform_lists or {}
+        self.max_videos = max_videos
         self.val_image_buffer = {}
         self.val_counter = {}
         self.override_dict = {

--- a/egomimic/hydra_configs/data/tsimulation_hpt_causal.yaml
+++ b/egomimic/hydra_configs/data/tsimulation_hpt_causal.yaml
@@ -1,0 +1,53 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# Fast in-memory variant of tsimulation_hpt.yaml. Identical batch contract
+# (per-frame obs + length-`action_horizon` action chunk for pushshapes_sim),
+# but each episode is decoded into RAM once at construction by
+# InMemoryZarrDataset, so __getitem__ is a slice + uint8->float cast with no
+# per-sample JPEG decode. The decode happens in the parent process before the
+# DataLoader forks, so the image buffers are shared to workers copy-on-write.
+#
+# Only difference from tsimulation_hpt.yaml: the resolver _target_, the
+# folder_path (new_circle_3), and tuned dataloader params. Everything
+# downstream (normalize / bounds / collate / norm_stats / model) is unchanged.
+
+train_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_inmem.InMemoryLocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/new_circle_3
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_causal
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_inmem.InMemoryLocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/new_circle_3
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_causal
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 10
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 10
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4

--- a/egomimic/hydra_configs/data/tsimulation_hpt_fast.yaml
+++ b/egomimic/hydra_configs/data/tsimulation_hpt_fast.yaml
@@ -1,0 +1,53 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# Fast in-memory variant of tsimulation_hpt.yaml. Identical batch contract
+# (per-frame obs + length-`action_horizon` action chunk for pushshapes_sim),
+# but each episode is decoded into RAM once at construction by
+# InMemoryZarrDataset, so __getitem__ is a slice + uint8->float cast with no
+# per-sample JPEG decode. The decode happens in the parent process before the
+# DataLoader forks, so the image buffers are shared to workers copy-on-write.
+#
+# Only difference from tsimulation_hpt.yaml: the resolver _target_, the
+# folder_path (new_circle_3), and tuned dataloader params. Everything
+# downstream (normalize / bounds / collate / norm_stats / model) is unchanged.
+
+train_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_inmem.InMemoryLocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/new_circle_3
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_inmem.InMemoryLocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/new_circle_3
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 10
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 10
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4

--- a/egomimic/hydra_configs/evaluator/eval_hnet_full.yaml
+++ b/egomimic/hydra_configs/evaluator/eval_hnet_full.yaml
@@ -1,0 +1,46 @@
+# H-Net full validation evaluator: val data viz + PCA + boundary strips + sim eval.
+#
+# Layout:
+#   1. composite (EvalVideoList) — HNetEvalVideo + PCATokenEval +
+#      BoundaryStripEval rendered side-by-side as one .mp4.
+#   2. sim — SimRolloutEval closed-loop rollout, capped at 2 videos via
+#      max_videos so the saved .mp4 stays small regardless of batch size.
+
+_target_: egomimic.eval.eval_composite.EvalList
+
+evals:
+  - _target_: egomimic.eval.eval_composite.EvalVideoList
+    pad_h: max
+    limit_val_batches: 4
+    evals:
+      - _target_: egomimic.eval.eval_hnet.HNetEvalVideo
+        limit_val_batches: 4
+        max_videos: 2
+        viz_func:
+          pushshapes_sim:
+            _target_: hydra.utils.get_method
+            path: egomimic.rldb.embodiment.pushshapes.viz_gt_preds
+      - _target_: egomimic.eval.eval_pca_tokens.PCATokenEval
+        limit_val_batches: 4
+        max_videos: 2
+        panel_h: 384
+        panel_w: 384
+        n_components: 2
+      - _target_: egomimic.eval.eval_boundary_strip.BoundaryStripEval
+        limit_val_batches: 4
+        max_videos: 2
+        window: 256
+        strip_width: 24
+        pixels_per_step: 1
+  - _target_: egomimic.eval.eval_sim.HNetSimEval
+    limit_val_batches: 4
+    max_videos: 2
+    embodiment_name: pushshapes_sim
+    init_mode: replay
+    max_steps: 1200
+    coverage_threshold: 0.7
+    env_kwargs:
+      object_shape: T
+      pusher_shape: circle
+      obstacle_level: 0
+      image_size: 96

--- a/egomimic/hydra_configs/evaluator/eval_hnet_sim.yaml
+++ b/egomimic/hydra_configs/evaluator/eval_hnet_sim.yaml
@@ -1,4 +1,4 @@
-_target_: egomimic.eval.eval_sim.SimRolloutEval
+_target_: egomimic.eval.eval_sim.HNetSimEval
 
 # Closed-loop sim eval. For each val episode, resets PushShapesEnv (init
 # mode is configurable) and steps the env one frame at a time using the
@@ -17,13 +17,13 @@ env_kwargs:
 #     match to current teacher-forced eval semantics).
 #   random: env.reset(seed=ep_idx) per rollout (random goal etc).
 #   seeds:  cycle through ``init_seeds`` per rollout (reproducible suite).
-init_mode: "replay"
-init_seeds: [0, 1, 2, 3]
+init_mode: seeds
+init_seeds: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
 
 # ---- Rollout knobs ----
 # When null, replay mode uses the recorded episode length; random/seeds
 # fall back to 200.
-max_steps: null
+max_steps: 1200
 coverage_threshold: 0.7
 video_fps: 30
 
@@ -36,3 +36,10 @@ limit_val_batches: 4
 # the sim's own rendered frames are the viz. Leave null.
 viz_func: null
 transform_lists: null
+
+# rollout-mode knobs (config-driven)
+delta_action: false
+temporal_ensemble: false
+rollout_mode: ar
+chunk_k: 32
+goal_in_obs: false

--- a/egomimic/hydra_configs/evaluator/eval_sim_only.yaml
+++ b/egomimic/hydra_configs/evaluator/eval_sim_only.yaml
@@ -1,0 +1,21 @@
+# Sim-rollout-only evaluator: closed-loop PushShapes rollout + coverage, no
+# composite (HNetEvalVideo/PCA/BoundaryStrip). The composite needs per-frame
+# batches (pad_mask, (B,S,D)) while SimRolloutEval needs packed batches
+# (cu_seqlens) — they can't share one data config, so for rollout videos we run
+# SimRolloutEval alone. coverage_threshold=0.8 = the success criterion.
+_target_: egomimic.eval.eval_sim.SimRolloutEval
+limit_val_batches: 8
+embodiment_name: pushshapes_sim
+init_mode: seeds
+max_steps: null          # use recorded episode length
+coverage_threshold: 0.8
+env_kwargs:
+  object_shape: T
+  pusher_shape: circle
+  obstacle_level: 0
+  image_size: 96
+
+temporal_ensemble: true
+te_m: 0.01
+
+init_seeds: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]

--- a/egomimic/hydra_configs/model/hnet_pushshapes_fused_goal.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_fused_goal.yaml
@@ -23,6 +23,10 @@ robomimic_model:
         input_slice: [0, 2]
         embed_dim: 64
         widths: [128]
+      goal_obs:
+        input_dim: 3
+        embed_dim: 64
+        widths: [128]
     img_encoders:
       front_img_1:
         _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv

--- a/egomimic/hydra_configs/model/hnet_pushshapes_fused_pusher.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_fused_pusher.yaml
@@ -1,0 +1,53 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.HNetFused
+  action_dim: 2
+  action_horizon: 400
+  d_model: 128
+  d_cond: 128
+  cond_encoder:
+    _target_: egomimic.models.hnet_nets.cond_encoders.CondEncoderModule
+    d_cond: 128
+    output_key: fused_cond
+    cond_proj_widths:
+    - 128
+    - 128
+    obs_specs:
+      state_agent_obj:
+        input_dim: 2
+        embed_dim: 64
+        widths:
+        - 128
+        input_slice:
+        - 0
+        - 2
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv
+        in_channels: 3
+        channels:
+        - 32
+        - 64
+        - 128
+        - 256
+        kernel_size: 3
+        stride: 2
+        embed_dim: 128
+        norm_groups: 8
+  arch_layout: T8
+  num_heads: 4
+  d_intermediate: 512
+  domains:
+  - pushshapes_sim
+  ac_keys:
+    pushshapes_sim: actions
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/hydra_configs/model/hnet_pushshapes_goal.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_goal.yaml
@@ -29,6 +29,10 @@ robomimic_model:
         input_slice: [0, 2]
         embed_dim: 64
         widths: [128]
+      goal_obs:
+        input_dim: 3
+        embed_dim: 64
+        widths: [128]
     img_encoders:
       front_img_1:
         _target_: egomimic.models.hnet_nets.image_encoders.SimpleConv

--- a/egomimic/hydra_configs/model/hnet_pushshapes_recipe.yaml
+++ b/egomimic/hydra_configs/model/hnet_pushshapes_recipe.yaml
@@ -13,7 +13,7 @@ robomimic_model:
   #   - weight_decay: 0.01               (used by parameter_groups)
   #   - optimizer.lr: 5e-5               (half of baseline 1e-4)
   action_dim: 2
-  action_horizon: 1024
+  action_horizon: 400
   d_model: 128
   d_cond: 128
 

--- a/egomimic/hydra_configs/model/hpt_pushshapes_circle_regression.yaml
+++ b/egomimic/hydra_configs/model/hpt_pushshapes_circle_regression.yaml
@@ -1,0 +1,113 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hpt.HPT
+  camera_transforms: null
+  diffusion: false
+  6dof: false
+  ac_keys:
+    pushshapes_sim: actions
+  trunk:
+    embed_dim: 128
+    num_blocks: 6
+    num_heads: 4
+    token_postprocessing: action_token
+    observation_horizon: 1
+    action_horizon: 32
+    no_trunk: false
+    use_domain_embedding: true
+    drop_path: 0.1
+    weight_init_style: pytorch
+  multitask: false
+  pretrained: false
+  pretrained_checkpoint: ''
+  reverse_kl_samples: 8
+  domains:
+  - pushshapes_sim
+  shared_obs_keys:
+  - front_img_1
+  shared_stem_specs:
+    front_img_1:
+      _target_: egomimic.models.hpt_nets.MLPPolicyStem
+      input_dim: 128
+      output_dim: 128
+      widths:
+      - 128
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 4
+          crossattn_dim_head: 32
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 128
+  stem_specs:
+    pushshapes_sim:
+      state_agent_obj:
+        _target_: egomimic.models.hpt_nets.MLPPolicyStem
+        input_dim: 2
+        input_slice: [0, 2]
+        output_dim: 128
+        widths:
+        - 128
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 4
+            crossattn_dim_head: 32
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 128
+  head_specs:
+    pushshapes_sim:
+      _target_: egomimic.models.hpt_nets.MLPPolicyHead
+      input_dim: 128
+      output_dim: 64
+      widths:
+      - 256
+      - 256
+      dropout: false
+      ln: true
+      tanh_end: false
+  encoder_specs:
+    front_img_1:
+      _target_: egomimic.models.hpt_nets.ResNet
+      output_dim: 128
+  train_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+    - _target_: torchvision.transforms.ColorJitter
+      brightness: 0.1
+      contrast: 0.1
+      saturation: 0.1
+      hue: 0.05
+    - _target_: torchvision.transforms.Normalize
+      mean:
+      - 0.485
+      - 0.456
+      - 0.406
+      std:
+      - 0.229
+      - 0.224
+      - 0.225
+  eval_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+    - _target_: torchvision.transforms.Normalize
+      mean:
+      - 0.485
+      - 0.456
+      - 0.406
+      std:
+      - 0.229
+      - 0.224
+      - 0.225
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/models/hnet_nets/__init__.py
+++ b/egomimic/models/hnet_nets/__init__.py
@@ -1,8 +1,18 @@
+from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
 from egomimic.models.hnet_nets.context import HNetContext
 from egomimic.models.hnet_nets.hnet import HNet, ratio_loss_from_aux
-from egomimic.models.hnet_nets.cond_encoders import CondEncoderModule
 from egomimic.models.hnet_nets.stages import (
-    EncoderDecoderStage,
     ChunkerStage,
     ComputeStage,
+    EncoderDecoderStage,
 )
+
+__all__ = [
+    "CondEncoderModule",
+    "HNetContext",
+    "HNet",
+    "ratio_loss_from_aux",
+    "ChunkerStage",
+    "ComputeStage",
+    "EncoderDecoderStage",
+]

--- a/egomimic/models/hnet_nets/_smoke_stages.py
+++ b/egomimic/models/hnet_nets/_smoke_stages.py
@@ -10,7 +10,6 @@ forward pass with dummy actions + cond_dict, verifies output shape and that
 the chunker registered its bpred entry into ctx.aux, then runs step() across
 all T tokens and compares to the cached forward output.
 """
-import math
 
 import torch
 
@@ -29,12 +28,18 @@ def build_tiny_hnet(d_model: int = 64, d_inner: int = 64, d_cond: int = 64) -> H
             input_hidden_dim=d_model,
             output_hidden_dim=d_model,
             encoder=dict(
-                arch_layout="T2", d_model=d_model, d_intermediate=128,
-                num_heads=4, cond=True,
+                arch_layout="T2",
+                d_model=d_model,
+                d_intermediate=128,
+                num_heads=4,
+                cond=True,
             ),
             decoder=dict(
-                arch_layout="T2", d_model=d_model, d_intermediate=128,
-                num_heads=4, cond=True,
+                arch_layout="T2",
+                d_model=d_model,
+                d_intermediate=128,
+                num_heads=4,
+                cond=True,
             ),
             cond_key="fused_cond",
             d_cond=d_cond,
@@ -51,11 +56,14 @@ def build_tiny_hnet(d_model: int = 64, d_inner: int = 64, d_cond: int = 64) -> H
             input_hidden_dim=d_inner,
             output_hidden_dim=d_inner,
             main_network=dict(
-                arch_layout="T2", d_model=d_inner, d_intermediate=128,
-                num_heads=4, cond=False,
+                arch_layout="T2",
+                d_model=d_inner,
+                d_intermediate=128,
+                num_heads=4,
+                cond=False,
             ),
             cond_key="fused_cond",
-            d_cond=0,            # inner stage has no AdaLN
+            d_cond=0,  # inner stage has no AdaLN
             causal=True,
         ),
     ]
@@ -93,14 +101,19 @@ def main():
 
     # --- step parity ---
     state = hnet.allocate_inference_cache(
-        batch_size=B, max_seqlen=T, device=x_full.device, dtype=torch.float32,
+        batch_size=B,
+        max_seqlen=T,
+        device=x_full.device,
+        dtype=torch.float32,
     )
     y_step = torch.zeros_like(y_full)
     with torch.no_grad():
         for t in range(T):
             cond_t = cond[:, t]
             step_ctx = HNetContext(
-                cond_dict={"fused_cond": cond_t}, aux=[], inference_params=state,
+                cond_dict={"fused_cond": cond_t},
+                aux=[],
+                inference_params=state,
             )
             y_t = hnet.step(x_full[:, t : t + 1], step_ctx)
             y_step[:, t : t + 1] = y_t
@@ -110,10 +123,12 @@ def main():
 
     tol = 5e-4
     if diff > tol:
-        print(f"WARN: step/forward divergence above tol={tol}. "
-              f"This can happen when chunker boundary patterns differ between "
-              f"the padded full-context path and the per-token step path "
-              f"(known difference inherited from the original H-Net design).")
+        print(
+            f"WARN: step/forward divergence above tol={tol}. "
+            f"This can happen when chunker boundary patterns differ between "
+            f"the padded full-context path and the per-token step path "
+            f"(known difference inherited from the original H-Net design)."
+        )
     else:
         print(f"OK: step/forward agree within {tol}.")
 

--- a/egomimic/models/hnet_nets/blocks.py
+++ b/egomimic/models/hnet_nets/blocks.py
@@ -132,8 +132,90 @@ def _adaln(x, scale, shift):
     return x * (1 + scale) + shift
 
 
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    """Apply RoPE to the leading ``rotary_dim`` channels of ``x``.
+
+    Mirrors ``flash_attn.layers.rotary.apply_rotary_emb_torch`` (non-interleaved,
+    i.e. GPT-NeoX style — rotate first/second halves). Works on any leading
+    shape; the last dim of ``x`` is ``head_dim``, and ``cos/sin`` are
+    broadcastable along all dims except the rotary-channel axis.
+
+    x:        (..., head_dim)
+    cos, sin: (..., rotary_dim / 2)  with positions aligned to x's positional
+              axis (caller is responsible for shaping so they broadcast).
+    """
+    rotary_dim = cos.shape[-1] * 2
+    assert rotary_dim <= x.shape[-1]
+    x_rot = x[..., :rotary_dim]
+    x_pass = x[..., rotary_dim:]
+    # Stack cos/sin into the rotary-channel layout: (..., rotary_dim).
+    cos_full = torch.cat([cos, cos], dim=-1).to(x.dtype)
+    sin_full = torch.cat([sin, sin], dim=-1).to(x.dtype)
+    out_rot = x_rot * cos_full + _rotate_half(x_rot) * sin_full
+    return torch.cat([out_rot, x_pass], dim=-1) if x_pass.numel() > 0 else out_rot
+
+
+class _RotaryCache(nn.Module):
+    """Cached cos/sin tables for RoPE.
+
+    Holds a cache sized to the largest seqlen seen so far. ``get(positions)``
+    returns ``(cos, sin)`` indexed by an arbitrary 1D position tensor —
+    crucial for packed mode where positions are per-subseq, not contiguous.
+    """
+
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        assert dim % 2 == 0, "rotary_emb_dim must be even"
+        self.dim = dim
+        self.base = float(base)
+        inv_freq = 1.0 / (
+            self.base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+        )
+        # Buffer so it follows .to(device); not persistent (no state_dict bloat).
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Optional[torch.Tensor] = None
+        self._sin_cached: Optional[torch.Tensor] = None
+        # ``_no_reinit`` keeps the residual-stream init from touching the
+        # frozen freq table even though it isn't a Linear weight.
+        self.inv_freq._no_reinit = True
+
+    def _maybe_resize(self, seqlen: int, device, dtype):
+        if (
+            self._cos_cached is None
+            or seqlen > self._seq_len_cached
+            or self._cos_cached.device != device
+            or self._cos_cached.dtype != dtype
+        ):
+            t = torch.arange(seqlen, device=device, dtype=torch.float32)
+            inv = self.inv_freq.to(device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv)  # (seqlen, dim/2)
+            self._cos_cached = freqs.cos().to(dtype)
+            self._sin_cached = freqs.sin().to(dtype)
+            self._seq_len_cached = seqlen
+
+    def get(self, positions: torch.Tensor, dtype: torch.dtype):
+        """positions: (N,) long. Returns (cos, sin) each (N, dim/2)."""
+        max_pos = int(positions.max().item()) + 1 if positions.numel() > 0 else 1
+        self._maybe_resize(max_pos, positions.device, dtype)
+        return self._cos_cached[positions], self._sin_cached[positions]
+
+
 class MultiHeadAttention(nn.Module):
-    def __init__(self, d_model, num_heads, causal=False, dropout=0.0):
+    def __init__(
+        self,
+        d_model,
+        num_heads,
+        causal=False,
+        dropout=0.0,
+        rotary_emb_dim: int = 0,
+        rotary_emb_base: float = 10000.0,
+    ):
         super().__init__()
         assert d_model % num_heads == 0
         self.d_model = d_model
@@ -143,6 +225,18 @@ class MultiHeadAttention(nn.Module):
         self.qkv = nn.Linear(d_model, 3 * d_model, bias=True)
         self.out_proj = nn.Linear(d_model, d_model, bias=True)
         self.dropout = dropout
+        # RoPE (F6): when > 0, rotate the leading ``rotary_emb_dim`` channels
+        # of q/k before attention. ``rotary_emb_dim <= head_dim``. Mirrors
+        # upstream ``goombalab/hnet/hnet/modules/mha.py:CausalMHA``.
+        self.rotary_emb_dim = int(rotary_emb_dim)
+        assert self.rotary_emb_dim <= self.head_dim, (
+            f"rotary_emb_dim ({self.rotary_emb_dim}) must be <= head_dim "
+            f"({self.head_dim})"
+        )
+        if self.rotary_emb_dim > 0:
+            self.rotary_emb = _RotaryCache(self.rotary_emb_dim, base=rotary_emb_base)
+        else:
+            self.rotary_emb = None
 
     def forward(
         self,
@@ -165,6 +259,15 @@ class MultiHeadAttention(nn.Module):
         B, L, D = x.shape
         qkv = self.qkv(x).reshape(B, L, 3, self.num_heads, self.head_dim)
         q, k, v = qkv.unbind(dim=2)
+        # RoPE on q/k (F6). Positions are 0..L-1, broadcast over batch + heads.
+        if self.rotary_emb is not None:
+            positions = torch.arange(L, device=x.device)
+            cos, sin = self.rotary_emb.get(positions, q.dtype)  # (L, dim/2)
+            # Broadcast shape: (1, L, 1, dim/2) to match (B, L, H, head_dim).
+            cos = cos[None, :, None, :]
+            sin = sin[None, :, None, :]
+            q = _apply_rotary(q, cos, sin)
+            k = _apply_rotary(k, cos, sin)
         q = q.transpose(1, 2)
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
@@ -174,14 +277,20 @@ class MultiHeadAttention(nn.Module):
             attn_mask = mask[:, None, None, :].to(dtype=torch.bool)
             attn_mask = attn_mask & attn_mask.transpose(-1, -2)
 
-        out = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=attn_mask,
-            dropout_p=self.dropout if self.training else 0.0,
-            is_causal=self.causal,
-        )
+        _W = getattr(self, "window", 0)
+        if _W > 0 and self.causal:
+            _p = torch.arange(q.shape[2], device=q.device)
+            _wm = ((_p[:, None] >= _p[None, :]) & (_p[:, None] - _p[None, :] < _W))[None, None]
+            attn_mask = _wm if attn_mask is None else (attn_mask & _wm)
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask,
+                dropout_p=self.dropout if self.training else 0.0, is_causal=False,
+            )
+        else:
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask,
+                dropout_p=self.dropout if self.training else 0.0, is_causal=self.causal,
+            )
         out = out.transpose(1, 2).reshape(B, L, D)
         return self.out_proj(out)
 
@@ -190,6 +299,22 @@ class MultiHeadAttention(nn.Module):
         T_total, D = x.shape
         qkv = self.qkv(x).reshape(T_total, 3, self.num_heads, self.head_dim)
         q, k, v = qkv.unbind(dim=1)  # each (T_total, H, Dh)
+
+        # RoPE on q/k in packed mode (F6). Positions are PER-SUBSEQ: token t
+        # at global index i belongs to subseq s with start cu_seqlens[s], so
+        # its rotary position is ``i - cu_seqlens[s]``. This avoids the
+        # cross-subseq position leakage that would happen with a single
+        # global arange.
+        if self.rotary_emb is not None:
+            pos_global = torch.arange(T_total, device=x.device)
+            seq_idx = (pos_global[:, None] >= cu_seqlens[None, 1:]).sum(dim=-1)
+            local_pos = pos_global - cu_seqlens[seq_idx]  # (T_total,)
+            cos, sin = self.rotary_emb.get(local_pos, q.dtype)  # (T_total, dim/2)
+            # Broadcast over heads: (T_total, 1, dim/2).
+            cos = cos[:, None, :]
+            sin = sin[:, None, :]
+            q = _apply_rotary(q, cos, sin)
+            k = _apply_rotary(k, cos, sin)
 
         # flash_attn_varlen_func ONLY supports fp16 / bf16. Under bf16
         # autocast (Lightning ``trainer.precision=bf16-mixed``) q/k/v
@@ -202,6 +327,7 @@ class MultiHeadAttention(nn.Module):
                 if max_seqlen is not None
                 else int((cu_seqlens[1:] - cu_seqlens[:-1]).max().item())
             )
+            _W = getattr(self, "window", 0)
             out = flash_attn_varlen_func(
                 q,
                 k,
@@ -212,6 +338,7 @@ class MultiHeadAttention(nn.Module):
                 max_seqlen_k=ms,
                 dropout_p=self.dropout if self.training else 0.0,
                 causal=self.causal,
+                window_size=((_W - 1, 0) if (_W > 0 and self.causal) else (-1, -1)),
             )
             # flash_attn returns (T_total, H, Dh)
             out = out.reshape(T_total, D)
@@ -228,6 +355,9 @@ class MultiHeadAttention(nn.Module):
         same_seq = seq_idx[:, None] == seq_idx[None, :]
         if self.causal:
             causal_mask = pos[:, None] >= pos[None, :]
+            _W = getattr(self, "window", 0)
+            if _W > 0:
+                causal_mask = causal_mask & (pos[:, None] - pos[None, :] < _W)
             attn_mask = (same_seq & causal_mask)[None, None]
         else:
             attn_mask = same_seq[None, None]
@@ -269,7 +399,18 @@ class MultiHeadAttention(nn.Module):
         # x: (B, 1, D). Per-batch K/V scatter + attn against valid prior slots.
         B, _, D = x.shape
         qkv = self.qkv(x).reshape(B, 1, 3, self.num_heads, self.head_dim)
-        q, k, v = qkv.unbind(dim=2)
+        q, k, v = qkv.unbind(dim=2)  # each (B, 1, H, head_dim)
+
+        # RoPE on q/k at the current AR position (F6). Each batch element may
+        # be at a different ``cache.offsets`` (variable-length rollouts), so
+        # we look up cos/sin per-row.
+        if self.rotary_emb is not None:
+            cos, sin = self.rotary_emb.get(cache.offsets, q.dtype)  # (B, dim/2)
+            cos = cos[:, None, None, :]  # (B, 1, 1, dim/2) -> broadcast over (1, H)
+            sin = sin[:, None, None, :]
+            q = _apply_rotary(q, cos, sin)
+            k = _apply_rotary(k, cos, sin)
+
         q = q.transpose(1, 2)
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
@@ -282,9 +423,15 @@ class MultiHeadAttention(nn.Module):
         max_T = cache.k.shape[2]
         pos = torch.arange(max_T, device=x.device)
         attn_mask = pos[None, :] < cache.offsets[:, None]
+        _W = getattr(self, "window", 0)
+        if _W > 0:
+            attn_mask = attn_mask & (pos[None, :] >= cache.offsets[:, None] - _W)
         attn_mask = attn_mask[:, None, None, :]
 
-        out = F.scaled_dot_product_attention(q, cache.k, cache.v, attn_mask=attn_mask)
+        # AR inference: never apply dropout regardless of training flag.
+        out = F.scaled_dot_product_attention(
+            q, cache.k, cache.v, attn_mask=attn_mask, dropout_p=0.0
+        )
         out = out.transpose(1, 2).reshape(B, 1, D)
         return self.out_proj(out)
 
@@ -351,6 +498,9 @@ class CrossMultiHeadAttention(nn.Module):
         same_seq = seq_idx[:, None] == seq_idx[None, :]
         if self.causal:
             causal_mask = pos[:, None] >= pos[None, :]
+            _W = getattr(self, "window", 0)
+            if _W > 0:
+                causal_mask = causal_mask & (pos[:, None] - pos[None, :] < _W)
             attn_mask = (same_seq & causal_mask)[None, None]
         else:
             attn_mask = same_seq[None, None]
@@ -446,6 +596,9 @@ class TransformerBlock(nn.Module):
         causal=False,
         d_cond=0,
         cond_mode: str = "adaln",
+        rotary_emb_dim: int = 0,
+        dropout: float = 0.0,
+        resid_dropout: float = 0.0,
     ):
         super().__init__()
         self.has_mlp = d_intermediate > 0
@@ -455,10 +608,25 @@ class TransformerBlock(nn.Module):
         if self.cond_mode not in ("adaln", "cross_attn", "none"):
             raise ValueError(f"Unknown cond_mode: {self.cond_mode}")
         self.norm1 = RMSNorm(d_model)
-        self.mixer = MultiHeadAttention(d_model, num_heads, causal=causal)
+        # F6: plumb rotary_emb_dim into the self-attn mixer. Cross-attn (cond
+        # tokens) intentionally does NOT use RoPE — cond positions are per-
+        # frame conditioning, not autoregressive token positions.
+        # ``dropout`` is the attention-softmax dropout (forwarded into MHA).
+        self.mixer = MultiHeadAttention(
+            d_model,
+            num_heads,
+            causal=causal,
+            dropout=dropout,
+            rotary_emb_dim=rotary_emb_dim,
+        )
+        # Residual-branch dropout (applied to attn/ffn outputs before the
+        # residual add). Default 0.0 — keeps existing call sites unaffected.
+        self.resid_dropout = float(resid_dropout)
+        self.attn_resid_drop = nn.Dropout(self.resid_dropout)
         if self.has_mlp:
             self.norm2 = RMSNorm(d_model)
             self.mlp = SwiGLU(d_model, d_intermediate)
+            self.ffn_resid_drop = nn.Dropout(self.resid_dropout)
         if self.cond_mode == "adaln":
             self.adaln1 = AdaLNModulation(d_cond, d_model)
             if self.has_mlp:
@@ -468,6 +636,7 @@ class TransformerBlock(nn.Module):
             self.cross_attn = CrossMultiHeadAttention(
                 d_model=d_model, d_cond=d_cond, num_heads=num_heads, causal=causal
             )
+            self.cross_resid_drop = nn.Dropout(self.resid_dropout)
 
     def forward(self, x, mask=None, cond=None, cu_seqlens=None, max_seqlen=None):
         # Self-attention.
@@ -475,13 +644,17 @@ class TransformerBlock(nn.Module):
         if self.cond_mode == "adaln" and cond is not None:
             s, b = self.adaln1(cond)
             h = _adaln(h, s, b)
-        x = x + self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        x = x + self.attn_resid_drop(
+            self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        )
 
         # Cross-attention (if enabled).
         if self.cond_mode == "cross_attn" and cond is not None:
             h = self.cross_norm(x)
-            x = x + self.cross_attn(
-                h, cond, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            x = x + self.cross_resid_drop(
+                self.cross_attn(
+                    h, cond, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                )
             )
 
         # MLP.
@@ -490,7 +663,7 @@ class TransformerBlock(nn.Module):
             if self.cond_mode == "adaln" and cond is not None:
                 s, b = self.adaln2(cond)
                 h = _adaln(h, s, b)
-            x = x + self.mlp(h)
+            x = x + self.ffn_resid_drop(self.mlp(h))
         return x
 
     def allocate_inference_cache(self, batch_size, max_seqlen, device, dtype):
@@ -527,12 +700,13 @@ class TransformerBlock(nn.Module):
         else:
             self_cache, cross_cache = cache, None
 
-        # Self-attention.
+        # Self-attention. Residual dropout modules are still applied — in
+        # eval/AR mode they are identity (self.training=False).
         h = self.norm1(x)
         if self.cond_mode == "adaln" and cond is not None:
             s, b = self.adaln1(cond)
             h = _adaln(h, s, b)
-        x = x + self.mixer.step(h, self_cache)
+        x = x + self.attn_resid_drop(self.mixer.step(h, self_cache))
 
         # Cross-attention.
         if self.cond_mode == "cross_attn" and cond is not None:
@@ -544,7 +718,9 @@ class TransformerBlock(nn.Module):
             # an explicit time dim.
             cond_curr = cond.unsqueeze(1) if cond.dim() == 2 else cond
             h = self.cross_norm(x)
-            x = x + self.cross_attn.step(h, cond_curr, cross_cache)
+            x = x + self.cross_resid_drop(
+                self.cross_attn.step(h, cond_curr, cross_cache)
+            )
 
         # MLP.
         if self.has_mlp:
@@ -552,7 +728,7 @@ class TransformerBlock(nn.Module):
             if self.cond_mode == "adaln" and cond is not None:
                 s, b = self.adaln2(cond)
                 h = _adaln(h, s, b)
-            x = x + self.mlp(h)
+            x = x + self.ffn_resid_drop(self.mlp(h))
         return x
 
 
@@ -632,6 +808,7 @@ class MambaBlock(nn.Module):
         ssm_cfg: Optional[dict] = None,
         device=None,
         dtype=None,
+        resid_dropout: float = 0.0,
     ):
         super().__init__()
         self.has_mlp = d_intermediate > 0
@@ -640,9 +817,13 @@ class MambaBlock(nn.Module):
         self.mixer = Mamba2Mixer(
             d_model, layer_idx=layer_idx, ssm_cfg=ssm_cfg, device=device, dtype=dtype
         )
+        # Residual-branch dropout (analogous to TransformerBlock).
+        self.resid_dropout = float(resid_dropout)
+        self.mixer_resid_drop = nn.Dropout(self.resid_dropout)
         if self.has_mlp:
             self.norm2 = RMSNorm(d_model)
             self.mlp = SwiGLU(d_model, d_intermediate)
+            self.ffn_resid_drop = nn.Dropout(self.resid_dropout)
         if self.has_cond:
             self.adaln1 = AdaLNModulation(d_cond, d_model)
             if self.has_mlp:
@@ -653,14 +834,16 @@ class MambaBlock(nn.Module):
         if self.has_cond and cond is not None:
             s, b = self.adaln1(cond)
             h = _adaln(h, s, b)
-        x = x + self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        x = x + self.mixer_resid_drop(
+            self.mixer(h, mask=mask, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        )
 
         if self.has_mlp:
             h = self.norm2(x)
             if self.has_cond and cond is not None:
                 s, b = self.adaln2(cond)
                 h = _adaln(h, s, b)
-            x = x + self.mlp(h)
+            x = x + self.ffn_resid_drop(self.mlp(h))
         return x
 
     def step(self, x, cache: MambaCache, cond: Optional[torch.Tensor] = None):
@@ -668,14 +851,14 @@ class MambaBlock(nn.Module):
         if self.has_cond and cond is not None:
             s, b = self.adaln1(cond)
             h = _adaln(h, s, b)
-        x = x + self.mixer.step(h, cache)
+        x = x + self.mixer_resid_drop(self.mixer.step(h, cache))
 
         if self.has_mlp:
             h = self.norm2(x)
             if self.has_cond and cond is not None:
                 s, b = self.adaln2(cond)
                 h = _adaln(h, s, b)
-            x = x + self.mlp(h)
+            x = x + self.ffn_resid_drop(self.mlp(h))
         return x
 
 
@@ -698,6 +881,14 @@ class Isotropic(nn.Module):
         self.cond_mode = cond_mode
         attn_cfg = get_stage_cfg(config.attn_cfg, stage_idx)
         num_heads = attn_cfg.get("num_heads", 8)
+        # F6: per-stage rotary_emb_dim. ``AttnConfig.rotary_emb_dim`` is a
+        # per-stage list (parallel to ``num_heads``); 0 disables RoPE in this
+        # stage.
+        rotary_emb_dim = int(attn_cfg.get("rotary_emb_dim", 0) or 0)
+        # Per-stage dropout knobs (default 0.0 — existing call sites that
+        # don't set them in their AttnConfig stay unaffected).
+        attn_dropout = float(attn_cfg.get("dropout", 0.0) or 0.0)
+        resid_dropout = float(attn_cfg.get("resid_dropout", 0.0) or 0.0)
         ssm_cfg = (
             get_stage_cfg(config.ssm_cfg, stage_idx)
             if hasattr(config, "ssm_cfg")
@@ -730,6 +921,9 @@ class Isotropic(nn.Module):
                         causal=causal,
                         d_cond=d_cond if cond_here else 0,
                         cond_mode=cond_mode,
+                        rotary_emb_dim=rotary_emb_dim,
+                        dropout=attn_dropout,
+                        resid_dropout=resid_dropout,
                     )
                 else:  # 'm' or 'M'
                     blk = MambaBlock(
@@ -738,6 +932,7 @@ class Isotropic(nn.Module):
                         d_intermediate=d_int,
                         d_cond=d_cond if cond_here else 0,
                         ssm_cfg=ssm_cfg or None,
+                        resid_dropout=resid_dropout,
                     )
                 blocks.append(blk)
                 self.arch_full.append(arch)

--- a/egomimic/models/hnet_nets/cond_encoders.py
+++ b/egomimic/models/hnet_nets/cond_encoders.py
@@ -12,13 +12,16 @@ Output:
     optionally per-obs raw embeddings keyed by their obs name when
     ``per_obs_keys=True`` (useful if a stage wants un-fused cond).
 """
+
 from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
 
 
-def _mlp(in_dim: int, out_dim: int, widths: Optional[List[int]] = None) -> nn.Sequential:
+def _mlp(
+    in_dim: int, out_dim: int, widths: Optional[List[int]] = None
+) -> nn.Sequential:
     widths = widths or []
     layers: List[nn.Module] = []
     prev = in_dim
@@ -60,12 +63,19 @@ class CondEncoderModule(nn.Module):
         obs_specs = obs_specs or {}
         self.obs_keys = sorted(obs_specs.keys())
         self.obs_encoders = nn.ModuleDict()
+        # Optional per-key input slice: spec["input_slice"] = [start, end] picks
+        # x[..., start:end] before the MLP. Lets a multi-component proprio
+        # tensor feed only a subset into the encoder without resaving the zarr.
+        self.obs_input_slices: Dict[str, slice] = {}
         fused_dim = 0
         for key in self.obs_keys:
             spec = obs_specs[key]
             self.obs_encoders[key] = _mlp(
                 spec["input_dim"], spec["embed_dim"], spec.get("widths", [])
             )
+            if "input_slice" in spec:
+                start, end = spec["input_slice"]
+                self.obs_input_slices[key] = slice(int(start), int(end))
             fused_dim += spec["embed_dim"]
 
         img_encoders = img_encoders or {}
@@ -88,7 +98,9 @@ class CondEncoderModule(nn.Module):
                 widths = [max(self.d_cond, fused_dim)]
             self.cond_proj = _mlp(fused_dim, self.d_cond, widths=list(widths))
 
-    def encode(self, obs: Dict[str, torch.Tensor], T_action: int) -> Dict[str, torch.Tensor]:
+    def encode(
+        self, obs: Dict[str, torch.Tensor], T_action: int
+    ) -> Dict[str, torch.Tensor]:
         """Returns a cond_dict. Single-frame obs are broadcast across T_action."""
         if self.cond_proj is None:
             return {}
@@ -100,9 +112,11 @@ class CondEncoderModule(nn.Module):
             if key not in obs:
                 continue
             x = obs[key]
-            if x.dim() == 2:                       # (B, D) -> (B, T, D)
+            if key in self.obs_input_slices:
+                x = x[..., self.obs_input_slices[key]]
+            if x.dim() == 2:  # (B, D) -> (B, T, D)
                 x = x.unsqueeze(1).expand(-1, T_action, -1)
-            emb = self.obs_encoders[key](x)         # (B, T, embed_dim)
+            emb = self.obs_encoders[key](x)  # (B, T, embed_dim)
             feats.append(emb)
             if self.per_obs_keys:
                 out[key] = emb
@@ -111,9 +125,9 @@ class CondEncoderModule(nn.Module):
             if key not in obs:
                 continue
             x = obs[key]
-            if x.dim() == 4:                       # (B, C, H, W) -> (B, T, ...)
+            if x.dim() == 4:  # (B, C, H, W) -> (B, T, ...)
                 x = x.unsqueeze(1).expand(-1, T_action, -1, -1, -1)
-            emb = self.img_encoders[key](x)         # (B, T, embed_dim)
+            emb = self.img_encoders[key](x)  # (B, T, embed_dim)
             feats.append(emb)
             if self.per_obs_keys:
                 out[key] = emb

--- a/egomimic/models/hnet_nets/config.py
+++ b/egomimic/models/hnet_nets/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Union, Any
+from typing import Any, List, Union
 
 
 @dataclass
@@ -7,11 +7,18 @@ class AttnConfig:
     num_heads: List[int] = field(default_factory=list)
     rotary_emb_dim: List[int] = field(default_factory=list)
     window_size: List[int] = field(default_factory=list)
+    # Per-stage dropout knobs. ``dropout`` is the attention-softmax dropout
+    # (applied inside MHA's SDPA / flash_attn call). ``resid_dropout`` is
+    # the residual-branch dropout applied to attn/ffn outputs before the
+    # residual add in each TransformerBlock.
+    dropout: List[float] = field(default_factory=list)
+    resid_dropout: List[float] = field(default_factory=list)
 
 
 @dataclass
 class SSMConfig:
     """Per-stage Mamba2 kwargs. Each list is indexed by stage_idx."""
+
     d_conv: List[int] = field(default_factory=list)
     expand: List[int] = field(default_factory=list)
     d_state: List[int] = field(default_factory=list)

--- a/egomimic/models/hnet_nets/hnet.py
+++ b/egomimic/models/hnet_nets/hnet.py
@@ -236,10 +236,34 @@ def ratio_loss_from_aux(aux: List[dict], device=None) -> torch.Tensor:
         w = float(entry["weight"])
         bm = bpred.boundary_mask.float()
         bp = bpred.boundary_prob[..., -1]
-        # We treat all positions as valid (no padding mask).
-        denom = max(bm.numel(), 1)
-        F_ = bm.sum() / denom
-        G_ = bp.sum() / denom
+        # F4 (upstream parity): exclude positions where ``boundary_prob`` was
+        # *forced* to 1.0 by the routing module. Padded mode: position 0 of
+        # each row (the leading ``F.pad(..., 1.0)``). Packed mode:
+        # ``cu_seqlens[:-1]`` (every subseq start). These are synthetic
+        # boundaries, not learned predictions — counting them in F (fraction
+        # selected) and G (mean boundary probability) inflates both toward
+        # 1.0 and pulls the ratio loss away from its real target.
+        cu = entry.get("cu_seqlens", None)
+        if cu is not None:
+            # Packed: bm/bp are (T_total,). Mask out subseq-start indices.
+            valid = torch.ones_like(bm, dtype=torch.bool)
+            valid[cu[:-1]] = False
+            denom = max(int(valid.sum().item()), 1)
+            vf = valid.to(bm.dtype)
+            F_ = (bm * vf).sum() / denom
+            G_ = (bp * vf).sum() / denom
+        else:
+            valid = entry.get("valid_mask_padded", None)
+            if valid is not None:
+                vf = valid.to(bm.dtype)
+                denom = max(int(valid.sum().item()), 1)
+                F_ = (bm * vf).sum() / denom
+                G_ = (bp * vf).sum() / denom
+            else:
+                # Legacy / no mask info — preserve old behaviour.
+                denom = max(bm.numel(), 1)
+                F_ = bm.sum() / denom
+                G_ = bp.sum() / denom
         loss_i = w * (N / (N - 1)) * ((N - 1) * F_ * G_ + (1 - F_) * (1 - G_))
         losses.append(loss_i)
     return torch.stack(losses).sum()

--- a/egomimic/models/hnet_nets/image_encoders.py
+++ b/egomimic/models/hnet_nets/image_encoders.py
@@ -18,6 +18,7 @@ Shape contract: accept any tensor of shape `(..., C, H, W)` and return
 unflattened on output — so `(B, T, C, H, W) -> (B, T, embed_dim)` works
 out of the box.
 """
+
 from typing import Sequence
 
 import torch
@@ -47,7 +48,9 @@ class SimpleConv(nn.Module):
         c = in_channels
         for c_out in channels:
             layers += [
-                nn.Conv2d(c, c_out, kernel_size, stride=stride, padding=kernel_size // 2),
+                nn.Conv2d(
+                    c, c_out, kernel_size, stride=stride, padding=kernel_size // 2
+                ),
                 nn.GroupNorm(min(norm_groups, c_out), c_out),
                 nn.GELU(),
             ]
@@ -61,6 +64,6 @@ class SimpleConv(nn.Module):
         # x: (..., C, H, W) -> (..., embed_dim)
         leading = x.shape[:-3]
         x = x.reshape(-1, *x.shape[-3:])
-        feat = self.conv(x).flatten(1)         # (N, C_last)
-        feat = self.head(feat)                 # (N, embed_dim)
+        feat = self.conv(x).flatten(1)  # (N, C_last)
+        feat = self.head(feat)  # (N, embed_dim)
         return feat.reshape(*leading, self.embed_dim)

--- a/egomimic/models/hnet_nets/isotropic_builder.py
+++ b/egomimic/models/hnet_nets/isotropic_builder.py
@@ -47,13 +47,26 @@ def build_isotropic(
     cond_here = bool(spec.get("cond", False))
     cond_mode = str(spec.get("cond_mode", "adaln"))
     ssm_kwargs = spec.get("ssm_cfg", {}) or {}
+    # F6: per-stack rotary_emb_dim (0 disables RoPE for this Isotropic).
+    rotary_emb_dim = int(spec.get("rotary_emb_dim", 0) or 0)
+    # Per-stack dropout knobs. ``dropout`` is the attention-softmax dropout
+    # (forwarded into MHA); ``resid_dropout`` is the residual-branch dropout
+    # applied to attn/ffn outputs in each TransformerBlock. Both default to
+    # 0.0 — yaml specs that omit them are unaffected.
+    attn_dropout = float(spec.get("dropout", 0.0) or 0.0)
+    resid_dropout = float(spec.get("resid_dropout", 0.0) or 0.0)
 
     # Wrap the per-stage scalars into the list-indexed config Isotropic expects.
     cfg = HNetConfig(
         arch_layout=[arch_layout],  # 1-level nesting; pos_idx=0 selects it
         d_model=[d_model],
         d_intermediate=[d_intermediate],
-        attn_cfg=AttnConfig(num_heads=[num_heads]),
+        attn_cfg=AttnConfig(
+            num_heads=[num_heads],
+            rotary_emb_dim=[rotary_emb_dim],
+            dropout=[attn_dropout],
+            resid_dropout=[resid_dropout],
+        ),
         ssm_cfg=SSMConfig(**{k: [v] for k, v in ssm_kwargs.items()}),
     )
     return Isotropic(

--- a/egomimic/models/hnet_nets/routing.py
+++ b/egomimic/models/hnet_nets/routing.py
@@ -73,6 +73,18 @@ class RoutingModule(nn.Module):
         self.d_model = d_model
         self.q_proj_layer = nn.Linear(d_model, d_model, bias=False, **factory_kwargs)
         self.k_proj_layer = nn.Linear(d_model, d_model, bias=False, **factory_kwargs)
+        # F9 (upstream parity): identity init for q/k is intentional in the
+        # H-Net paper / reference implementation
+        # (``goombalab/hnet/hnet/modules/dc.py:RoutingModule.__init__``).
+        # At init cos_sim(q(h_t), k(h_{t+1})) reduces to cosine similarity
+        # of consecutive hidden states themselves; near-identical consecutive
+        # embeddings give cos_sim ~ 1 → boundary_prob ~ 0, so the chunker
+        # initially fires ONLY at the forced subseq-start positions
+        # (``boundary_prob[cu_seqlens[:-1]] = 1.0`` below). The network is
+        # expected to break this degeneracy during training. The
+        # ``_no_reinit`` flags keep residual-stream-aware init from
+        # overwriting these back to a normal-init. Do NOT change to a random
+        # init: upstream relies on this exact behaviour.
         with torch.no_grad():
             self.q_proj_layer.weight.copy_(torch.eye(d_model))
             self.k_proj_layer.weight.copy_(torch.eye(d_model))

--- a/egomimic/models/hnet_nets/stages.py
+++ b/egomimic/models/hnet_nets/stages.py
@@ -96,6 +96,20 @@ def _ste(x):
     return _STE.apply(x)
 
 
+def _build_padded_valid_mask(shape, device) -> torch.Tensor:
+    """(B, T) mask that's False at position 0 of each row (the synthetic
+    boundary forced by ``RoutingModule._forward_padded``), True elsewhere.
+
+    Used by ``ratio_loss_from_aux`` (F4) so the F/G aggregates only see
+    actual predicted boundaries.
+    """
+    B, T = shape
+    m = torch.ones(B, T, dtype=torch.bool, device=device)
+    if T > 0:
+        m[:, 0] = False
+    return m
+
+
 # --------------------------------------------------------------------------- #
 # Per-batch slice/scatter helpers for nested inference state during step().
 # Reused (and slightly simplified) from the previous monolithic HNet.
@@ -347,40 +361,39 @@ class EncoderDecoderStage(_BaseStage):
         self.decoder = build_isotropic(decoder, d_cond=d_cond, causal=causal)
 
     def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
+        # F1 (upstream parity): there is exactly ONE residual around the
+        # chunker, and it lives INSIDE the ChunkerStage as the STE-gated
+        # ``residual_proj(encoder_output)`` path (matches upstream
+        # ``residual_func = out * ste_func(p) + residual`` in
+        # ``hnet/models/hnet.py``). We must NOT add a second un-gated
+        # encoder→decoder residual at this outer level; doing so would feed
+        # the encoder output around the chunker twice. The inner_stage
+        # (chunker) returns the already-residual-mixed tensor.
         cond = self._get_cond(ctx)
         if ctx.packed:
-            # Packed mode: x is (T_total, D); pass cu_seqlens/max_seqlen straight
-            # through. Both encoder and decoder operate at the outer pack.
             x = self.encoder(
                 x, cu_seqlens=ctx.cu_seqlens, max_seqlen=ctx.max_seqlen, cond=cond
             )
-            residual = x
             if self.inner_stage is not None:
                 x = self.inner_stage(x, ctx)
-            x = x + residual
             x = self.decoder(
                 x, cu_seqlens=ctx.cu_seqlens, max_seqlen=ctx.max_seqlen, cond=cond
             )
         else:
-            # Padded mode: build an all-ones mask along T (causal already wired
-            # into the Isotropic). This matches the algo's BOS-prefixed teacher-
-            # forced input.
             mask = torch.ones(x.shape[:2], dtype=torch.bool, device=x.device)
             x = self.encoder(x, mask=mask, cond=cond)
-            residual = x
             if self.inner_stage is not None:
                 x = self.inner_stage(x, ctx)
-            x = x + residual
             x = self.decoder(x, mask=mask, cond=cond)
         return x
 
     def step(self, x: torch.Tensor, ctx: HNetContext, state: EncoderDecoderStageState):
+        # F1 (upstream parity): single residual lives inside the chunker; no
+        # outer encoder→decoder residual here.
         cond = self._get_cond(ctx)
         x = self.encoder.step(x, state.encoder_state, cond=cond)
-        residual = x
         if self.inner_stage is not None:
             x = self.inner_stage.step(x, ctx, state.inner_state)
-        x = x + residual
         x = self.decoder.step(x, state.decoder_state, cond=cond)
         return x
 
@@ -513,6 +526,15 @@ class ChunkerStage(_BaseStage):
                 "bpred": bpred,
                 "target_ratio": self.target_compression_ratio,
                 "weight": self.ratio_loss_weight,
+                # F4: ratio loss must exclude positions where boundary_prob
+                # was *forced* to 1.0 by the routing module. In padded mode
+                # that's only position 0 along each row (see
+                # ``RoutingModule._forward_padded``: the leading
+                # ``F.pad(..., 1.0)``). Encode this as a (B, T) bool mask of
+                # *real* (non-forced) positions.
+                "valid_mask_padded": _build_padded_valid_mask(
+                    bpred.boundary_mask.shape, x.device
+                ),
             }
         )
         return out
@@ -566,6 +588,11 @@ class ChunkerStage(_BaseStage):
                 "bpred": bpred,
                 "target_ratio": self.target_compression_ratio,
                 "weight": self.ratio_loss_weight,
+                # F4: in packed mode boundary_prob is forced to 1.0 at every
+                # subseq start (``boundary_prob[cu_seqlens[:-1]] = 1.0`` in
+                # ``RoutingModule._forward_packed``). Pass cu_seqlens through
+                # so the ratio loss can exclude those synthetic positions.
+                "cu_seqlens": cu,
             }
         )
         return out

--- a/egomimic/models/hpt_nets.py
+++ b/egomimic/models/hpt_nets.py
@@ -540,10 +540,17 @@ class MLPPolicyStem(PolicyStem):
         tanh_end: bool = False,
         ln: bool = True,
         num_of_copy: int = 1,
+        input_slice=None,
         **kwargs,
     ) -> None:
         """vanilla MLP class"""
         super().__init__(**kwargs)
+        # input_slice [start,end]: use only a feature sub-range (e.g.
+        # [0,2] = pusher xy, dropping object pose). input_dim == end-start.
+        self.input_slice = (
+            slice(int(input_slice[0]), int(input_slice[1]))
+            if input_slice is not None else None
+        )
         modules = [nn.Linear(input_dim, widths[0]), nn.SiLU()]
 
         for i in range(len(widths) - 1):
@@ -571,6 +578,8 @@ class MLPPolicyStem(PolicyStem):
         Returns:
             Flatten tensor with shape [B, M, 512]
         """
+        if getattr(self, "input_slice", None) is not None:
+            x = x[..., self.input_slice]
         if self.num_of_copy > 1:
             out = []
             iter_num = min(self.num_of_copy, x.shape[1])

--- a/egomimic/rldb/embodiment/pushshapes.py
+++ b/egomimic/rldb/embodiment/pushshapes.py
@@ -76,6 +76,82 @@ def get_keymap(action_horizon: int = 32, **kwargs) -> dict:
     }
 
 
+def get_keymap_causal(action_horizon: int = 32, **kwargs) -> dict:
+    """Causal keymap: obs is the SINGLE current frame (horizon 1), actions are a
+    chunk of length ``action_horizon``. This matches closed-loop inference
+    (sim_predict_step feeds one current obs and predicts an action chunk),
+    unlike ``get_keymap`` which gives the obs the same 32-step window that
+    includes FUTURE frames unavailable at rollout time. Train with this so
+    train == inference and the policy doesn't drift in closed loop.
+    """
+    return {
+        "front_img_1": {
+            "key_type": "camera_keys",
+            "zarr_key": "observations.images.front_img_1",
+            "horizon": 1,
+        },
+        "state_agent_obj": {
+            "key_type": "proprio_keys",
+            "zarr_key": "observations.state",
+            "horizon": 1,
+        },
+        "actions": {
+            "key_type": "action_keys",
+            "zarr_key": "actions",
+            "horizon": int(action_horizon),
+        },
+    }
+
+
+def get_keymap_goal(action_horizon: int = 32, **kwargs) -> dict:
+    """``get_keymap`` + ``goal_obs`` = the goal pose as a normalized proprio model
+    input (H2 goal-conditioning test). proprio_keys => normalized + fed to the
+    cond encoder."""
+    km = get_keymap(action_horizon=action_horizon)
+    km["goal_obs"] = {
+        "key_type": "proprio_keys",
+        "zarr_key": "goal_pose",
+        "horizon": int(action_horizon),
+    }
+    return km
+
+
+def get_keymap_goal_eval(action_horizon: int = 32, **kwargs) -> dict:
+    """``get_keymap_goal`` + raw ``goal_pose`` passthrough for the sim env init."""
+    km = get_keymap_goal(action_horizon=action_horizon)
+    km["goal_pose"] = {
+        "key_type": "goal_keys",
+        "zarr_key": "goal_pose",
+        "horizon": int(action_horizon),
+    }
+    return km
+
+
+def get_keymap_eval(action_horizon: int = 32, **kwargs) -> dict:
+    """``get_keymap`` plus ``goal_pose`` for closed-loop sim eval.
+
+    ``SimRolloutEval`` (replay init) reads ``sample['goal_pose']`` to set the
+    PushShapes env goal. The training keymap omits it (training never uses the
+    goal). ``goal_pose`` uses a non-normalized, non-image key_type so it is read
+    into the packed batch and passed straight through to the evaluator.
+    """
+    km = get_keymap(action_horizon=action_horizon)
+    km["goal_pose"] = {
+        "key_type": "goal_keys",
+        "zarr_key": "goal_pose",
+        "horizon": int(action_horizon),
+    }
+    # Raw (un-normalized, un-delta'd) copy of the absolute actions so the delta
+    # rollout can seed its integration from action[0]. DeltaAction only rewrites
+    # the "actions" key, so this passthrough stays absolute.
+    km["init_action"] = {
+        "key_type": "goal_keys",
+        "zarr_key": "actions",
+        "horizon": int(action_horizon),
+    }
+    return km
+
+
 # ---------------------------------------------------------------------- #
 # Validation viz
 # ---------------------------------------------------------------------- #

--- a/egomimic/rldb/zarr/zarr_dataset_inmem.py
+++ b/egomimic/rldb/zarr/zarr_dataset_inmem.py
@@ -1,0 +1,228 @@
+"""In-memory ZarrDataset variant for fast HPT-style per-frame training.
+
+Motivation
+----------
+The base ``ZarrDataset.__getitem__`` decodes JPEG frames and reads zarr arrays
+*per sample*. For the pushshapes_sim per-frame loader (horizon=32 obs+action
+windows) this puts an irreducible ~3-5 ms of Python/JPEG work on every sample,
+which caps DataLoader throughput well below what the GPU can consume.
+
+``InMemoryZarrDataset`` decodes each episode **once** at construction time and
+holds the frames in RAM as ``uint8`` CHW tensors (plus float32 state/action
+arrays). ``__getitem__`` then becomes a pure array slice + a ``uint8 -> float32
+/255`` cast — no JPEG decode, no zarr read. Because the decode happens in the
+parent process *before* the DataLoader forks its workers, the large image
+buffers are shared with every worker via copy-on-write (the workers only read,
+so the pages are never duplicated).
+
+Design constraints
+------------------
+* **Drop-in / byte-identical output.** ``__getitem__`` returns exactly the same
+  dict (same keys, dtypes, shapes, value ranges, and pad-by-repeat-last
+  semantics) as ``ZarrDataset.__getitem__``. Normalization, bounds-checking,
+  collation, ``norm_stats`` and the model's ``process_batch_for_training`` are
+  therefore completely unchanged — this class only swaps *how* a leaf produces
+  its raw window.
+* **Zero edits to existing files.** Wiring is via a ``LocalEpisodeResolver``
+  subclass that sets ``_dataset_class`` (the same mechanism
+  ``LocalAnnotationCutoffEpisodeResolver`` already uses) plus a new data config.
+  Other users / configs are unaffected.
+
+Memory
+------
+One frame decoded to uint8 CHW at 96x96 is ~27 KB. A 954-episode x 300-frame
+circle dataset is ~7.7 GB held once in the parent and shared to workers. State
+and action arrays are negligible.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import simplejpeg
+import torch
+
+from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+from egomimic.rldb.zarr.zarr_dataset_multi import (
+    LocalEpisodeResolver,
+    ZarrDataset,
+)
+
+logger = logging.getLogger(__name__)
+
+# How many threads to use for the per-episode JPEG decode at construction.
+# simplejpeg (libjpeg-turbo) releases the GIL during decode, so threads give a
+# real speedup. Overridable for nodes with few cores.
+_DECODE_THREADS = int(os.environ.get("EGOVERSE_INMEM_DECODE_THREADS", "8"))
+
+
+class InMemoryZarrDataset(ZarrDataset):
+    """``ZarrDataset`` that preloads its whole episode into RAM at construction.
+
+    All windowing / padding semantics mirror the base class exactly:
+      * window is ``[idx : min(idx + horizon, total_frames))``
+      * sequences shorter than ``horizon`` are padded by repeating the last
+        real frame (``_pad_sequences`` repeat-last)
+      * images are returned CHW float32 in ``[0, 1]``; state/action are returned
+        raw float32 (normalization is applied later by ``MultiDataset``)
+    """
+
+    def __init__(self, Episode_path, key_map, transform_list=None):
+        # Base init opens the zarr store, reads metadata, sets total_frames,
+        # _image_keys / _json_keys, key_map, etc.
+        super().__init__(Episode_path, key_map, transform_list=transform_list)
+        # Preloaded per-key arrays:
+        #   image keys   -> uint8 ndarray (T, 3, H, W)
+        #   other keys   -> float32 ndarray (T, ...)
+        self._mem: dict[str, np.ndarray] = {}
+        self._preload()
+        # Optional idle-tail / (0,0)-garbage filter (EGOVERSE_TRIM_IDLE=1).
+        # The pushshapes demos record the cursor at (0,0) when it parks/leaves
+        # the screen (mostly an idle tail at episode end). Those frames teach a
+        # BC policy to "drive to the corner and stop". Drop them so the policy
+        # only sees real pushing actions; this also cleans the quantile-norm
+        # floor (computed from this same dataset).
+        self._valid_indices = None
+        if os.environ.get("EGOVERSE_TRIM_IDLE") == "1":
+            self._build_valid_indices()
+
+    # ------------------------------------------------------------------ #
+    # Construction-time preload
+    # ------------------------------------------------------------------ #
+    def _preload(self) -> None:
+        store = self.episode_reader._get_store()
+        for k in self.key_map:
+            spec = self.key_map[k]
+            zarr_key = spec["zarr_key"]
+            key_type = spec.get("key_type", None)
+
+            # Non-windowed metadata/annotation keys are handled lazily in
+            # __getitem__ (mirrors the base class); nothing to preload.
+            if key_type in ("annotation_keys", "metadata_keys"):
+                continue
+
+            raw = store[zarr_key][:]
+
+            if zarr_key in self._image_keys:
+                self._mem[k] = self._decode_all_jpegs(raw)
+            elif zarr_key in self._json_keys:
+                # JSON keys aren't used by the pushshapes per-frame keymap; keep
+                # them out of the in-RAM fast path and let __getitem__ raise if
+                # one is ever requested, rather than silently mishandling it.
+                raise NotImplementedError(
+                    f"InMemoryZarrDataset does not support JSON key {zarr_key!r}"
+                )
+            else:
+                self._mem[k] = np.asarray(raw, dtype=np.float32)
+
+    def _build_valid_indices(self):
+        """Drop (0,0)-garbage action frames and truncate the trailing idle tail.
+
+        Sets self._valid_indices (sampled positions) and self.total_frames to
+        the idle-tail start (so action-chunk windows never read tail garbage).
+        """
+        act = self._mem.get("actions")
+        if act is None:
+            return
+        a = np.asarray(act, dtype=np.float32).reshape(len(act), -1)
+        zero = (np.abs(a[:, 0]) < 1.0) & (np.abs(a[:, 1]) < 1.0)
+        nz = np.where(~zero)[0]
+        if len(nz) == 0:
+            return  # degenerate episode: keep as-is
+        tail_start = int(nz[-1]) + 1            # exclude trailing idle (0,0) run
+        self.total_frames = tail_start          # clamp windows to real frames
+        # sample only non-(0,0) frames before the tail (also drops scattered ones)
+        self._valid_indices = [i for i in range(tail_start) if not zero[i]]
+        if not self._valid_indices:             # safety: never empty
+            self._valid_indices = list(range(tail_start))
+
+    def __len__(self):
+        if getattr(self, "_valid_indices", None) is not None:
+            return len(self._valid_indices)
+        return self.total_frames
+
+    @staticmethod
+    def _decode_one(buf) -> np.ndarray:
+        # HWC uint8 -> CHW uint8 (defer the /255 float cast to __getitem__ so the
+        # in-RAM buffer stays 4x smaller).
+        img = simplejpeg.decode_jpeg(buf, colorspace="RGB")
+        return np.ascontiguousarray(np.transpose(img, (2, 0, 1)))
+
+    def _decode_all_jpegs(self, raw) -> np.ndarray:
+        n = len(raw)
+        if n == 0:
+            return np.empty((0, 3, 0, 0), dtype=np.uint8)
+        if _DECODE_THREADS > 1 and n > 1:
+            with ThreadPoolExecutor(max_workers=_DECODE_THREADS) as ex:
+                frames = list(ex.map(self._decode_one, raw))
+        else:
+            frames = [self._decode_one(b) for b in raw]
+        return np.stack(frames, axis=0)  # (T, 3, H, W) uint8
+
+    # ------------------------------------------------------------------ #
+    # Fast per-sample read
+    # ------------------------------------------------------------------ #
+    def _window(self, arr: np.ndarray, idx: int, horizon: int) -> np.ndarray:
+        """Slice ``[idx:idx+horizon]`` with repeat-last padding to ``horizon``.
+
+        Matches ``ZarrDataset._chunk_end_idx`` + ``_pad_sequences``.
+        """
+        end = min(idx + horizon, self.total_frames)
+        window = arr[idx:end]
+        seq_len = window.shape[0]
+        if seq_len < horizon:
+            pad = np.repeat(window[-1:], horizon - seq_len, axis=0)
+            window = np.concatenate([window, pad], axis=0)
+        return window
+
+    def __getitem__(self, idx, _fallback_origin=None, _attempts=None):
+        if getattr(self, "_valid_indices", None) is not None:
+            idx = self._valid_indices[idx]
+        data: dict = {}
+        for k in self.key_map:
+            spec = self.key_map[k]
+            zarr_key = spec["zarr_key"]
+            key_type = spec.get("key_type", None)
+            horizon = spec.get("horizon", None)
+
+            # Annotation/metadata keys fall back to the base implementation's
+            # behaviour (the pushshapes per-frame keymap has none of these, but
+            # keep parity for safety).
+            if key_type == "annotation_keys":
+                data[k] = self._annotation_text_for_frame(idx)
+                continue
+            if key_type == "metadata_keys":
+                continue
+
+            arr = self._mem[k]
+            if horizon is not None:
+                window = self._window(arr, idx, int(horizon))
+            else:
+                window = arr[idx]
+
+            if zarr_key in self._image_keys:
+                # uint8 CHW -> float32 [0, 1], identical to the base decode path.
+                window = window.astype(np.float32) / 255.0
+
+            data[k] = torch.from_numpy(np.ascontiguousarray(window)).to(torch.float32)
+
+        if self.transform:
+            for transform in self.transform or []:
+                data = transform.transform(data)
+            # A transform may reintroduce numpy arrays; mirror the base cast.
+            for k, v in data.items():
+                if isinstance(v, np.ndarray):
+                    data[k] = torch.from_numpy(v).to(torch.float32)
+
+        data["metadata.robot_name"] = get_embodiment_id(self.embodiment)
+        data["embodiment"] = get_embodiment_id(self.embodiment)
+        return data
+
+
+class InMemoryLocalEpisodeResolver(LocalEpisodeResolver):
+    """LocalEpisodeResolver that loads :class:`InMemoryZarrDataset` leaves."""
+
+    _dataset_class = InMemoryZarrDataset

--- a/egomimic/utils/schedulers.py
+++ b/egomimic/utils/schedulers.py
@@ -1,0 +1,57 @@
+"""LR scheduler factories that need the optimizer + dynamic step counts.
+
+Hydra-friendly: target one of these with ``_partial_: true`` and Lightning will
+pass the optimizer at instantiation time.
+"""
+
+from __future__ import annotations
+
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import (
+    CosineAnnealingLR,
+    LinearLR,
+    LRScheduler,
+    SequentialLR,
+)
+
+
+def warmup_cosine_scheduler(
+    optimizer: Optimizer,
+    max_steps: int,
+    warmup_steps: int = 500,
+    warmup_start_factor: float = 0.01,
+    eta_min: float = 2e-5,
+) -> LRScheduler:
+    """Linear warmup → CosineAnnealingLR.
+
+    Args:
+        optimizer: bound at Lightning instantiation time.
+        max_steps: total number of optimizer steps for the whole training run.
+            Cosine annealing spans the post-warmup window
+            ``max_steps - warmup_steps``.
+        warmup_steps: number of warmup steps. LR linearly goes from
+            ``base_lr * warmup_start_factor`` to ``base_lr``.
+        warmup_start_factor: fraction of base_lr to start the warmup at.
+        eta_min: minimum LR at the end of cosine annealing.
+
+    Stepping convention: this expects ``scheduler_interval="step"`` (the
+    default in the EgoVerse pl_model wrapper).
+    """
+    warmup_steps = max(1, int(warmup_steps))
+    max_steps = max(warmup_steps + 1, int(max_steps))
+    warmup = LinearLR(
+        optimizer,
+        start_factor=float(warmup_start_factor),
+        end_factor=1.0,
+        total_iters=warmup_steps,
+    )
+    cosine = CosineAnnealingLR(
+        optimizer,
+        T_max=max_steps - warmup_steps,
+        eta_min=float(eta_min),
+    )
+    return SequentialLR(
+        optimizer,
+        schedulers=[warmup, cosine],
+        milestones=[warmup_steps],
+    )


### PR DESCRIPTION
HPT pushshapes: fp64 cast, packed passthrough, sim_predict_step, input_slice; in-mem zarr loader

H-Net: config-driven AR/scheduled-sampling training, sliding-window attention, token-dropout

Sim eval: HNetSimEval (AR + chunk_te), delta-action, goal conditioning, temporal-ensemble, fixed-seed eval

Configs: pusher-only + goal model configs, config-driven eval params, gitignore scratch