### PR TITLE
docs(CONTRIBUTING_DATA): Dataset Practices guidelines + example tasks

### DIFF
--- a/CONTRIBUTING_DATA.md
+++ b/CONTRIBUTING_DATA.md
@@ -7,17 +7,18 @@
 ## Table of Contents
 
 1. [Overview](#1-overview)
-2. [Prerequisites](#2-prerequisites)
-3. [Episode Hash Convention](#3-episode-hash-convention)
-4. [Database Registry](#4-database-registry)
-5. [Zarr v3 Episode Format](#5-zarr-v3-episode-format)
-6. [Coordinate Frame Conventions](#6-coordinate-frame-conventions)
-7. [Language Annotations](#7-language-annotations)
-8. [Embodiment Identifiers](#8-embodiment-identifiers)
-9. [Uploading to S3](#9-uploading-to-s3)
-10. [Validation and Verification](#10-validation-and-verification)
-11. [Pre-Submission Checklist](#11-pre-submission-checklist)
-12. [Getting Access and Contact](#12-getting-access-and-contact)
+2. [Dataset Practices](#2-dataset-practices)
+3. [Prerequisites](#3-prerequisites)
+4. [Episode Hash Convention](#4-episode-hash-convention)
+5. [Database Registry](#5-database-registry)
+6. [Zarr v3 Episode Format](#6-zarr-v3-episode-format)
+7. [Coordinate Frame Conventions](#7-coordinate-frame-conventions)
+8. [Language Annotations](#8-language-annotations)
+9. [Embodiment Identifiers](#9-embodiment-identifiers)
+10. [Uploading to S3](#10-uploading-to-s3)
+11. [Validation and Verification](#11-validation-and-verification)
+12. [Pre-Submission Checklist](#12-pre-submission-checklist)
+13. [Getting Access and Contact](#13-getting-access-and-contact)
 
 ---
 
@@ -32,7 +33,7 @@ Every contributed episode must satisfy these check lists:
 | **File format** | Zarr v3 store with specific key names, dtypes, and shapes |
 | **Coordinate frame** | All poses expressed in a consistent reference frame |
 | **Database record** | Consistent one row per episode registered in the PostgreSQL episode registry before upload |
-| **Dataset Practices** | Example: reducing idle times, check for data flaws |
+| **[Dataset Practices](#2-dataset-practices)** | Example: reducing idle times, check for data flaws |
 
 The pipeline at a glance:
 
@@ -46,9 +47,65 @@ Your raw data
 
 ---
 
-## 2. Prerequisites
+## 2. Dataset Practices
 
-### 2.1 Hardware
+*What to capture, and how to keep it clean.*
+
+We want to capture **economically useful work performed by a proficient demonstrator**.
+
+### 2.1 Target Data Composition
+
+A rough heuristic for the data **in aggregate**:
+
+| Dimension | Target mix |
+|---|---|
+| **Task type** | no more than ~5% navigation · ~10% mobile manipulation · ~85% manipulation |
+| **Gripper** | ~60% doable with a parallel-jaw gripper · ~40% doable by either a parallel-jaw gripper or a dexterous hand |
+| **Setting** | ~70% tabletop · ~30% non-tabletop |
+
+### 2.2 Capture Settings
+
+Data can range from **staged studios** (realistic work captured in a controlled setting) all the way to **in the wild** — people doing tasks at home or in factory settings. If you are capturing real labor in the wild, it is **especially important to trim down to the relevant portions.**
+
+### 2.3 Quality — Avoid These Failure Modes
+
+A common failure mode is the demonstrator **randomly stalling, inspecting an item, patting clothes**, etc. Capture proficient, purposeful execution — not idle filler.
+
+### 2.4 Trimming Rules
+
+- **Trim out aggressive head movements.**
+- **Hand tracking must be visible in all frames** — trim out any frames without hands.
+- In-the-wild captures: **trim down to the task-relevant portions** (drop setup, breaks, wandering).
+
+### 2.5 Example Tasks
+
+Some example tasks we would prefer:
+
+| # | Task | What it covers |
+|---|---|---|
+| 1 | **Sorting** | Sort parts/components into bins by type, color, or size (factory); sort utensils into a cutlery tray, or sort a cluttered table by category (food / tool / toy), color, or shape (home). |
+| 2 | **Packing** | Place items into a box, bin, or bag with room to spare (loose packing, not tight-fit). |
+| 3 | **Opening & closing containers** | Drawers, cabinet doors, box lids/flaps, bags (ziploc, drawstring). |
+| 4 | **Tidying a cluttered table** | Return scattered objects to their places / into containers (dry, no wiping). |
+| 5 | **Spatial arrangement** | Arrange objects into an approximate target layout: line up, group by type, set out in roughly canonical positions (exact spacing not required). |
+| 6 | **Stacking** | Stack wide, stable items (plates, bowls, books) or nest bowls; no precise tall towers. |
+| 7 | **Folding** | Rough-fold towels / cloth / clothing in half or thirds; crisp creases not required. |
+| 8 | **Capping & uncapping** | Place or remove loose lids on boxes/jars, or large-thread caps; no fine threading. |
+| 9 | **Hanging** | Drape a cloth/towel over a rod, or hang a bag/mug on a large hook; generous targets. |
+| 10 | **Shelving** | Place books/boxes onto an open shelf with free space; no tight insertion. |
+| 11 | **Loading & unloading** | Load items into a tray, caddy, or dish rack with generous slots; unload onto the table. |
+| 12 | **Buttons & switches** | Press large buttons, flip switches, toggle controls. |
+| 13 | **Retrieval by description** | Pick a specified item from a mixed set and bring it to a drop zone — e.g. "the red mug," "the biggest book," "the metal one." Delivery to a zone, not a precise pose. |
+| 14 | **Relational placement** | Place an object relative to another by instruction: to the left of, behind, between, or on top of a reference object. Approximate positions are fine. |
+| 15 | **Matching & pairing** | Pair like items (socks, gloves, shoes), match lids to their containers, or match an object to its printed outline. Forgiving placement. |
+| 16 | **Reorientation & flipping** | Turn objects to a target pose: stand cups upright, flip cards face-up, or rotate items so labels face front. Forgiving rotation, no exact angle. |
+| 17 | **Search & retrieve** | Open a drawer/box, find a specified item inside, and take it out (combines opening, selection, and extraction). |
+
+---
+
+## 3. Prerequisites
+
+### 3.1 Hardware
 
 EgoVerse is hardware-agnostic. Any egocentric camera with a SLAM system that provides 6-DOF pose tracking is supported. The minimum requirements are:
 
@@ -58,13 +115,13 @@ EgoVerse is hardware-agnostic. Any egocentric camera with a SLAM system that pro
 | SLAM / pose tracking | A system that outputs 6-DOF device pose in a consistent metric world frame at ≥ 30 fps, synchronized with the RGB stream. Examples: Aria MPS, ZED SDK positional tracking, ORB-SLAM3, OpenVINS, RealSense tracking firmware. |
 | Hand tracking | Per-frame 3D hand landmark estimates (21 keypoints per hand) synchronized to the RGB stream, expressed in the same SLAM world frame. Examples: Aria MPS hand tracking, MediaPipe + depth unprojection, OAK-D depthai hand tracker, Ultraleap. If your setup does not produce hand keypoints, omit `*.obs_keypoints` and `*.obs_wrist_pose` and use only `*.obs_ee_pose` (e.g. derived from a robot's FK or a wrist-worn IMU). |
 | Wrist cameras | Optional. Include as `images.left_wrist` / `images.right_wrist` if present. |
-| Robot | Any bimanual arm or single-arm platform. See §8 for embodiment identifiers. |
+| Robot | Any bimanual arm or single-arm platform. See §9 for embodiment identifiers. |
 
 **Minimum viable setup (no robot):** egocentric camera + SLAM + hand tracking → contributes `images.front_1`, `obs_head_pose`, `left/right.obs_ee_pose`, `left/right.obs_wrist_pose`, `left/right.obs_keypoints`.
 
 **If your SLAM system does not run at 30 fps**, ensure you upsample or interpolate pose tracks to match the RGB frame rate before writing. The training pipeline assumes all arrays are frame-aligned.
 
-### 2.2 Software
+### 3.2 Software
 
 ```bash
 # Clone and install EgoVerse
@@ -75,7 +132,7 @@ source .venv/bin/activate
 uv pip install -e .
 ```
 
-### 2.3 Credentials
+### 3.3 Credentials
 
 You need two things: AWS credentials for the episode registry (PostgreSQL via Secrets Manager) and Cloudflare R2 credentials for the data bucket.
 
@@ -106,7 +163,7 @@ engine = create_default_engine()   # should print: Tables in schema 'app': ['epi
 
 ---
 
-## 3. Episode Hash Convention
+## 4. Episode Hash Convention
 
 Every episode is identified by a **UTC timestamp** rendered as:
 
@@ -143,23 +200,23 @@ ts_ms = episode_hash_to_timestamp_ms("2026-01-12-03-47-29-664000")
 
 ---
 
-## 4. Database Registry
+## 5. Database Registry
 
 Every episode must be registered in the PostgreSQL `app.episodes` table **before** its Zarr store is uploaded. The registry is the authoritative index used by all download and training tooling.
 
-### 4.1 Schema
+### 5.1 Schema
 
 The authoritative schema is the `TableRow` dataclass defined in [egomimic/utils/aws/aws_sql.py](egomimic/utils/aws/aws_sql.py). Refer to that file for the exact set of fields, defaults, and types — this guide may drift if the schema changes.
 
 Key field notes:
-- `episode_hash`: PRIMARY KEY, must match the `.zarr` directory name exactly (see §3).
+- `episode_hash`: PRIMARY KEY, must match the `.zarr` directory name exactly (see §4).
 - `operator`: **hashed** operator ID (e.g. SHA-256 hex digest). MUST be hashed before insertion — never store raw names/emails.
 - `lab`: short, stable, lowercase string. Once set, do not change it (used in filters).
 - `task`: high-level `task_name` that groups related episodes. Before inventing a new name, check the existing tasks in the episode registry via [`sql_tutorial.ipynb`](egomimic/scripts/tutorials/sql_tutorial.ipynb) (`df.groupby("task").size()`) and reuse one if your episode fits. If no existing task matches, canonicalize your new `task_name` to a short, stable, lowercase string that names a semantically meaningful category (e.g. `fold_clothes`, `object_in_container`) — not a one-off trial description. Put trial-specific detail in `task_description`, `scene`, and `objects`.
-- `embodiment`: must be one of the strings in §8.
+- `embodiment`: must be one of the strings in §9.
 - `robot_name`: finer-grained variant; use the format `<platform>_<config>` (e.g. `aria_bimanual`, `aria_right_arm`).
 
-### 4.2 Inserting a Row
+### 5.2 Inserting a Row
 
 ```python
 from egomimic.utils.aws.aws_sql import TableRow, add_episode, create_default_engine
@@ -191,7 +248,7 @@ add_episode(engine, row)
 
 `add_episode` raises `RuntimeError` on a duplicate `episode_hash`. Check for collisions before inserting.
 
-### 4.3 Updating a Row After Upload
+### 5.3 Updating a Row After Upload
 
 ```python
 from egomimic.utils.aws.aws_sql import update_episode
@@ -203,11 +260,11 @@ update_episode(engine, row)
 
 ---
 
-## 5. Zarr v3 Episode Format
+## 6. Zarr v3 Episode Format
 
 Each episode is a **Zarr v3 group** (a directory ending in `.zarr`) containing arrays and top-level attributes.
 
-### 5.1 Directory Structure
+### 6.1 Directory Structure
 
 ```
 <episode_hash>.zarr/
@@ -239,7 +296,7 @@ Each episode is a **Zarr v3 group** (a directory ending in `.zarr`) containing a
 └── obs_rgb_timestamps_ns/          ← per-frame capture timestamps
 ```
 
-### 5.2 Required Arrays
+### 6.2 Required Arrays
 
 All arrays are indexed along axis 0 by frame index. Every array must have **exactly `total_frames` entries** along axis 0 (matching the value in `zarr.attrs["total_frames"]`).
 
@@ -301,7 +358,7 @@ If you need to convert your proprietary keypoints to MANO, try using [otaheri/MA
 | `obs_rgb_timestamps_ns` | `(T,)` | `int64` | UTC nanoseconds for each RGB frame |
 | `obs_eye_gaze` | `(T, 3)` | `float64` | Unit gaze direction vector in SLAM world frame (x, y, z) |
 
-### 5.3 Top-Level Attributes (`zarr.attrs`)
+### 6.3 Top-Level Attributes (`zarr.attrs`)
 
 The root group's `.attrs` dictionary is the **episode metadata**. It is written as JSON and is the primary indexing surface.
 
@@ -333,7 +390,7 @@ The root group's `.attrs` dictionary is the **episode metadata**. It is written 
 - `features` must have one entry per array key present in the store.
 - `embodiment` and `task_name` must exactly match the values in the DB row for this episode.
 
-### 5.4 Storage / Chunking
+### 6.4 Storage / Chunking
 
 > # ⚠️ **USE THE [`ZarrWriter`](egomimic/rldb/zarr/zarr_writer.py) CLASS** ⚠️
 > # **This is the only supported way to produce EgoVerse Zarr stores. It guarantees sharding and chunking match the rest of the dataset — do NOT roll your own writer.**
@@ -345,7 +402,7 @@ The root group's `.attrs` dictionary is the **episode metadata**. It is written 
 
 See example usage in eva_to_zarr.py and aria_to_zarr.py.
 
-### 5.5 Episode Preview MP4 (sibling artifact)
+### 6.5 Episode Preview MP4 (sibling artifact)
 
 Alongside each `<episode_hash>.zarr` store, write a preview video of the egocentric RGB stream named **`<episode_hash>.mp4`** (e.g. `2026-03-15-14-22-10-000000.mp4`). The Mecka AI dataset viz looks previews up by this exact filename, so any deviation from the `<episode_hash>.mp4` convention will break it.
 
@@ -353,9 +410,9 @@ Any standard MP4 encoder works. If it's convenient, the [`save_preview_mp4`](ego
 
 ---
 
-## 6. Coordinate Frame Conventions
+## 7. Coordinate Frame Conventions
 
-### 6.1 SLAM World Frame (storage frame)
+### 7.1 SLAM World Frame (storage frame)
 
 All poses are stored in the **SLAM world frame** produced by your pose-tracking system (e.g. Aria MPS, ZED SDK, ORB-SLAM3). This is an arbitrary fixed Euclidean frame that is consistent within a single recording session but **not** consistent across sessions or between different hardware setups.
 
@@ -363,9 +420,9 @@ All poses are stored in the **SLAM world frame** produced by your pose-tracking 
 - Axes: right-handed, metric (meters).
 - **This is what you write into the Zarr arrays.** Do not pre-transform poses to any other frame before writing.
 
-The SLAM world frame origin and orientation will differ between labs and hardware. That is expected and fine — the training-time head-frame normalization (§6.2) cancels out any global offset or rotation.
+The SLAM world frame origin and orientation will differ between labs and hardware. That is expected and fine — the training-time head-frame normalization (§7.2) cancels out any global offset or rotation.
 
-### 6.2 Head Frame (training frame)
+### 7.2 Head Frame (training frame)
 
 At training time, the pipeline automatically re-expresses all poses **relative to the current egocentric device pose** (`obs_head_pose`) using `ActionChunkCoordinateFrameTransform`. You do **not** need to do this conversion yourself; it is applied on-the-fly by the data loader.
 
@@ -379,11 +436,11 @@ The end-effector frame uses the same convention (+X right, +Y down, +Z forward).
 
 ![End-effector frame convention](convention.png)
 
-### 6.3 Wrist Frame (optional training frame)
+### 7.3 Wrist Frame (optional training frame)
 
 For keypoint-based models, keypoints can optionally be further expressed relative to the wrist frame via `PoseCoordinateFrameTransform`. Again, this is a training-time transform; store everything in the SLAM world frame.
 
-### 6.4 Frame Summary
+### 7.4 Frame Summary
 
 | Array | Written in | Re-expressed at train time |
 |---|---|---|
@@ -399,11 +456,11 @@ For keypoint-based models, keypoints can optionally be further expressed relativ
 
 ---
 
-## 7. Language Annotations
+## 8. Language Annotations
 
 Language annotations are **optional but strongly encouraged**. They are stored as a span-based structure: each annotation covers a contiguous range of frames.
 
-### 7.1 Format (`annotation_v1`)
+### 8.1 Format (`annotation_v1`)
 
 The `annotations` array in the Zarr store contains `N` entries, where `N` is the total number of annotation spans in the episode (not the number of frames). Each entry is a UTF-8-encoded JSON string:
 
@@ -425,7 +482,7 @@ The `annotations` array in the Zarr store contains `N` entries, where `N` is the
 - Do **not** encode task-level descriptions here (those go in `task_description`). Use annotations for sub-step descriptions.
 - An empty `annotations` array (shape `(0,)`) is valid when no annotation is available.
 
-### 7.2 Annotation Granularity
+### 8.2 Annotation Granularity
 
 Use at minimum one annotation per task phase. For `fold_clothes`, for example:
 
@@ -437,7 +494,7 @@ Use at minimum one annotation per task phase. For `fold_clothes`, for example:
 | Fold right sleeve | "folding the right sleeve towards the center" |
 | Fold body | "folding the bottom half up to complete the fold" |
 
-### 7.3 Writing Annotations
+### 8.3 Writing Annotations
 
 Via `ZarrWriter`:
 ```python
@@ -471,13 +528,13 @@ writer.append_annotations(
 )
 ```
 
-### 7.4 Scale AI Annotation Format
+### 8.4 Scale AI Annotation Format
 
 If you are delivering data through Scale AI, annotations are generated via the Scale annotation API. The `ScaleAnnotationDatasetFilter` class can be used to filter episodes to only those with completed Scale annotations. Set `SCALE_API_KEY` in your environment.
 
 ---
 
-## 8. Embodiment Identifiers
+## 9. Embodiment Identifiers
 
 The `embodiment` field in the DB row and in `zarr.attrs` must be one of the following strings. The `robot_name` field is the same string (fine-grained variant names are allowed in `robot_name` but `embodiment` must match this list exactly).
 
@@ -500,9 +557,9 @@ The `embodiment` field in the DB row and in `zarr.attrs` must be one of the foll
 
 ---
 
-## 9. Uploading to S3
+## 10. Uploading to S3
 
-### 9.1 S3 Path Convention
+### 10.1 S3 Path Convention
 
 ```
 s3://rldb/processed_v3/<embodiment_prefix>/<episode_hash>.zarr/
@@ -521,7 +578,7 @@ s3://rldb/processed_v3/aria/2026-03-15-14-22-10-000000.zarr/
 s3://rldb/processed_v3/eva/2025-11-04-09-30-00-000000.zarr/
 ```
 
-### 9.2 Upload with `s5cmd`
+### 10.2 Upload with `s5cmd`
 
 `s5cmd` is the recommended upload tool (installed as part of the Python environment).
 
@@ -544,7 +601,7 @@ upload_dir_to_s3(
 )
 ```
 
-### 9.3 Bulk Upload with Ray
+### 10.3 Bulk Upload with Ray
 
 For batch uploads of many episodes, use Ray to parallelize:
 
@@ -571,9 +628,9 @@ ray.get(tasks)
 
 ---
 
-## 10. Validation and Verification
+## 11. Validation and Verification
 
-### 10.1 Automated Checks
+### 11.1 Automated Checks
 
 Run these checks on every episode before uploading:
 
@@ -729,7 +786,7 @@ else:
     print("All checks passed.")
 ```
 
-### 10.2 End-to-End Load Test
+### 11.2 End-to-End Load Test
 
 Verify the episode loads correctly through the full training pipeline before uploading:
 
@@ -769,7 +826,7 @@ Expected output for a valid Aria bimanual episode in cartesian mode:
 
 ---
 
-## 11. Pre-Submission Checklist
+## 12. Pre-Submission Checklist
 
 Complete every item before considering an episode ready for upload.
 
@@ -805,7 +862,7 @@ Complete every item before considering an episode ready for upload.
 - [ ] DB row inserted before upload.
 - [ ] `zarr_processed_path` updated to the correct S3 path after upload.
 - [ ] `num_frames` in DB row matches `total_frames` in `zarr.attrs`.
-- [ ] `embodiment` in DB row exactly matches the embodiment enum string (§8).
+- [ ] `embodiment` in DB row exactly matches the embodiment enum string (§9).
 
 **Upload**
 - [ ] Episode is accessible at `s3://rldb/processed_v3/<prefix>/<episode_hash>.zarr/`.
@@ -813,7 +870,7 @@ Complete every item before considering an episode ready for upload.
 
 ---
 
-## 12. Getting Access and Contact
+## 13. Getting Access and Contact
 
 ### Access Request
 


### PR DESCRIPTION
Adds a new §2 "Dataset Practices" section to CONTRIBUTING_DATA.md — the
"what data to capture" guidance the Overview already references but the doc lacked:

- §2.1 Target data composition (≤5% navigation / ~10% mobile-manipulation /
  ~85% manipulation; ~60/40 parallel-jaw vs either gripper; ~70/30 tabletop)
- §2.2 Capture settings (staged studio → in-the-wild)
- §2.3 Quality / failure modes to avoid (stalling, inspecting, patting)
- §2.4 Trimming rules (aggressive head movement, hands visible in all frames,
  trim to task-relevant portions)
- §2.5 Example tasks (17-row table)

Renumbers §2→§12 to §3→§13, updates all cross-refs / TOC anchors, and links
the Overview "Dataset Practices" row to the new section. Based on main.