### PR TITLE
pi0.5: raise prompt token cap 128/180 -> 200 to match pi0.5 base training

### DIFF
--- a/egomimic/hydra_configs/model/pi0.5_base.yaml
+++ b/egomimic/hydra_configs/model/pi0.5_base.yaml
@@ -8,7 +8,7 @@ robomimic_model:
       pi05: true
       action_dim: 32
       action_horizon: 100
-      max_token_len: 180
+      max_token_len: 200
 
   # Prompt assembly + tokenization. The PI algo owns the tokenizer because
   # the prompt template is model-specific (paligemma + pi0.5 anchor). All
@@ -30,7 +30,7 @@ robomimic_model:
   #   model.robomimic_model.default_prompt="this is a bad action"
   #   model.robomimic_model.control_mode='{aria: "wrist frame xyzypr per arm", eva: "wrist frame xyzypr gripper per arm"}'
   tokenizer_model_name: "google/paligemma-3b-mix-224"
-  tokenizer_max_length: 128
+  tokenizer_max_length: 200
   sampling_mode: "random"
   annotation_key: "annotations"
   default_prompt: "This is a bad action."


### PR DESCRIPTION
The PI prompt tokenizer was capping text at tokenizer_max_length=128 (a
legacy default carried over from the old build_tokenized_collate) while
the model was instantiated with max_token_len=180 -- both below pi0.5's
actual training length.

pi0.5 base was trained/released with max_token_len=200 (openpi Pi0Config
pi05 default; gs://openpi-assets/checkpoints/pi05_base). Raising both
knobs to 200 matches the pretrained checkpoint and is in-distribution
(Gemma uses RoPE, so there is no positional-table limit). This roughly
doubles the usable annotation budget once the proprio + control-mode
blocks are spliced into the prompt, and removes the truncation footgun
where an over-long prompt (truncation=True, right side) silently clipped
the trailing State / "Action:" anchor.

- max_token_len:        180 -> 200
- tokenizer_max_length: 128 -> 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>