### PR TITLE
Drop unused robot_name from TableRow (DB has only embodiment)

### DIFF
--- a/egomimic/utils/aws/aws_sql.py
+++ b/egomimic/utils/aws/aws_sql.py
@@ -32,7 +32,6 @@ class TableRow:
     lab: str
     task: str
     embodiment: str
-    robot_name: str
     num_frames: int = -1  # Updateable
     task_description: str = ""
     scene: str = ""

--- a/external/scale/scripts/sfs_zarr_pipeline.py
+++ b/external/scale/scripts/sfs_zarr_pipeline.py
@@ -89,7 +89,6 @@ def register_in_sql(
         lab="scale",
         task=task_desc,
         embodiment="scale",
-        robot_name="scale_bimanual",
         num_frames=total_frames,
         task_description=task_desc,
         scene="unknown",


### PR DESCRIPTION
robot_name was declared in TableRow but app.episodes has only the embodiment column.
The strict column check in episode_hash_to_table_row raised on it, crashing any
conversion that reaches it (e.g. force re-converts). It was never populated as a real
column; add_raw_data_to_table already omits it. Removed the field and the only
constructor still passing it (external/scale/scripts/sfs_zarr_pipeline.py).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>