### PR TITLE
baseline8 encdec H-Net campaign: EncDec-bottom per-emb stages + bottom-allocation sweep

### DIFF
--- a/count_active.py
+++ b/count_active.py
@@ -1,0 +1,101 @@
+"""Module-tree ACTIVE param count for the chunkchunk_trunk H-Net.
+
+Active = all shared modules + exactly ONE embodiment's branch of every
+per-emb container (PerEmbodimentStage.sub_stages / MultiEmbodimentCondEncoder.encoders
+/ gmm_heads ModuleDict). Walks the tree by IDENTITY, not names.
+"""
+
+import sys
+
+import torch
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+
+CFG = sys.argv[1]
+EMB = "pushshapes_sim"  # the branch counted as active
+
+cfg = OmegaConf.load(CFG)
+outer = instantiate(cfg.robomimic_model.outer_stage)
+
+M = 1e6
+
+
+def n_params(mod):
+    return sum(p.numel() for p in mod.parameters())
+
+
+def active_params(mod):
+    """Recurse; at any per-emb dict container keep only EMB's branch."""
+    kids = dict(mod.named_children())
+    # per-emb containers in this codebase
+    for attr in ("sub_stages", "encoders"):
+        sub = getattr(mod, attr, None)
+        if isinstance(sub, torch.nn.ModuleDict) and EMB in sub:
+            others = {k: v for k, v in sub.items() if k != EMB}
+            total = n_params(mod)
+            dead = sum(n_params(v) for v in others.values())
+            # recurse into the kept branch for nested per-emb containers
+            kept = sub[EMB]
+            kept_total = n_params(kept)
+            kept_active = active_params(kept)
+            return total - dead - (kept_total - kept_active)
+    tot = 0
+    counted = set()
+    for name, k in kids.items():
+        tot += active_params(k)
+        counted.add(name)
+    # direct parameters on this module
+    tot += sum(p.numel() for n, p in mod.named_parameters(recurse=False))
+    return tot
+
+
+def report(label, mod):
+    if mod is None:
+        return 0
+    a = active_params(mod)
+    t = n_params(mod)
+    print(f"{label:42s} active {a/M:8.2f}M   total {t/M:8.2f}M")
+    return a
+
+
+print("=== component breakdown ===")
+tot = 0
+tot += report("obs encoders (input_modules)", outer.input_modules)
+hnet = outer.inner_stage
+for i, st in enumerate(hnet.stages):
+    # count each stage's OWN params (exclude the chained inner_stage)
+    class Own(torch.nn.Module):
+        def __init__(self, s):
+            super().__init__()
+            for n, c in s.named_children():
+                if n != "inner_stage":
+                    self.add_module(n, c)
+            self._direct = [p for _, p in s.named_parameters(recurse=False)]
+
+    own = Own(st)
+    tot += report(f"stage[{i}] {type(st).__name__}", own)
+# heads
+gh = getattr(outer, "gmm_heads", None) or getattr(outer, "action_out", None)
+if isinstance(gh, torch.nn.ModuleDict):
+    a = n_params(gh[EMB]) if EMB in gh else 0
+    print(f"{'gmm head (1 emb)':42s} active {a/M:8.2f}M   total {n_params(gh)/M:8.2f}M")
+    tot += a
+else:
+    tot += report("action head", gh)
+print(f"{'TOTAL ACTIVE (1 emb)':42s} {tot/M:8.2f}M")
+print(f"{'TOTAL (all params)':42s} {n_params(outer)/M:8.2f}M")
+
+# fine-grained chunker internals for the budget-swap design
+print("\n=== chunker internals (per emb, level 0 + 1) ===")
+for i, st in enumerate(hnet.stages):
+    sub = getattr(st, "sub_stages", None)
+    if isinstance(sub, torch.nn.ModuleDict) and EMB in sub:
+        ch = sub[EMB]
+        for name, child in ch.named_children():
+            if name == "inner_stage":
+                continue
+            print(f"  L{i}.{name:24s} {n_params(child)/M:7.3f}M")
+        d = sum(p.numel() for _, p in ch.named_parameters(recurse=False))
+        if d:
+            print(f"  L{i}.<direct params>          {d/M:7.3f}M")
+print("DONE")

--- a/egomimic/algo/bc/algo.py
+++ b/egomimic/algo/bc/algo.py
@@ -535,6 +535,14 @@ class WindowedBC(PackedAlgoBase):
         # any rollout — which is exactly what blocked BC-RNN sim eval (DESIGN
         # step 10 headline). Pre-existing latent bug from the H-Net restructure.
         self.train_obs_transforms: list = []
+        # Same gap for the episode-level transforms branch added later to
+        # PackedAlgoBase.process_batch_for_training (reads
+        # self.episode_level_transforms at the top of the loop, BEFORE the
+        # train_obs_transforms guard). WindowedBC has no episode-level
+        # transforms, so set it empty too; otherwise the VALIDATION path
+        # (pl_model.validation_step -> process_batch_for_training) raises
+        # AttributeError: WindowedBC has no attribute episode_level_transforms.
+        self.episode_level_transforms: list = []
         # CONFIG-FACING name is ``core_net``; ``lstm`` is the DEPRECATED ALIAS
         # (kept so old configs / EgoVerse-pact-2 ported yamls keep working). Pass
         # exactly one of the two. Downstream code below keeps the local name

--- a/egomimic/algo/hnet/algo.py
+++ b/egomimic/algo/hnet/algo.py
@@ -23,11 +23,11 @@ import torch.nn as nn
 from overrides import override
 
 from egomimic.algo.algo import Algo
+from egomimic.models.stems.input_modules import ActionInToken, InputModule
+from egomimic.models.stems.cond_encoders import CondEncoderModule
 from egomimic.models.hnet.context import HNetContext
 from egomimic.models.hnet.hnet import HNet as HNetCore
 from egomimic.models.hnet.hnet import chunk_stats_from_aux
-from egomimic.models.stems.cond_encoders import CondEncoderModule
-from egomimic.models.stems.input_modules import ActionInToken, InputModule
 from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
 
 
@@ -115,9 +115,7 @@ class GMMLoss(nn.Module):
         T = actions.shape[1]
         device = actions.device
         t = torch.arange(T, device=device)
-        idx = torch.clamp(
-            t[:, None] + torch.arange(C, device=device)[None, :], max=T - 1
-        )
+        idx = torch.clamp(t[:, None] + torch.arange(C, device=device)[None, :], max=T - 1)
         return actions[:, idx]
 
     def forward(self, batch: dict, ctx) -> torch.Tensor:
@@ -511,6 +509,7 @@ class HNetPolicy(nn.Module):
                 B=state["batch_size"],
                 device=state["device"],
                 dtype=state["dtype"],
+                embodiment_id=embodiment_id,
             )
             cur = contrib if cur is None else cur + contrib
         if cur is None:
@@ -522,7 +521,8 @@ class HNetPolicy(nn.Module):
             inference_params=state["params"],
         )
         h = self.hnet.step(cur, ctx)
-        a_t_norm = self.action_out(h)
+        _head = self.action_out[embodiment_id] if isinstance(self.action_out, nn.ModuleDict) else self.action_out
+        a_t_norm = _head(h)
 
         # F6: no per-step pos_emb add. Cache the prediction so the next
         # step's ActionInToken (if any) can read it.
@@ -605,8 +605,7 @@ class HNetOuterStage(nn.Module):
                 self.action_out = gmm_head
             else:
                 raise ValueError(
-                    "action_head_type='gmm' requires gmm_head or gmm_heads"
-                )
+                    "action_head_type='gmm' requires gmm_head or gmm_heads")
         else:
             raise ValueError(
                 f"action_head_type must be 'linear'|'mlp'|'gmm', got "
@@ -651,12 +650,7 @@ class HNetOuterStage(nn.Module):
         x = None
         for mod in self.input_modules:
             contrib = mod.forward_padded(
-                actions=actions,
-                obs=obs,
-                B=B,
-                T=T,
-                device=device,
-                dtype=dtype,
+                actions=actions, obs=obs, B=B, T=T, device=device, dtype=dtype,
                 embodiment_id=ctx.embodiment_id,
             )
             x = contrib if x is None else x + contrib
@@ -712,12 +706,9 @@ class HNetOuterStage(nn.Module):
         actions); the head is stashed on ``ctx.extras`` so ``GMMLoss`` can read
         them back through the same head's ``.nll``.
         """
-        head = (
-            self.action_out[ctx.embodiment_id]
-            if isinstance(self.action_out, nn.ModuleDict)
-            else self.action_out
-        )
-        self._cur_head = head  # remember for the per-frame eval decode path
+        head = (self.action_out[ctx.embodiment_id]
+                if isinstance(self.action_out, nn.ModuleDict) else self.action_out)
+        object.__setattr__(self, "_cur_head", head)  # NOT a registered submodule: self._cur_head=head adds duplicate _cur_head.* keys to state_dict and breaks strict resume
         batch["pred_action"] = head(h)
         if self.action_head_type == "gmm":
             ctx.extras["gmm_head"] = head
@@ -753,11 +744,8 @@ class HNetOuterStage(nn.Module):
             return raw
         head = getattr(self, "_cur_head", None)
         if head is None or isinstance(head, nn.ModuleDict):
-            head = (
-                next(iter(self.action_out.values()))
-                if isinstance(self.action_out, nn.ModuleDict)
-                else self.action_out
-            )
+            head = (next(iter(self.action_out.values()))
+                    if isinstance(self.action_out, nn.ModuleDict) else self.action_out)
         a = head.decode(raw)
         if int(getattr(head, "chunk_len", 1)) > 1:
             a = a[..., 0, :]
@@ -837,14 +825,12 @@ class HNetOuterStage(nn.Module):
         cond_2d = {k: v.squeeze(1) for k, v in cond_dict_seq.items()}
 
         obs_step = {
-            k: v.unsqueeze(1)
-            if (
+            k: v.unsqueeze(1) if (
                 torch.is_tensor(v)
                 and v.dim() < 5
                 and v.shape[0] == state["batch_size"]
                 and (v.dim() == 1 or v.shape[1] != 1)
-            )
-            else v
+            ) else v
             for k, v in obs_norm.items()
         }
         cur = None
@@ -856,6 +842,7 @@ class HNetOuterStage(nn.Module):
                 B=state["batch_size"],
                 device=state["device"],
                 dtype=state["dtype"],
+                embodiment_id=embodiment_id,
             )
             cur = contrib if cur is None else cur + contrib
         if cur is None:
@@ -868,7 +855,8 @@ class HNetOuterStage(nn.Module):
             embodiment_id=embodiment_id,
         )
         h = self.inner_stage.step(cur, ctx)
-        a_t_norm = self.action_out(h)
+        _head = self.action_out[embodiment_id] if isinstance(self.action_out, nn.ModuleDict) else self.action_out
+        a_t_norm = _head(h)
         state["prev_action"] = a_t_norm
         return a_t_norm
 
@@ -903,16 +891,8 @@ def _stride_packed(obs, actions, cu_seqlens, sigma, C):
         idx_list.append(fr)
         ep_end_list.append(torch.full_like(fr, e))
         new_cu.append(new_cu[-1] + int(fr.numel()))
-    sidx = (
-        torch.cat(idx_list)
-        if idx_list
-        else torch.empty(0, dtype=torch.long, device=dev)
-    )
-    ep_end = (
-        torch.cat(ep_end_list)
-        if ep_end_list
-        else torch.empty(0, dtype=torch.long, device=dev)
-    )
+    sidx = torch.cat(idx_list) if idx_list else torch.empty(0, dtype=torch.long, device=dev)
+    ep_end = torch.cat(ep_end_list) if ep_end_list else torch.empty(0, dtype=torch.long, device=dev)
     new_cu_t = torch.tensor(new_cu, device=dev, dtype=torch.long)
     # Strided obs: gather per-frame tensors at sidx; pass through anything whose
     # leading dim isn't T_total (e.g. scalar/meta tensors).
@@ -952,7 +932,8 @@ class PackedAlgoBase(Algo):
         use_parameter_groups: bool = False,
         weight_decay: float = 0.0,
         train_obs_transforms: list | None = None,
-        obs_stride: int = 1,
+        episode_level_transforms: list | None = None,
+        obs_stride: int = None,
         **kwargs,
     ):
         """
@@ -996,6 +977,7 @@ class PackedAlgoBase(Algo):
         self.lr_multipliers = list(lr_multipliers) if lr_multipliers else None
         self.weight_decay = float(weight_decay)
         self.train_obs_transforms = list(train_obs_transforms or [])
+        self.episode_level_transforms = list(episode_level_transforms or [])
         # obs_stride: subsample the obs-token stream fed to the chunker so
         # routed tokens are ``obs_stride`` sim-frames apart (mirrors the
         # working WindowedBC/HNetCore recipe). With stride > 1 the RoutingModule
@@ -1005,6 +987,19 @@ class PackedAlgoBase(Algo):
         # actions at FULL frame resolution, so with obs_stride == chunk_len the
         # 8-action chunks tile the episode exactly (like obs_stride=8/chunk_len=8
         # on the RNN side).
+        # Resolve the GMM head chunk_len once. ``action_out`` is an nn.ModuleDict
+        # of per-embodiment GMM heads for the indomain_c4 cells, and the dict
+        # itself has no .chunk_len (it lives on the member heads), so read it
+        # from a member head when action_out is a ModuleDict; previously this
+        # fell back to 1 and silently mis-trained chunk_len>1 models.
+        _ao = getattr(outer_stage, "action_out", None)
+        if isinstance(_ao, nn.ModuleDict):
+            _ao = next(iter(_ao.values()), None)
+        _cl = int(getattr(_ao, "chunk_len", 1))
+        if obs_stride is None:
+            # default to the GMM head chunk_len so the validated obs_stride==chunk_len
+            # recipe holds when unset.
+            obs_stride = _cl
         self.obs_stride = int(obs_stride)
         if self.obs_stride < 1:
             raise ValueError(f"obs_stride must be >= 1, got {self.obs_stride}")
@@ -1014,7 +1009,7 @@ class PackedAlgoBase(Algo):
         # non-GMM has no chunk fan-out) instead of corrupting metrics silently.
         if self.obs_stride > 1:
             _ah = getattr(outer_stage, "action_head_type", None)
-            _C = int(getattr(getattr(outer_stage, "action_out", None), "chunk_len", 1))
+            _C = _cl
             if _ah != "gmm":
                 raise ValueError(
                     f"obs_stride>1 currently requires action_head_type='gmm' (got {_ah!r})."
@@ -1098,6 +1093,12 @@ class PackedAlgoBase(Algo):
         processed = {}
         for emb_name, _batch in batch.items():
             emb_id = get_embodiment_id(emb_name)
+            # Episode-level transforms (e.g. PadHoldStill) — PRE-norm, may
+            # change length (updates cu_seqlens). Train-only, packed-only.
+            if (self.episode_level_transforms and self.outer_stage.training
+                    and "cu_seqlens" in _batch):
+                from egomimic.algo.hnet.episode_transforms import apply_episode_level_transforms
+                _batch = apply_episode_level_transforms(_batch, self.episode_level_transforms)
             processed[emb_id] = {}
             # Detect packed batches by the presence of cu_seqlens. Packed and
             # padded batches have a different key topology; treat them
@@ -1177,6 +1178,8 @@ class PackedAlgoBase(Algo):
                 # For action_head_type='gmm', the head IS outer_stage.action_out
                 # (no separate .gmm_head attr); chunk_len lives there.
                 head = getattr(outer_stage, "action_out", None)
+                if isinstance(head, nn.ModuleDict):
+                    head = next(iter(head.values()))
                 C = int(getattr(head, "chunk_len", 1))
                 sobs, scu, smax, chunk_targets, sidx, _ = _stride_packed(
                     obs, actions, _batch["cu_seqlens"], self.obs_stride, C
@@ -1283,6 +1286,8 @@ class PackedAlgoBase(Algo):
             # the downstream metric/viz code is untouched. (Mirrors how the sim
             # inference_step rolls out: re-observe every chunk_len frames.)
             head = getattr(policy, "action_out", None)
+            if isinstance(head, nn.ModuleDict):
+                head = head[self.domain_by_id.get(emb_id)]
             C = int(getattr(head, "chunk_len", 1))
             sobs, scu, smax, _, sidx, ep_end = _stride_packed(
                 obs, actions, cu, self.obs_stride, C
@@ -1313,11 +1318,7 @@ class PackedAlgoBase(Algo):
             )
         else:
             pred_packed, _ = policy.forward_packed(
-                actions,
-                obs,
-                cu,
-                max_seqlen,
-                embodiment_id=self.domain_by_id.get(emb_id),
+                actions, obs, cu, max_seqlen, embodiment_id=self.domain_by_id.get(emb_id)
             )
 
         B = int(seq_lens.shape[0])
@@ -1392,6 +1393,7 @@ class PackedAlgoBase(Algo):
             device = next(self.outer_stage.parameters()).device
             default_T = int(getattr(policy, "action_horizon", 1024))
             T_max_use = int(T_max) if T_max is not None else default_T
+            import torch
 
             # Run the AR rollout in the MODEL's own dtype (fp32 when loaded
             # .float(), like training + teacher-forced overlay + txar's sim),
@@ -1401,9 +1403,7 @@ class PackedAlgoBase(Algo):
             # and uniquely degraded the H-Net (txar's init_step_state defaults to
             # fp32, hence "txar works, H-Net doesn't"). Match training precision.
             self._sim_state = policy.init_step_state(
-                batch_size=1,
-                T_max=T_max_use,
-                device=device,
+                batch_size=1, T_max=T_max_use, device=device,
                 dtype=next(policy.parameters()).dtype,
             )
             # Open-loop action queue (mirrors WindowedBCPolicy.step): on an
@@ -1430,14 +1430,14 @@ class PackedAlgoBase(Algo):
             # token, decode a fresh chunk, refill the queue.
             obs_norm = self.norm_stats.normalize(obs_zarr, emb_id)
             raw = policy.step(
-                self._sim_state,
-                obs_norm,
-                t,
+                self._sim_state, obs_norm, t,
                 embodiment_id=self.domain_by_id.get(emb_id),
             )  # (B,1,*)
             if is_gmm:
-                chunk = policy.action_out.decode(raw)  # (B,1,C,D) if C>1 else (B,1,D)
-                C = int(getattr(policy.action_out, "chunk_len", 1))
+                _ah = (policy.action_out[self.domain_by_id.get(emb_id)]
+                       if isinstance(policy.action_out, nn.ModuleDict) else policy.action_out)
+                chunk = _ah.decode(raw)  # (B,1,C,D) if C>1 else (B,1,D)
+                C = int(getattr(_ah, "chunk_len", 1))
                 if C > 1:
                     # (B,1,C,D) -> C tensors (B,1,D), one per chunk position.
                     # RE-PLAN CADENCE = the ARCHITECTURE's obs_stride. A model
@@ -1520,3 +1520,4 @@ class PackedAlgoBase(Algo):
 # that referenced the ``HNet`` name (now reachable at
 # ``egomimic.algo.hnet.HNet``). New code should use ``PackedAlgoBase``.
 HNet = PackedAlgoBase
+

--- a/egomimic/algo/hnet/episode_transforms.py
+++ b/egomimic/algo/hnet/episode_transforms.py
@@ -1,0 +1,114 @@
+"""Episode-level batch transforms applied during training in PackedAlgoBase.
+
+Unlike the per-frame ``transform_list`` (dataset ``_read_span``, length-preserving)
+and ``train_obs_transforms`` (post-norm, length-preserving), these operate on ONE
+episode at a time and MAY change its length. They run PRE-normalization at the top
+of ``PackedAlgoBase.process_batch_for_training`` so cross-key raw values (e.g. the
+agent position in ``observations.state``) are in the same world-coord space as
+``actions``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_EPT_LOGGED = False
+
+_PACKED_META = (
+    "cu_seqlens", "max_seq_len", "seq_lens", "batch_size",
+    "embodiment", "episode_idx", "chunk_offset", "_packed",
+)
+
+
+class EpisodeLevelTransform:
+    """Base: operate on one episode's packed tensors (each ``(L, ...)``, time
+    leading). May change ``L``. Return the transformed episode dict."""
+
+    def __call__(self, episode: dict) -> dict:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+def apply_episode_level_transforms(batch: dict, transforms: list) -> dict:
+    """Split a packed batch by ``cu_seqlens``, apply each transform per episode
+    (length may change), re-pack, and update ``cu_seqlens`` / ``seq_lens`` /
+    ``max_seq_len``. Meta + non-time-series keys are preserved. Returns a new dict.
+    """
+    if not transforms or "cu_seqlens" not in batch:
+        return batch
+    cu = batch["cu_seqlens"]
+    cu_list = [int(x) for x in cu.tolist()]
+    B = len(cu_list) - 1
+    T_total = cu_list[-1]
+    seq_keys = [
+        k for k, v in batch.items()
+        if torch.is_tensor(v) and k not in _PACKED_META
+        and v.dim() >= 1 and v.shape[0] == T_total
+    ]
+    if not seq_keys:
+        return batch
+    eps = []
+    for b in range(B):
+        s, e = cu_list[b], cu_list[b + 1]
+        ep = {k: batch[k][s:e] for k in seq_keys}
+        for t in transforms:
+            ep = t(ep)
+        eps.append(ep)
+    out = dict(batch)
+    new_lens = [int(ep[seq_keys[0]].shape[0]) for ep in eps]
+    new_cu = [0]
+    for L in new_lens:
+        new_cu.append(new_cu[-1] + L)
+    global _EPT_LOGGED
+    if not _EPT_LOGGED:
+        print('[EpisodeLevelTransform] fired %s: T_total %d -> %d over %d episodes' % (
+            [type(t).__name__ for t in transforms], T_total, new_cu[-1], B))
+        _EPT_LOGGED = True
+    out["cu_seqlens"] = torch.tensor(new_cu, device=cu.device, dtype=cu.dtype)
+    for k in seq_keys:
+        out[k] = torch.cat([ep[k] for ep in eps], dim=0)
+    if "seq_lens" in batch and torch.is_tensor(batch["seq_lens"]):
+        out["seq_lens"] = torch.tensor(
+            new_lens, device=batch["seq_lens"].device, dtype=batch["seq_lens"].dtype)
+    if "max_seq_len" in batch:
+        mv, old = max(new_lens), batch["max_seq_len"]
+        out["max_seq_len"] = (torch.tensor(mv, device=old.device, dtype=old.dtype)
+                              if torch.is_tensor(old) else type(old)(mv))
+    return out
+
+
+class PadHoldStill(EpisodeLevelTransform):
+    """Append ``n_pad`` hold-still frames to each episode so the policy learns to
+    STAY STILL after it solves the task. obs / state / image repeat their final
+    frame; ``actions`` are held at the **actual agent position**
+    (``observations.state[:agent_dim][-1]``) — NOT the last action/cursor (which
+    is ``pusher_cmd_pose`` == ``actions``). Pre-norm: action and state[:2] share
+    the world-coord (0-512) space.
+    """
+
+    def __init__(self, n_pad: int = 50, action_key: str = "actions",
+                 state_key: str = "observations.state", agent_dim: int = 2):
+        self.n_pad = int(n_pad)
+        self.action_key = action_key
+        self.state_key = state_key
+        self.agent_dim = int(agent_dim)
+
+    def __call__(self, ep: dict) -> dict:
+        if self.n_pad <= 0:
+            return ep
+        hold = None
+        if self.state_key in ep and torch.is_tensor(ep[self.state_key]):
+            hold = ep[self.state_key][-1, : self.agent_dim]
+        out = {}
+        for k, v in ep.items():
+            if not torch.is_tensor(v) or v.dim() == 0:
+                out[k] = v
+                continue
+            if k == self.action_key and hold is not None:
+                step = v[-1].clone()
+                d = min(step.shape[-1], hold.shape[-1])
+                step[..., :d] = hold[:d].to(step.dtype)
+                pad = step.unsqueeze(0).repeat(self.n_pad, *([1] * step.dim()))
+            else:
+                pad = v[-1:].repeat(self.n_pad, *([1] * (v.dim() - 1)))
+            out[k] = torch.cat([v, pad], dim=0)
+        return out

--- a/egomimic/algo/hpt/algo.py
+++ b/egomimic/algo/hpt/algo.py
@@ -358,7 +358,19 @@ class HPTModel(nn.Module):
         feat_dict = {}
         for modality in self.modalities.get(domain, []) + self.shared_keys:
             if modality not in data:
-                continue
+                # A registered modality missing from the batch is a wiring bug,
+                # not a benign skip: the silent `continue` here is what let the
+                # "state_state_agent_obj" double-prefix drop ALL proprio
+                # unnoticed for an entire training run (the only symptom was a
+                # DDP unused-parameters crash, which got masked by
+                # find_unused_parameters_true). Fail loudly instead.
+                raise KeyError(
+                    f"stem_process: registered modality {modality!r} for domain "
+                    f"{domain!r} is missing from data (available: "
+                    f"{sorted(data.keys())}). A registered stem would receive "
+                    f"no input — check the key translation in "
+                    f"_robomimic_to_hpt_data."
+                )
             if modality in self.shared_keys:
                 domain = "shared"
 
@@ -1214,7 +1226,17 @@ class HPT(Algo):
             }
         state = self._sim_state
 
-        if state["action_chunk"] is None or state["chunk_idx"] >= chunk_size:
+        # Replan cadence: by default consume the full action_horizon chunk
+        # open-loop (chunk_size steps between looks). ``self.replan_every``
+        # (eval-time knob, settable by the standalone evaluator) re-plans after
+        # only the first N actions of each chunk — receding-horizon execution.
+        # replan_every=1 = re-plan every env step (the cadence the 0.323
+        # reference HPT used); the chunk positions executed (0..N-1) are the
+        # best-trained ones, so no retrain is needed.
+        replan_every = min(
+            int(getattr(self, "replan_every", 0) or chunk_size), chunk_size
+        )
+        if state["action_chunk"] is None or state["chunk_idx"] >= replan_every:
             cam_keys = self.camera_keys[emb_id]
             proprio_keys = self.proprio_keys[emb_id]
             ac_key = self.ac_keys[embodiment_name]
@@ -1243,6 +1265,7 @@ class HPT(Algo):
             )
             actions = policy_module.forward(embodiment_name, data)
             chunk = actions.get(embodiment_name)
+            if chunk is None and "shared" in actions: chunk = actions["shared"]  # cotrain shared-head keys output as shared, not embodiment name
             if chunk is None:
                 raise RuntimeError(
                     f"policy.forward did not return key {embodiment_name!r}"
@@ -1288,11 +1311,18 @@ class HPT(Algo):
 
         # MultiDataset emits dotted batch keys (e.g. "observations.state.ee_pose"),
         # but HPT stems are registered under the last segment ("state_ee_pose",
-        # "front_img_1"). Translate via rsplit; no-op on already-flat keys.
+        # "front_img_1"). Translate via rsplit. Keys that are already flat AND
+        # already carry the "state_" prefix (e.g. pushshapes "state_agent_obj")
+        # must NOT be prefixed again: the old unconditional f"state_{short}"
+        # produced "state_state_agent_obj", which matches no registered stem and
+        # silently dropped ALL proprio from the trunk (train + eval) — the
+        # policy trained image-only. Found 2026-06-09.
         for key in proprio_keys:
             if key in batch:
                 short = key.rsplit(".", 1)[-1]
-                data[f"state_{short}"] = batch[key].unsqueeze(1)
+                if not short.startswith("state_"):
+                    short = f"state_{short}"
+                data[short] = batch[key].unsqueeze(1)
 
         for key in cam_keys:
             if key in batch:

--- a/egomimic/eval/core/ckpt_loading.py
+++ b/egomimic/eval/core/ckpt_loading.py
@@ -101,6 +101,10 @@ def main():
     parser.add_argument("--embodiment-name", default="pushshapes_sim",
                         help="Which embodiment to roll out (e.g. pushshapes_sim_small_circle for the small run).")
     parser.add_argument("--pusher", default="circle", help="env pusher_shape")
+    parser.add_argument("--obstacle-level", type=int, default=0,
+                        help="env obstacle_level (0-29 with the ported 30-level obstacles.py)")
+    parser.add_argument("--coverage-threshold", type=float, default=0.7,
+                        help="episode early-stop + success cutoff; 0.95 for true peak + SR@0.95")
     parser.add_argument(
         "--obs-stride",
         type=int,
@@ -132,6 +136,12 @@ def main():
         action="store_true",
         help="Reseed the sampler RNG per episode (inside fork_rng) so GMM "
         "sampling noise is paired across runs for the same episode index.",
+    )
+    parser.add_argument(
+        "--full-horizon",
+        action="store_true",
+        help="Ignore the env terminated (coverage>=0.95) early-stop so every "
+        "episode runs the full --max-steps -> true uncapped peak + uniform length.",
     )
     parser.add_argument(
         "--only-emb",
@@ -236,15 +246,16 @@ def main():
         print(f"[sim] init_mode=seeds  seeds={init_seeds[0]}..{init_seeds[-1]}")
     eval_cls = HPTSimEval if args.eval_class == "hpt" else PackedSimEval
     sim_eval = eval_cls(
-        env_kwargs={"object_shape": "T", "pusher_shape": args.pusher},
+        env_kwargs={"object_shape": "T", "pusher_shape": args.pusher, "obstacle_level": args.obstacle_level},
         embodiment_name=args.embodiment_name,
         init_mode=args.init_mode,
         init_seeds=init_seeds,
         max_steps=args.max_steps,
         report_max_coverage=args.max_coverage,
-        coverage_threshold=0.7,
+        coverage_threshold=args.coverage_threshold,
         limit_val_batches=args.n_episodes,
         rng_pairing=args.rng_pairing,
+        run_full_horizon=args.full_horizon,
     )
     sim_eval.trainer = _MockTrainer(args.out_dir, device)
     sim_eval.model = algo

--- a/egomimic/eval/core/eval_sim.py
+++ b/egomimic/eval/core/eval_sim.py
@@ -86,6 +86,7 @@ class SimRolloutEval(EvalVideo):
         viz_func: dict | None = None,
         transform_lists: dict | None = None,
         rng_pairing: bool = False,
+        run_full_horizon: bool = False,
     ):
         super().__init__(
             limit_val_batches=limit_val_batches,
@@ -122,6 +123,10 @@ class SimRolloutEval(EvalVideo):
         # for the same episode index. Off by default: numbers from unpaired
         # evals stay reproducible.
         self.rng_pairing = bool(rng_pairing)
+        # If True, ignore the env terminated (coverage>=0.95) early-stop so
+        # every episode runs the full max_steps -> true uncapped peak +
+        # uniform length.
+        self.run_full_horizon = bool(run_full_horizon)
         self._env = None
         self._init_counter = 0
 
@@ -286,7 +291,7 @@ class SimRolloutEval(EvalVideo):
                 if frame is not None:
                     frame = self._draw_action_overlay(frame, action_xy, action_history)
                     frames.append(np.ascontiguousarray(frame))
-                if terminated:
+                if terminated and not self.run_full_horizon:
                     break
         except _RolloutTimeout:
             print(

--- a/egomimic/eval/probes/eval_trunk_hf.py
+++ b/egomimic/eval/probes/eval_trunk_hf.py
@@ -1,0 +1,122 @@
+"""TrunkHFEval — per-embodiment high-frequency diagnostic for the SHARED trunk.
+
+For each embodiment, logs the per-token first-difference L2 norm (high-frequency
+content) of the TRUNK reconstruction (``up`` from msublatent_up) vs the linear
+RESIDUAL (``residual_scale * residual_proj(x)``), plus their ratio.
+
+Reading:
+  * ``hf_ratio = HFtrunk / HFresid``.
+  * ``> ~1``  -> the trunk carries the per-token detail (emb is living on the trunk).
+  * ``< 1``   -> the residual carries the per-token detail = the emb is BYPASSING
+                the trunk (trunk is only a smooth baseline).
+
+Why HF and not magnitude: a heavily under-segmented chunk produces a high-MAGNITUDE
+but SMOOTH trunk reconstruction (one chunk spread over hundreds of tokens), so raw
+norm hides the bypass; the first-difference isolates information-bearing per-token
+variation. Forward-only (teacher-forced) -> no DECHUNK-AR needed.
+
+Watch the two embodiments' hf_ratio CONVERGE across training; divergence is the
+shared-trunk capture (one emb grabs the trunk, the other bypasses via residual).
+See vault: 30_Projects/RL2/Transformer HNet/Findings.md.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+
+from egomimic.eval.core.eval_video import EvalVideo
+
+
+def _hf(x: torch.Tensor, cu: torch.Tensor) -> float:
+    """Mean per-token first-difference L2 norm WITHIN sequences (skips the
+    cross-sequence jumps at cu_seqlens starts)."""
+    if x.shape[0] < 2:
+        return float("nan")
+    d = (x[1:] - x[:-1]).norm(dim=-1)  # (T-1,)
+    mask = torch.ones_like(d, dtype=torch.bool)
+    starts = cu[1:-1].long() - 1
+    starts = starts[(starts >= 0) & (starts < d.shape[0])]
+    mask[starts] = False
+    return d[mask].mean().item() if bool(mask.any()) else float("nan")
+
+
+class TrunkHFEval(EvalVideo):
+    """Logs per-emb {trunk_hf, resid_hf, hf_ratio}. No viz."""
+
+    def __init__(
+        self,
+        limit_val_batches: int = 2,
+        viz_func: dict | None = None,
+        transform_lists: dict | None = None,
+        max_videos: int | None = 0,
+    ):
+        super().__init__(
+            limit_val_batches=limit_val_batches,
+            viz_func=viz_func,
+            transform_lists=transform_lists,
+            max_videos=max_videos,
+        )
+
+    @staticmethod
+    def _is_chunker(m) -> bool:
+        return (hasattr(m, "residual_proj") and hasattr(m, "residual_scale")
+                and hasattr(m, "msublatent_up"))
+
+    @torch.no_grad()
+    def compute_metrics_and_viz(
+        self, batch: Dict[int, Dict[str, Any]]
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[int, np.ndarray]]:
+        metrics: Dict[str, torch.Tensor] = {}
+        algo = self.model
+        root = getattr(algo, "nets", None)
+        if root is None or not hasattr(root, "named_modules"):
+            root = getattr(algo, "policy", None)
+        if root is None:
+            return metrics, {}
+        stages = [(n, m) for n, m in root.named_modules() if self._is_chunker(m)]
+        if not stages:
+            return metrics, {}
+
+        cap: Dict[str, torch.Tensor] = {}
+
+        def mk(key):
+            def h(mod, i, o):
+                cap[key] = (o[0] if isinstance(o, (tuple, list)) else o).detach().float()
+            return h
+
+        handles = []
+        for n, m in stages:
+            handles.append(m.msublatent_up.register_forward_hook(mk(n + "::up")))
+            handles.append(m.residual_proj.register_forward_hook(mk(n + "::res")))
+        try:
+            for emb_id, _batch in batch.items():
+                if not isinstance(_batch, dict) or not _batch.get("_packed", False):
+                    continue
+                ac_key = algo.resolved_ac_keys[emb_id]
+                obs = algo._build_obs(_batch, emb_id)
+                actions = _batch[ac_key]
+                cu = _batch["cu_seqlens"]
+                ms = int(_batch["max_seq_len"])
+                dom = getattr(algo, "domain_by_id", {}).get(emb_id)
+                cap.clear()
+                algo.policy.forward_packed(actions, obs, cu, ms, embodiment_id=dom)
+                cu_t = cu if torch.is_tensor(cu) else torch.as_tensor(cu)
+                for n, m in stages:
+                    up = cap.get(n + "::up")
+                    res = cap.get(n + "::res")
+                    if up is None or res is None:
+                        continue  # this sub_stage didn't run for this emb
+                    sc = (float(m.residual_scale.detach()) if torch.is_tensor(m.residual_scale)
+                          else float(m.residual_scale))
+                    res = sc * res
+                    cu_d = cu_t.to(up.device)
+                    hft, hfr = _hf(up, cu_d), _hf(res, cu_d)
+                    metrics[f"Valid/emb{emb_id}_trunk_hf"] = torch.tensor(hft)
+                    metrics[f"Valid/emb{emb_id}_resid_hf"] = torch.tensor(hfr)
+                    metrics[f"Valid/emb{emb_id}_hf_ratio"] = torch.tensor(hft / (hfr + 1e-9))
+        finally:
+            for h in handles:
+                h.remove()
+        return metrics, {}

--- a/egomimic/hydra_configs/callbacks/ckpt_ratio_loss_scheduler.yaml
+++ b/egomimic/hydra_configs/callbacks/ckpt_ratio_loss_scheduler.yaml
@@ -1,0 +1,25 @@
+# Checkpoints + ratio-loss reg-off scheduler (FIX #3).
+# Wires the ratio_loss_scheduler into the transformer-router arch runs (every
+# transformer-router config previously OMITTED it). switch_fraction=0.25 =>
+# reg-off at epoch 500 when max_epochs=2000 (the default ratio_loss_scheduler
+# uses switch_fraction=0.5 => ep1000, so we override it here explicitly).
+#
+# For the real (non-smoke) transformer-router configs: use THIS callbacks group
+# (callbacks=ckpt_ratio_loss_scheduler) at max_epochs=2000 to get reg-off@500.
+defaults:
+  - defaults
+  - _self_
+
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.output_dir}/checkpoints
+  filename: "epoch_{epoch}"
+  save_last: true
+  save_top_k: -1
+  every_n_epochs: 100
+
+ratio_loss_scheduler:
+  _target_: egomimic.pl_utils.callbacks.ratio_loss_scheduler.RatioLossScheduler
+  on_value: 0.03
+  off_value: 0.0
+  switch_fraction: 0.25   # reg-off @ ep500 for max_epochs=2000

--- a/egomimic/hydra_configs/data/indomain_c4_big.yaml
+++ b/egomimic/hydra_configs/data/indomain_c4_big.yaml
@@ -1,0 +1,64 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# PUSHSHAPES TABLE FEED -- BIG-ONLY  (in-domain, chunk-4 families).
+#
+# Feeds ONE domain: pushshapes_sim -> circle_3000 (big circle, 3040 ep).
+# Packed full-episode teacher forcing (chunking="none" -> one full episode per
+# packed sample); pack_collate concatenates batch_size episodes into a single
+# flat stream with cu_seqlens boundaries. Action chunking (chunk-4) is handled
+# in the model head / GMMLoss, NOT here.
+#
+# For the H-Net firstend pyramid + Tx WindowedBC families (both consume the
+# ZarrEpisodePackedDataset packed loader + get_keymap windowed obs). The model
+# keeps BOTH heads (pushshapes_sim + pushshapes_sim_small_circle); this feed
+# only provides big-circle data, so the small-circle head gets no gradient.
+#
+# circle_3000 episodes are tagged embodiment="pushshapes_sim" on disk, so the
+# plain LocalEpisodeResolver routes them correctly (no override needed).
+#
+# action_horizon=2560 is the keymap obs/action window cap (matches the firstend
+# model's outer_stage.action_horizon=2560). Longest episode here is ~500 frames,
+# so 2560 leaves ample headroom; max_seq_len=2560 packs whole episodes.
+
+train_datasets:
+  pushshapes_sim:                       # big circle
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000_plus_gen
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000_plus_gen
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4

--- a/egomimic/hydra_configs/data/indomain_c4_cotrain.yaml
+++ b/egomimic/hydra_configs/data/indomain_c4_cotrain.yaml
@@ -1,0 +1,104 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# PUSHSHAPES TABLE FEED -- BOTH / COTRAIN  (in-domain, chunk-4 families).
+#
+# Feeds BOTH domains from SEPARATE on-disk dirs (no name filter):
+#   pushshapes_sim              -> circle_3000_plus_gen  (big + generated, 3760 ep)
+#   pushshapes_sim_small_circle -> small_circle_3000     (small, 3040 ep)
+# Packed full-episode teacher forcing (chunking="none"); action chunking
+# (chunk-4) is handled in the model head / GMMLoss, NOT here.
+#
+# For the H-Net firstend pyramid + Tx WindowedBC families. The algo's
+# forward_training iterates per-embodiment and sets ctx.embodiment_id so the
+# per-emb cond encoder + PerEmbodimentStage outer levels (H-Net) / per-emb
+# norm-stats (Tx shared policy) route correctly.
+#
+# circle_3000_plus_gen is tagged embodiment="pushshapes_sim" (includes ncc_*
+# generated episodes) -> plain LocalEpisodeResolver. small_circle_3000 is ALSO
+# tagged "pushshapes_sim" on disk, so it uses
+# LocalEpisodeResolverWithEmbodimentOverride to re-tag to
+# "pushshapes_sim_small_circle" at resolve time.
+#
+# action_horizon=2560 matches the firstend model's outer_stage.action_horizon.
+# Longest episode ~500 frames; 2560 leaves headroom.
+
+train_datasets:
+  pushshapes_sim:                       # big circle + generated
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000_plus_gen
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+  pushshapes_sim_small_circle:          # small circle
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000_plus_gen
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+  pushshapes_sim_small_circle:
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+  pushshapes_sim_small_circle:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+  pushshapes_sim_small_circle:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4

--- a/egomimic/hydra_configs/data/indomain_c4_hpt_big.yaml
+++ b/egomimic/hydra_configs/data/indomain_c4_hpt_big.yaml
@@ -1,0 +1,62 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# PUSHSHAPES TABLE FEED -- HPT BIG-ONLY  (in-domain, chunk-4).
+#
+# HPT-correct sibling of indomain_c4_big.yaml. HPT does NOT use the packed
+# ZarrEpisodePackedDataset loader + windowed get_keymap that the H-Net /
+# TransformerAR cells use. HPT's contract is "one CURRENT obs -> predict the
+# next action_horizon actions", so it must consume:
+#   - MultiDataset._from_resolver  (per-frame, not packed full-episode)
+#   - get_keymap_hpt               (SINGLE-frame obs front_img_1 +
+#                                   state_agent_obj, action_horizon-long
+#                                   action chunk, NO per-token obs horizon)
+#   - mode: total  +  skip_bounds_check: true
+# Feeding HPT the packed/windowed configs trains it out-of-distribution (the
+# model would read future obs out of context at train time, then go wildly OOD
+# in closed-loop rollout where only the current obs exists). See the
+# pushshapes.get_keymap_hpt docstring (diagnosed 2026-05-19).
+#
+# Feeds ONE domain: pushshapes_sim -> circle_3000 (big circle). circle_3000
+# episodes are tagged embodiment="pushshapes_sim" on disk, so the plain
+# LocalEpisodeResolver routes them correctly (no override needed). The model
+# keeps BOTH heads (pushshapes_sim + pushshapes_sim_small_circle); this feed
+# only provides big-circle data, so the small-circle head gets no gradient.
+#
+# action_horizon=4 matches the chunk-4 HPT model
+# (hpt_cotrain_pushshapes_flow_shared_head_c4_big.yaml: trunk.action_horizon=4,
+# head act_seq=4). Schema cloned from tsimulation_hpt_cot3000.yaml.
+
+train_datasets:
+  pushshapes_sim:                       # big circle
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 64
+    num_workers: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 64
+    num_workers: 4

--- a/egomimic/hydra_configs/data/indomain_c4_hpt_cotrain.yaml
+++ b/egomimic/hydra_configs/data/indomain_c4_hpt_cotrain.yaml
@@ -1,0 +1,96 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# PUSHSHAPES TABLE FEED -- HPT BOTH / COTRAIN  (in-domain, chunk-4).
+#
+# HPT-correct sibling of indomain_c4_cotrain.yaml. HPT does NOT use the packed
+# ZarrEpisodePackedDataset loader + windowed get_keymap that the H-Net /
+# TransformerAR cells use. HPT's contract is "one CURRENT obs -> predict the
+# next action_horizon actions", so it must consume:
+#   - MultiDataset._from_resolver  (per-frame, not packed full-episode)
+#   - get_keymap_hpt               (SINGLE-frame obs front_img_1 +
+#                                   state_agent_obj, action_horizon-long
+#                                   action chunk, NO per-token obs horizon)
+#   - mode: total  +  skip_bounds_check: true
+# Feeding HPT the packed/windowed configs trains it out-of-distribution (see
+# pushshapes.get_keymap_hpt docstring, diagnosed 2026-05-19).
+#
+# Feeds BOTH domains from SEPARATE on-disk dirs:
+#   pushshapes_sim              -> circle_3000_plus_gen  (big + generated)
+#   pushshapes_sim_small_circle -> small_circle_3000     (small)
+# The HPT algo iterates per-embodiment so the per-emb cond encoder / stems /
+# shared flow head route correctly.
+#
+# circle_3000_plus_gen is tagged embodiment="pushshapes_sim" (includes ncc_*
+# generated episodes) -> plain LocalEpisodeResolver. small_circle_3000 is ALSO
+# tagged "pushshapes_sim" on disk, so it uses
+# LocalEpisodeResolverWithEmbodimentOverride to re-tag to
+# "pushshapes_sim_small_circle" at resolve time.
+#
+# action_horizon=4 matches the chunk-4 HPT model
+# (hpt_cotrain_pushshapes_flow_shared_head_c4_big.yaml: trunk.action_horizon=4,
+# head act_seq=4). Schema cloned from tsimulation_hpt_cot3000.yaml.
+
+train_datasets:
+  pushshapes_sim:                       # big circle + generated
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000_plus_gen
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+  pushshapes_sim_small_circle:          # small circle
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /coc/flash7/paphiwetsa3/datasets/circle_3000_plus_gen
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+  pushshapes_sim_small_circle:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 64
+    num_workers: 4
+  pushshapes_sim_small_circle:
+    batch_size: 64
+    num_workers: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 64
+    num_workers: 4
+  pushshapes_sim_small_circle:
+    batch_size: 64
+    num_workers: 4

--- a/egomimic/hydra_configs/data/indomain_c4_hpt_small.yaml
+++ b/egomimic/hydra_configs/data/indomain_c4_hpt_small.yaml
@@ -1,0 +1,66 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# PUSHSHAPES TABLE FEED -- HPT SMALL-ONLY  (in-domain, chunk-4).
+#
+# HPT-correct sibling of indomain_c4_small.yaml. HPT does NOT use the packed
+# ZarrEpisodePackedDataset loader + windowed get_keymap that the H-Net /
+# TransformerAR cells use. HPT's contract is "one CURRENT obs -> predict the
+# next action_horizon actions", so it must consume:
+#   - MultiDataset._from_resolver  (per-frame, not packed full-episode)
+#   - get_keymap_hpt               (SINGLE-frame obs front_img_1 +
+#                                   state_agent_obj, action_horizon-long
+#                                   action chunk, NO per-token obs horizon)
+#   - mode: total  +  skip_bounds_check: true
+# Feeding HPT the packed/windowed configs trains it out-of-distribution (see
+# pushshapes.get_keymap_hpt docstring, diagnosed 2026-05-19).
+#
+# Feeds ONE domain: pushshapes_sim_small_circle -> small_circle_3000 (small
+# circle). The model keeps BOTH heads; this feed only provides small-circle
+# data, so the big-circle head gets no gradient.
+#
+# IMPORTANT: small_circle_3000 episodes are tagged embodiment="pushshapes_sim"
+# on disk (same tag as the big circle). LocalEpisodeResolverWithEmbodimentOverride
+# re-tags them to "pushshapes_sim_small_circle" at resolve time (no zarr
+# rewriting) so the per-emb cond encoder + cotrain dispatch route to the
+# small-circle head.
+#
+# action_horizon=4 matches the chunk-4 HPT model
+# (hpt_cotrain_pushshapes_flow_shared_head_c4_big.yaml: trunk.action_horizon=4,
+# head act_seq=4). Schema cloned from tsimulation_hpt_cot3000.yaml.
+
+train_datasets:
+  pushshapes_sim_small_circle:          # small circle
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+valid_datasets:
+  pushshapes_sim_small_circle:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 4
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+train_dataloader_params:
+  pushshapes_sim_small_circle:
+    batch_size: 64
+    num_workers: 4
+valid_dataloader_params:
+  pushshapes_sim_small_circle:
+    batch_size: 64
+    num_workers: 4

--- a/egomimic/hydra_configs/data/indomain_c4_small.yaml
+++ b/egomimic/hydra_configs/data/indomain_c4_small.yaml
@@ -1,0 +1,65 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# PUSHSHAPES TABLE FEED -- SMALL-ONLY  (in-domain, chunk-4 families).
+#
+# Feeds ONE domain: pushshapes_sim_small_circle -> small_circle_3000 (small
+# circle, 3040 ep). Packed full-episode teacher forcing (chunking="none");
+# action chunking (chunk-4) is handled in the model head / GMMLoss, NOT here.
+#
+# For the H-Net firstend pyramid + Tx WindowedBC families. The model keeps BOTH
+# heads; this feed only provides small-circle data, so the big-circle head gets
+# no gradient.
+#
+# IMPORTANT: small_circle_3000 episodes are tagged embodiment="pushshapes_sim"
+# on disk (same tag as the big circle). LocalEpisodeResolverWithEmbodimentOverride
+# re-tags them to "pushshapes_sim_small_circle" at resolve time (no zarr
+# rewriting) so the per-emb cond encoder + cotrain dispatch route to the
+# small-circle head.
+#
+# action_horizon=2560 matches the firstend model's outer_stage.action_horizon.
+# Longest episode ~500 frames; 2560 leaves headroom.
+
+train_datasets:
+  pushshapes_sim_small_circle:          # small circle
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+
+valid_datasets:
+  pushshapes_sim_small_circle:
+    _target_: egomimic.rldb.zarr.zarr_dataset_packed.ZarrEpisodePackedDataset.from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /coc/flash7/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap
+        action_horizon: 2560
+      transform_list: null
+    chunking: "none"
+    min_seq_len: 64
+    max_seq_len: 2560
+
+train_dataloader_params:
+  pushshapes_sim_small_circle:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4
+valid_dataloader_params:
+  pushshapes_sim_small_circle:
+    batch_size: 8
+    num_workers: 8
+    pin_memory: true
+    persistent_workers: true
+    prefetch_factor: 4

--- a/egomimic/hydra_configs/data/tsimulation_hpt_cot3000.yaml
+++ b/egomimic/hydra_configs/data/tsimulation_hpt_cot3000.yaml
@@ -1,0 +1,77 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# HPT cotrain on two pushshapes embodiments: big circle (circle_3000,
+# pushshapes_sim) + small circle (small_circle_3000,
+# pushshapes_sim_small_circle). Cloned from tsimulation_hpt_nc3.yaml and
+# extended with a second embodiment, following the per-embodiment
+# dataloader_params structure of gmm_cotrain.yaml.
+#
+# Both embodiments use the HPT per-frame loader (get_keymap_hpt): SINGLE-frame
+# obs (front_img_1 + state_agent_obj) + an action_horizon-long action chunk.
+# This is required by HPT's "one current obs -> predict next action_horizon
+# actions" contract (see pushshapes.get_keymap_hpt docstring).
+
+train_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/circle_3000
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+  pushshapes_sim_small_circle:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/circle_3000
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+  pushshapes_sim_small_circle:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolverWithEmbodimentOverride
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/small_circle_3000
+      embodiment_override: "pushshapes_sim_small_circle"
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 4
+  pushshapes_sim_small_circle:
+    batch_size: 128
+    num_workers: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 4
+  pushshapes_sim_small_circle:
+    batch_size: 128
+    num_workers: 4

--- a/egomimic/hydra_configs/data/tsimulation_hpt_nc3.yaml
+++ b/egomimic/hydra_configs/data/tsimulation_hpt_nc3.yaml
@@ -1,0 +1,48 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# Per-frame loader for HPT-style training on pushshapes_sim. Each sample
+# is one frame with obs (image + state) and an action chunk of length
+# ``action_horizon`` (32 by default). Unlike ``tsimulation.yaml`` which
+# packs full episodes into a single varlen stream, this returns
+# (B, T_chunk, ...) tensors that fit HPT's chunked-action head directly.
+
+train_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/new_circle_3
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true   # accept slightly-out-of-quantile frames as-is
+                              # (per-frame loader + reused norm stats causes
+                              # ~1-2% of frames to fail bounds; resampling
+                              # each one stalls data loading).
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/new_circle_3
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true   # accept slightly-out-of-quantile frames as-is
+                              # (per-frame loader + reused norm stats causes
+                              # ~1-2% of frames to fail bounds; resampling
+                              # each one stalls data loading).
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 4

--- a/egomimic/hydra_configs/data/tsimulation_hpt_paper.yaml
+++ b/egomimic/hydra_configs/data/tsimulation_hpt_paper.yaml
@@ -1,0 +1,48 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# Per-frame loader for HPT-style training on pushshapes_sim. Each sample
+# is one frame with obs (image + state) and an action chunk of length
+# ``action_horizon`` (32 by default). Unlike ``tsimulation.yaml`` which
+# packs full episodes into a single varlen stream, this returns
+# (B, T_chunk, ...) tensors that fit HPT's chunked-action head directly.
+
+train_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pushshapes_paper
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true   # accept slightly-out-of-quantile frames as-is
+                              # (per-frame loader + reused norm stats causes
+                              # ~1-2% of frames to fail bounds; resampling
+                              # each one stalls data loading).
+
+valid_datasets:
+  pushshapes_sim:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.LocalEpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/paphiwetsa3/datasets/pushshapes_paper
+      key_map:
+        _target_: egomimic.rldb.embodiment.pushshapes.get_keymap_hpt
+        action_horizon: 32
+      transform_list: null
+    mode: total
+    skip_bounds_check: true   # accept slightly-out-of-quantile frames as-is
+                              # (per-frame loader + reused norm stats causes
+                              # ~1-2% of frames to fail bounds; resampling
+                              # each one stalls data loading).
+
+train_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 4
+valid_dataloader_params:
+  pushshapes_sim:
+    batch_size: 128
+    num_workers: 4

--- a/egomimic/hydra_configs/evaluator/gmm_eval_cotrain_nosim.yaml
+++ b/egomimic/hydra_configs/evaluator/gmm_eval_cotrain_nosim.yaml
@@ -1,0 +1,40 @@
+# Teacher-forced-only cotrain eval (NO closed-loop sim). Phase-1 evaluator for
+# the scan/spline (B/A) interface runs, whose autoregressive step() path isn't
+# built yet. Gives the dense teacher-forced overlay (GT-vs-pred) + chunking
+# health (PCA, boundary strip) — the cheap-signal eval to iterate on FIRST per
+# the debugging-methodology rule. Swap back to gmm_eval_cotrain once AR step()
+# lands so closed-loop sim coverage logs again.
+_target_: egomimic.eval.core.eval_composite.EvalList
+evals:
+  - _target_: egomimic.eval.core.eval_composite.EvalVideoList
+    pad_h: max
+    below_indices: [2]
+    limit_val_batches: 2
+    evals:
+      - _target_: egomimic.eval.core.eval_hnet.HNetEvalVideo
+        limit_val_batches: 2
+        max_videos: 2
+        viz_func:
+          pushshapes_sim:
+            _target_: hydra.utils.get_method
+            path: egomimic.rldb.embodiment.pushshapes.viz_gt_preds
+          pushshapes_sim_small_circle:
+            _target_: hydra.utils.get_method
+            path: egomimic.rldb.embodiment.pushshapes.viz_gt_preds
+      - _target_: egomimic.eval.probes.eval_pca_tokens.PCATokenEval
+        limit_val_batches: 2
+        max_videos: 2
+        panel_h: 384
+        panel_w: 384
+        n_components: 2
+      - _target_: egomimic.eval.probes.eval_boundary_strip.BoundaryStripEval
+        limit_val_batches: 2
+        max_videos: 2
+        window: 256
+        strip_width: 24
+        pixels_per_step: 1
+  # Per-emb shared-trunk health: HF (per-token variation) of trunk(up) vs residual.
+  # hf_ratio<1 => that emb bypasses the trunk; watch the two embs converge.
+  # (metric-only; EvalList aggregates its metrics, discards the empty viz.)
+  - _target_: egomimic.eval.probes.eval_trunk_hf.TrunkHFEval
+    limit_val_batches: 2

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_b1_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_b1_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_b1_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_b1_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_b3_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_b3_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_b3_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_b3_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_b4_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_b4_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_b4_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_b4_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_bc_big.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_bc_big.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_bc_big
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_bc_big
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_chunkchunk_trunk_200M
+  - override /data: indomain_c4_big
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_bc_big
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_bc_big_dino.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_bc_big_dino.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+# In-domain chunk-4 cell: hnet_bc_big with a DINOv3 image encoder (orientation-
+# perception test). Identical to hnet_bc_big.yaml EXCEPT the model points at the
+# *_200M_dino variant, whose front_img_1 encoder is DinoVisualCore (FROZEN DINOv3 ViT-S/16,
+# 224 interp, SPATIAL grid7 7x7 patch-pool, Linear(49*384->96)+LN) instead of the
+# resnet18+SpatialSoftmax VisualCore. 2026-06-24 encoder sweep (object-pose linear probe):
+# ResNet 70.4deg/130px -> DINOv3-S/16 grid7 15.3deg/59px (B/16 12.6deg, L/16 11.9deg better
+# still). S/16 chosen for THROUGHPUT: B/16 fwd_s=2.17s = ~16x the ResNet twin -> epoch too
+# slow to reach ep1499 in the 7-day alloc; S/16 (~4x fewer FLOPs, frozen=no backward) lands
+# near twin speed. B/L need frozen-feature PRECOMPUTE to be feasible (future). Spatial-grid
+# ~halves error vs mean-pool; mean-pool is worst.
+defaults:
+  - override /model: hnet_cotrain_cossim_chunkchunk_trunk_200M_dino
+  - override /data: indomain_c4_big
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_bc_big_dino
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_bc_small.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_bc_small.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_bc_small
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_bc_small
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_chunkchunk_trunk_200M
+  - override /data: indomain_c4_small
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_bc_small
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_chunkchunk_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed2_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed2_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_encdec2_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_ed2_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_bc_big.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_bc_big.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_bc_big
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_bc_big
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_encdec_trunk_200M
+  - override /data: indomain_c4_big
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_ed_bc_big
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_bc_big_dino.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_bc_big_dino.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+# In-domain chunk-4 cell: hnet_bc_big with a DINOv3 image encoder (orientation-
+# perception test). Identical to hnet_bc_big.yaml EXCEPT the model points at the
+# *_200M_dino variant, whose front_img_1 encoder is DinoVisualCore (FROZEN DINOv3 ViT-S/16,
+# 224 interp, SPATIAL grid7 7x7 patch-pool, Linear(49*384->96)+LN) instead of the
+# resnet18+SpatialSoftmax VisualCore. 2026-06-24 encoder sweep (object-pose linear probe):
+# ResNet 70.4deg/130px -> DINOv3-S/16 grid7 15.3deg/59px (B/16 12.6deg, L/16 11.9deg better
+# still). S/16 chosen for THROUGHPUT: B/16 fwd_s=2.17s = ~16x the ResNet twin -> epoch too
+# slow to reach ep1499 in the 7-day alloc; S/16 (~4x fewer FLOPs, frozen=no backward) lands
+# near twin speed. B/L need frozen-feature PRECOMPUTE to be feasible (future). Spatial-grid
+# ~halves error vs mean-pool; mean-pool is worst.
+defaults:
+  - override /model: hnet_cotrain_cossim_encdec_trunk_200M_dino
+  - override /data: indomain_c4_big
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_ed_bc_big_dino
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_bc_small.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_bc_small.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_bc_small
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_bc_small
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_encdec_trunk_200M
+  - override /data: indomain_c4_small
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_ed_bc_small
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_ed_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_encdec_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_ed_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_s3_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_s3_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_s3_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_s3_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_s4_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_s4_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_s4_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_s4_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_s5_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_s5_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_s5_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_s5_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_s6_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_s6_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_s6_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_s6_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_s8_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_s8_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_s8_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_s8_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hnet_s9_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hnet_s9_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hnet_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hnet_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hnet_cotrain_cossim_s9_trunk_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hnet_s9_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hpt_bc_big.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hpt_bc_big.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hpt_bc_big
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hpt_bc_big
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hpt_cotrain_pushshapes_flow_shared_head_c4_big
+  - override /data: indomain_c4_hpt_big
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hpt_bc_big
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hpt_bc_small.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hpt_bc_small.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hpt_bc_small
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hpt_bc_small
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hpt_cotrain_pushshapes_flow_shared_head_c4_big
+  - override /data: indomain_c4_hpt_small
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hpt_bc_small
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/hpt_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/hpt_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: hpt_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/hpt_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: hpt_cotrain_pushshapes_flow_shared_head_c4_big
+  - override /data: indomain_c4_hpt_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: hpt_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/tx_bc_big.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/tx_bc_big.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: tx_bc_big
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/tx_bc_big
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: transformer_rope_peremb_200M
+  - override /data: indomain_c4_big
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: tx_bc_big
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/tx_bc_small.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/tx_bc_small.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: tx_bc_small
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/tx_bc_small
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: transformer_rope_peremb_200M
+  - override /data: indomain_c4_small
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: tx_bc_small
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/experiment/indomain_c4/tx_cotrain.yaml
+++ b/egomimic/hydra_configs/experiment/indomain_c4/tx_cotrain.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+# In-domain chunk-4 table cell: tx_cotrain
+# Self-contained per-run config. Launch with:
+#   python -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/tx_cotrain
+# Overrides the train_zarr_cartesian defaults: pins model + data feed +
+# family-correct evaluator + csv_wandb logger (wandb project
+# pushshapes-indomain-c4), 2000 epochs. All three model families keep BOTH
+# domains/heads (~63.9M); the BC cells feed ONE domain so the unfed head gets
+# no gradient.
+
+defaults:
+  - override /model: transformer_rope_peremb_200M
+  - override /data: indomain_c4_cotrain
+  - override /evaluator: gmm_eval_firstend
+  - override /logger: csv_wandb
+
+name: indomain_c4
+description: tx_cotrain
+
+trainer:
+  max_epochs: 3000
+  min_epochs: 3000
+
+logger:
+  wandb:
+    project: pushshapes-indomain-c4
+
+norm_stats:
+  norm_mode: minmax

--- a/egomimic/hydra_configs/model/bc_rnn_pushshapes_paperexact_tx_cotrain_c4_200M.yaml
+++ b/egomimic/hydra_configs/model/bc_rnn_pushshapes_paperexact_tx_cotrain_c4_200M.yaml
@@ -1,0 +1,115 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# BC-RNN-TRANSFORMER COTRAIN (2-embodiment) -- CHUNK-4 capacity-matched build.
+#
+# DERIVED FROM bc_rnn_pushshapes_paperexact_tx_chunk8.yaml (the single-domain
+# TransformerCore + GMM head recipe) with exactly FOUR deltas:
+#   1. domains -> [pushshapes_sim, pushshapes_sim_small_circle] (2-embodiment
+#      cotrain: big circle + small circle). WindowedBC.forward_training already
+#      loops over batch.items() (one entry per embodiment id) and accumulates a
+#      per-embodiment GMM NLL with the SHARED policy, so a 2-domain batch trains
+#      both domains in one step. NOTE: WindowedBC has a SINGLE shared policy
+#      (ONE obs_encoder + ONE core + ONE gmm_head) -- there are NO per-embodiment
+#      encoders/heads (unlike the H-Net firstend pyramid). Both embodiments share
+#      ALL weights; the only per-embodiment thing is the action/obs norm-stats
+#      (norm_stats.normalize/unnormalize keyed by emb_id). Pair with data config
+#      tsimulation_cotrain_small_circle.yaml.
+#   2. chunk_len 8 -> 4 (predict 4, execute 4, re-predict; n_action_steps=4).
+#      gmm_head.chunk_len matched to 4 (the algo guards they agree).
+#   3. obs_stride 8 -> 4 (kept == chunk_len so the rollout queue never drains
+#      between obs steps, matching the chunk8 invariant chunk_len==obs_stride).
+#   4. core_net.d_model 448 -> 936 (head_dim 936/8 = 117, integer / clean) so the
+#      SHARED-weight total lands at ~63.92M (the cross-family cotrain target).
+#      n_layers/n_heads/ff_mult UNCHANGED (5 / 8 / 4) -> only the trunk WIDTH
+#      grows; encoder + head STRUCTURE are untouched. gmm_head.d_model tracks
+#      core_net.d_model (= core.hidden_dim, no actor MLP).
+#
+# Because the policy is fully shared, the 2-embodiment COTRAIN total EQUALS the
+# single instantiated policy param count (one set of weights serves both
+# domains): obs_encoder(11.20M) + core(52.75M @ d_model=936) + gmm_head(0.045M)
+# = 63.99M (+0.11% vs 63.92M). Verified by hydra.instantiate of the three
+# param-bearing submodules (see model card / structured report).
+#
+# Everything else is IDENTICAL to the chunk8 single-domain recipe: paper-exact
+# obs encoder, minmax norm (launcher), repeat_unmasked windows, rnn_horizon=10,
+# random eval crop, warmup->cosine peak 1e-4, fp32, no grad clip.
+robomimic_model:
+  _target_: egomimic.algo.bc.WindowedBC
+
+  action_dim: 2
+  action_horizon: 1024
+  rnn_horizon: 128
+  window_anchor: start
+  max_windows_per_batch: 8
+  actor_mlp_dims: []
+  pad_mode: repeat_unmasked
+  core: transformer
+  # OBS STRIDING + ACTION CHUNKING -> chunk-4 (was 8/8).
+  obs_stride: 4
+  chunk_len: 4
+
+  obs_encoder:
+    _target_: egomimic.models.stems.obs_encoder.ObsEncoder
+    embed_dim: 66
+    paper_exact: true
+    obs_specs:
+      state_agent_obj:
+        input_dim: 2
+        input_slice: [0, 2]
+        embed_dim: 64
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.stems.visual_core.VisualCore
+        in_channels: 3
+        image_size: 96
+        num_kp: 32
+        feature_dimension: 64
+        pretrained: false
+        crop_aug: true
+        crop_height: 86
+        crop_width: 86
+        crop_eval_mode: random
+        crop_sample_mode: v02
+
+  # CORE: TransformerCore, width grown to hit the 63.92M cotrain target.
+  core_net:
+    _target_: egomimic.models.cores.transformer_core.TransformerCore
+    input_dim: 66             # = obs_encoder concat (64 img + 2 raw)
+    d_model: 1408             # 1408 / 8 = 176 (clean integer head_dim) -- 200M build
+    n_layers: 8               # 5 -> 8 (deeper) + width 936 -> 1408 to reach ~200M
+    n_heads: 8                # 1408 / 8 = 176 dim/head
+    ff_mult: 4                # FF hidden = 4*1408 = 5632
+    dropout: 0.0
+    max_window: ${..rnn_horizon}
+
+  gmm_head:
+    _target_: egomimic.models.heads.gmm_head.GMMActionHead
+    d_model: 1408             # = core.hidden_dim (must match core_net.d_model)
+    action_dim: 2
+    num_modes: 32             # 16 -> 32 modes for the 200M build
+    min_std: 1.0e-4
+    std_activation: softplus
+    low_noise_eval: true
+    chunk_len: 4              # MUST match robomimic_model.chunk_len above
+
+  # 2-EMBODIMENT COTRAIN: big circle + small circle (shared policy weights).
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/bc_rnn_pushshapes_paperexact_tx_cotrain_c4_big.yaml
+++ b/egomimic/hydra_configs/model/bc_rnn_pushshapes_paperexact_tx_cotrain_c4_big.yaml
@@ -1,0 +1,115 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# BC-RNN-TRANSFORMER COTRAIN (2-embodiment) -- CHUNK-4 capacity-matched build.
+#
+# DERIVED FROM bc_rnn_pushshapes_paperexact_tx_chunk8.yaml (the single-domain
+# TransformerCore + GMM head recipe) with exactly FOUR deltas:
+#   1. domains -> [pushshapes_sim, pushshapes_sim_small_circle] (2-embodiment
+#      cotrain: big circle + small circle). WindowedBC.forward_training already
+#      loops over batch.items() (one entry per embodiment id) and accumulates a
+#      per-embodiment GMM NLL with the SHARED policy, so a 2-domain batch trains
+#      both domains in one step. NOTE: WindowedBC has a SINGLE shared policy
+#      (ONE obs_encoder + ONE core + ONE gmm_head) -- there are NO per-embodiment
+#      encoders/heads (unlike the H-Net firstend pyramid). Both embodiments share
+#      ALL weights; the only per-embodiment thing is the action/obs norm-stats
+#      (norm_stats.normalize/unnormalize keyed by emb_id). Pair with data config
+#      tsimulation_cotrain_small_circle.yaml.
+#   2. chunk_len 8 -> 4 (predict 4, execute 4, re-predict; n_action_steps=4).
+#      gmm_head.chunk_len matched to 4 (the algo guards they agree).
+#   3. obs_stride 8 -> 4 (kept == chunk_len so the rollout queue never drains
+#      between obs steps, matching the chunk8 invariant chunk_len==obs_stride).
+#   4. core_net.d_model 448 -> 936 (head_dim 936/8 = 117, integer / clean) so the
+#      SHARED-weight total lands at ~63.92M (the cross-family cotrain target).
+#      n_layers/n_heads/ff_mult UNCHANGED (5 / 8 / 4) -> only the trunk WIDTH
+#      grows; encoder + head STRUCTURE are untouched. gmm_head.d_model tracks
+#      core_net.d_model (= core.hidden_dim, no actor MLP).
+#
+# Because the policy is fully shared, the 2-embodiment COTRAIN total EQUALS the
+# single instantiated policy param count (one set of weights serves both
+# domains): obs_encoder(11.20M) + core(52.75M @ d_model=936) + gmm_head(0.045M)
+# = 63.99M (+0.11% vs 63.92M). Verified by hydra.instantiate of the three
+# param-bearing submodules (see model card / structured report).
+#
+# Everything else is IDENTICAL to the chunk8 single-domain recipe: paper-exact
+# obs encoder, minmax norm (launcher), repeat_unmasked windows, rnn_horizon=10,
+# random eval crop, warmup->cosine peak 1e-4, fp32, no grad clip.
+robomimic_model:
+  _target_: egomimic.algo.bc.WindowedBC
+
+  action_dim: 2
+  action_horizon: 1024
+  rnn_horizon: 128
+  window_anchor: start
+  max_windows_per_batch: 8
+  actor_mlp_dims: []
+  pad_mode: repeat_unmasked
+  core: transformer
+  # OBS STRIDING + ACTION CHUNKING -> chunk-4 (was 8/8).
+  obs_stride: 4
+  chunk_len: 4
+
+  obs_encoder:
+    _target_: egomimic.models.stems.obs_encoder.ObsEncoder
+    embed_dim: 66
+    paper_exact: true
+    obs_specs:
+      state_agent_obj:
+        input_dim: 2
+        input_slice: [0, 2]
+        embed_dim: 64
+    img_encoders:
+      front_img_1:
+        _target_: egomimic.models.stems.visual_core.VisualCore
+        in_channels: 3
+        image_size: 96
+        num_kp: 32
+        feature_dimension: 64
+        pretrained: false
+        crop_aug: true
+        crop_height: 86
+        crop_width: 86
+        crop_eval_mode: random
+        crop_sample_mode: v02
+
+  # CORE: TransformerCore, width grown to hit the 63.92M cotrain target.
+  core_net:
+    _target_: egomimic.models.cores.transformer_core.TransformerCore
+    input_dim: 66             # = obs_encoder concat (64 img + 2 raw)
+    d_model: 936              # 936 / 8 = 117 (clean integer head_dim)
+    n_layers: 5               # UNCHANGED -- grow WIDTH only
+    n_heads: 8                # 936 / 8 = 117 dim/head
+    ff_mult: 4                # FF hidden = 4*936 = 3744
+    dropout: 0.0
+    max_window: ${..rnn_horizon}
+
+  gmm_head:
+    _target_: egomimic.models.heads.gmm_head.GMMActionHead
+    d_model: 936              # = core.hidden_dim (no actor MLP)
+    action_dim: 2
+    num_modes: 16
+    min_std: 1.0e-4
+    std_activation: softplus
+    low_noise_eval: true
+    chunk_len: 4              # MUST match robomimic_model.chunk_len above
+
+  # 2-EMBODIMENT COTRAIN: big circle + small circle (shared policy weights).
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_b1_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_b1_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T1
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T1
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T12
+          d_model: 1024
+          d_intermediate: 3168
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_b3_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_b3_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T4
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T4
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T4
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T4
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T5
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T5
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T5
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T5
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 1024
+          d_intermediate: 3488
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_b4_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_b4_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T6
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T6
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T6
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T6
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T8
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T8
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T8
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T8
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T7
+          d_model: 1024
+          d_intermediate: 3776
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_chunkchunk_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_chunkchunk_trunk_200M.yaml
@@ -1,0 +1,200 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T12
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_chunkchunk_trunk_200M_dino.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_chunkchunk_trunk_200M_dino.yaml
@@ -1,0 +1,194 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.dino_core.DinoVisualCore
+                in_channels: 3
+                image_size: 224
+                feature_dimension: 96
+                hub_repo: facebookresearch/dinov3
+                model_name: dinov3_vits16
+                freeze: true
+                feature: grid7
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.dino_core.DinoVisualCore
+                in_channels: 3
+                image_size: 224
+                feature_dimension: 96
+                hub_repo: facebookresearch/dinov3
+                model_name: dinov3_vits16
+                freeze: true
+                feature: grid7
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T11
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_encdec2_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_encdec2_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T11
+          d_model: 1024
+          d_intermediate: 3104
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_encdec_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_encdec_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T12
+          d_model: 1024
+          d_intermediate: 2944
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_encdec_trunk_200M_dino.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_encdec_trunk_200M_dino.yaml
@@ -1,0 +1,298 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.dino_core.DinoVisualCore
+                in_channels: 3
+                image_size: 224
+                feature_dimension: 96
+                hub_repo: facebookresearch/dinov3
+                model_name: dinov3_vits16
+                freeze: true
+                feature: grid7
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.dino_core.DinoVisualCore
+                in_channels: 3
+                image_size: 224
+                feature_dimension: 96
+                hub_repo: facebookresearch/dinov3
+                model_name: dinov3_vits16
+                freeze: true
+                feature: grid7
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T1
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T11
+          d_model: 1024
+          d_intermediate: 2944
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_s3_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_s3_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 768
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 768
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 768
+        output_hidden_dim: 768
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T20
+          d_model: 768
+          d_intermediate: 2240
+          num_heads: 12
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_s4_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_s4_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 640
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 640
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 640
+        output_hidden_dim: 640
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T28
+          d_model: 640
+          d_intermediate: 1952
+          num_heads: 10
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_s5_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_s5_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T4
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T4
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T4
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T4
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 768
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 768
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 768
+        output_hidden_dim: 768
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T18
+          d_model: 768
+          d_intermediate: 2400
+          num_heads: 12
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_s6_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_s6_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T14
+          d_model: 1024
+          d_intermediate: 2144
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_s8_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_s8_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T11
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_cossim_s9_trunk_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_cossim_s9_trunk_200M.yaml
@@ -1,0 +1,304 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 256
+            output_hidden_dim: 256
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T2
+              d_model: 256
+              d_intermediate: 768
+              num_heads: 4
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.EncoderDecoderStage
+            input_hidden_dim: 512
+            output_hidden_dim: 512
+            cond_key: null
+            d_cond: 0
+            causal: true
+            encoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+            decoder:
+              arch_layout: T3
+              d_model: 512
+              d_intermediate: 1536
+              num_heads: 8
+              cond: false
+              rotary_emb_dim: 64
+              dropout: 0.0
+              resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1536
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1536
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 1.0
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 2
+            prev_end_combine_n_layers: 3
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1536
+        output_hidden_dim: 1536
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T5
+          d_model: 1536
+          d_intermediate: 4384
+          num_heads: 24
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage.yaml
@@ -1,0 +1,129 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# std-384 AB'C (scan down + spline up + SCAN ROUTER) at 1 CHUNKER STAGE:
+#   L0 = per-embodiment ChunkerStage ONLY (no shared stage) -> 8x compression.
+# Full redesign (router_interface=scan). Tests AB'C at the shallowest feasible depth.
+# Derived from hnet_cotrain_gmm_obs_big_c4r8_BA (shared ChunkerStage removed).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 384
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 384
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 384
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 384
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 384
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 384
+          output_key: "fused_cond"
+          cond_proj_widths: [384, 384]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 384
+            d_intermediate: 1152
+            num_heads: 12
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage_512.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage_512.yaml
@@ -1,0 +1,141 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# UNIFORM 512 AB'C (scan down + spline up + SCAN ROUTER) at 1 CHUNKER STAGE.
+#   L0 = per-embodiment ChunkerStage ONLY -> 8x compression; dim 512 throughout.
+# No shared chunker (user) => 1-stage => fine dim == trunk dim (uniform), set to 512.
+# Bigger sibling of hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage (was std-384).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 512
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 512
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 512
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 512
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 512
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 512
+          output_key: "fused_cond"
+          cond_proj_widths: [512, 512]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 512
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+              # Scan-interface stability/flexibility knobs (gated, DEFAULT OFF
+              # == current behaviour, byte-identical / live-requeue safe).
+              encoder_layernorm: false   # ChunkScanEncoder post-GRU LayerNorm
+              router_use_block: false    # ScanRouter: wrap scan in MambaBlock(s)
+              router_n_layer: 1          # MambaBlock-stack depth (use_block only)
+              router_has_mlp: false      # add SwiGLU MLP inside the MambaBlock(s)
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 512
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+              # Scan-interface stability/flexibility knobs (gated, DEFAULT OFF
+              # == current behaviour, byte-identical / live-requeue safe).
+              encoder_layernorm: false   # ChunkScanEncoder post-GRU LayerNorm
+              router_use_block: false    # ScanRouter: wrap scan in MambaBlock(s)
+              router_n_layer: 1          # MambaBlock-stack depth (use_block only)
+              router_has_mlp: false      # add SwiGLU MLP inside the MambaBlock(s)
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage_taper256.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage_taper256.yaml
@@ -1,0 +1,129 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 256->512 AB'C (scan down + spline up + SCAN ROUTER) at 1 CHUNKER STAGE.
+#   L0 = per-embodiment ChunkerStage ONLY -> 8x compression; fine dim 256 -> trunk 512.
+# Tapered variant of hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage (was std-384).
+# Small per-emb stage (256) + big shared trunk (512) = cross-emb capacity argument.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_2stage.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_ABC_2stage.yaml
@@ -1,0 +1,139 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# std-384 AB'C (scan down + spline up + SCAN ROUTER) at 2 CHUNKER STAGES:
+#   L0 = per-embodiment ChunkerStage, L1 = shared ChunkerStage -> 8x8 = 64x (feasible).
+# Full redesign (router_interface=scan on every chunker). Tests AB'C at a feasible
+# depth (vs the broken 3-level/512x taper). Derived from hnet_cotrain_gmm_obs_big_c4r8_BA.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 384
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 384
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 384
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 384
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 384
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 384
+          output_key: "fused_cond"
+          cond_proj_widths: [384, 384]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          router_interface: scan
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 384
+            d_intermediate: 1152
+            num_heads: 12
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_BA.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_BA.yaml
@@ -1,0 +1,139 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# std-384 c4r8 + the BA interface swap (scan downsampler + spline upsampler) on
+# every ChunkerStage. Identical to hnet_cotrain_gmm_obs_big_c4r8 EXCEPT
+# down_interface=scan / up_interface=spline / m_sublatents=4 on the 3 chunkers
+# and enable_grad_norm=true. This is the CLEAN test bed for the BA modules
+# (2 chunker levels @ ratio8 = 64x, the working compression) — vs the broken
+# taper128 BA (3 levels @ ratio8 = 512x over-compression). scan_interface.py
+# now LayerNorm-stabilizes the GRU/spline outputs (was exploding the fwd pass).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 384
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 384
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 384
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 384
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 384
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 384
+          output_key: "fused_cond"
+          cond_proj_widths: [384, 384]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 384
+            d_intermediate: 1152
+            num_heads: 12
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_register.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_c4r8_register.yaml
@@ -1,0 +1,126 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# std-384 c4r8 + the REGISTER masked-transformer fused interface on
+# every ChunkerStage. Identical to hnet_cotrain_gmm_obs_big_c4r8 EXCEPT
+# down_interface=scan / up_interface=spline / m_sublatents=4 on the 3 chunkers
+# and enable_grad_norm=true. This is the CLEAN test bed for the BA modules
+# (2 chunker levels @ ratio8 = 64x, the working compression) — vs the broken
+# taper128 BA (3 levels @ ratio8 = 512x over-compression). scan_interface.py
+# now LayerNorm-stabilizes the GRU/spline outputs (was exploding the fwd pass).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 384
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 384
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 384
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 384
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 384
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 384
+          output_key: "fused_cond"
+          cond_proj_widths: [384, 384]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              chunk_interface: register
+              reg_m: 4
+              reg_trunk_depth: 4
+              reg_trunk_n_heads: 12
+              reg_trunk_ff_mult: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 384
+              output_hidden_dim: 384
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              chunk_interface: register
+              reg_m: 4
+              reg_trunk_depth: 4
+              reg_trunk_n_heads: 12
+              reg_trunk_ff_mult: 4
+        # The PerEmbodimentStage above is TERMINAL: each per-embodiment register
+        # ChunkerStage's RegisterTrunk (register<-register attention) IS the
+        # chunk-rate inner trunk, so the fused design needs no separate inner
+        # ComputeStage / second chunker. reg_trunk_depth carries the compute.
+        # (The BA base nested PerEmb -> ChunkerStage -> ComputeStage; for the
+        # register smoke we collapse to a single terminal register level so no
+        # stage is orphaned by the unused inner_stage ctx-swap.)
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128.yaml
@@ -1,0 +1,141 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (base c4r4).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 4.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 4.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 4.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 4.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_512_1024_c4r8.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_512_1024_c4r8.yaml
@@ -1,0 +1,143 @@
+# VARIANT taper128_512_1024: SHARED-chunker taper (same structure as taper128_c4r8) but dims 128->512->1024.
+# per-emb 128->128, shared 128->512, shared 512->1024, trunk ComputeStage @1024 (d_intermediate 3072, 32 heads).
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 512
+          output_hidden_dim: 1024
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 1024
+          output_hidden_dim: 1024
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 1024
+            d_intermediate: 3072
+            num_heads: 32
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8.yaml
@@ -1,0 +1,141 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_Aonly.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_Aonly.yaml
@@ -1,0 +1,154 @@
+# A only: scan downsampler + upstream duplicate-broadcast upsampler.
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: duplicate
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: duplicate
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: duplicate
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: duplicate
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_BA.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_BA.yaml
@@ -1,0 +1,154 @@
+# B+A: scan downsampler + spline upsampler (full interface swap).
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_Bonly.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_Bonly.yaml
@@ -1,0 +1,155 @@
+# B only: upstream first-token down (to inner) + spline upsampler
+#         (scan encoder runs to condition the upsampler only).
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: first_token
+              up_interface: spline
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: first_token
+              up_interface: spline
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: first_token
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: first_token
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_C.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_C.yaml
@@ -1,0 +1,159 @@
+# C (full new stack): scan/Mamba router + scan-down (A) + spline-up (B').
+#    BA vs C isolates the router (cossim vs scan); baseline vs BA the interface.
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: scan
+              up_interface: spline
+              router_interface: scan
+              m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          router_interface: scan
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          router_interface: scan
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_sep1.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_sep1.yaml
@@ -1,0 +1,147 @@
+# VARIANT sep1 (FIXED): NO shared chunker. per-emb 128->128 (mandatory outermost) + per-emb 128->512,
+# then 512 trunk. Fully separate chunking; 1 dim-up level. (from taper128_c4r8)
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_sep2.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c4r8_sep2.yaml
@@ -1,0 +1,163 @@
+# VARIANT sep2 (FIXED): NO shared chunker. per-emb 128->128 (outermost) + per-emb 128->256 + per-emb 256->512,
+# then 512 trunk. Fully separate chunking; 2 dim-up levels. (from taper128_c4r8)
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c4r8).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c8r4.yaml
+++ b/egomimic/hydra_configs/model/hnet_cotrain_gmm_obs_big_taper128_c8r4.yaml
@@ -1,0 +1,141 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# TAPER 128->256->512 variant (2026-06-16, from hnet_cotrain_gmm_obs_big_taper_c8r2).
+# Three-level hourglass: fine 128 -> mid 256 -> trunk 512. The H-Net OuterStage
+# forces the OUTERMOST stage back to d_model (=128), so the two dim-steps live in
+# the inner ChunkerStages (128->256, then 256->512). This ADDS one chunker level
+# vs the 256->512 taper => 3 chunker levels @ ratio 2.0 = ~8x total compression
+# (was ~4x). Action head decodes from the FINE level (now d_model=128) -- watch
+# for under-capacity (head MLP widens 128->1024). chunk_len=8, ratio=2.0 (c8r4).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 8
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    # 3-level tapered chunking (cond_key=null -> no AdaLN):
+    #   [0] PerEmbodimentStage(ChunkerStage)  fine 128 -> 128, PER-EMB (==d_model)
+    #   [1] ChunkerStage                       128 -> 256, SHARED
+    #   [2] ChunkerStage                       256 -> 512, SHARED  (NEW level)
+    #   [3] ComputeStage                       trunk 512, SHARED (terminal)
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 4.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 128
+              target_compression_ratio: 4.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 4.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 4.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_firstend_bc_BIG_cossim_2stage_128_256_512_pyramid.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_bc_BIG_cossim_2stage_128_256_512_pyramid.yaml
@@ -1,0 +1,159 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim
+  ac_keys:
+    pushshapes_sim: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 128
+        output_hidden_dim: 128
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 128
+          d_intermediate: 384
+          num_heads: 2
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_bc_SMALL_cossim_2stage_128_256_512_pyramid.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_bc_SMALL_cossim_2stage_128_256_512_pyramid.yaml
@@ -1,0 +1,159 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 128
+        output_hidden_dim: 128
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 128
+          d_intermediate: 384
+          num_heads: 2
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb.yaml
@@ -1,0 +1,196 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb_c8.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb_c8.yaml
@@ -1,0 +1,196 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 8
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 8
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb_pad100.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb_pad100.yaml
@@ -1,0 +1,199 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+  episode_level_transforms:
+  - _target_: egomimic.algo.hnet.episode_transforms.PadHoldStill
+    n_pad: 100
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb_pyramid.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_128_256_512_peremb_pyramid.yaml
@@ -1,0 +1,226 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 128
+        output_hidden_dim: 128
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 128
+          d_intermediate: 384
+          num_heads: 2
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 16
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 16
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_64_128_256_peremb.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_64_128_256_peremb.yaml
@@ -1,0 +1,196 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 64
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 32
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_64_128_256_peremb_c8.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_64_128_256_peremb_c8.yaml
@@ -1,0 +1,196 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 64
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 32
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 8
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 8
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200M.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200M.yaml
@@ -1,0 +1,230 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200M.yaml.bak_4layer
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200M.yaml.bak_4layer
@@ -1,0 +1,226 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200M_dino.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200M_dino.yaml
@@ -1,0 +1,224 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.dino_core.DinoVisualCore
+                in_channels: 3
+                image_size: 224
+                feature_dimension: 96
+                hub_repo: facebookresearch/dinov3
+                model_name: dinov3_vits16
+                freeze: true
+                feature: grid7
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.dino_core.DinoVisualCore
+                in_channels: 3
+                image_size: 224
+                feature_dimension: 96
+                hub_repo: facebookresearch/dinov3
+                model_name: dinov3_vits16
+                freeze: true
+                feature: grid7
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+            prev_end_combine_n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T9
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200Mtotal.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_2stage_peremb_pyramid_200Mtotal.yaml
@@ -1,0 +1,226 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 256
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 256
+            output_key: fused_cond
+            cond_proj_widths:
+            - 256
+            - 256
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T7
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 4
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T7
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 512
+            output_hidden_dim: 1024
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1024
+        output_hidden_dim: 1024
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T7
+          d_model: 1024
+          d_intermediate: 3072
+          num_heads: 16
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 256
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_3stage_64_128_256_512_peremb.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_cossim_3stage_64_128_256_512_peremb.yaml
@@ -1,0 +1,226 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 64
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: cossim
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_sigmoid_2stage_128_256_512_peremb.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_sigmoid_2stage_128_256_512_peremb.yaml
@@ -1,0 +1,204 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 128
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 128
+            output_key: fused_cond
+            cond_proj_widths:
+            - 128
+            - 128
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 128
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_sigmoid_2stage_64_128_256_peremb.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_sigmoid_2stage_64_128_256_peremb.yaml
@@ -1,0 +1,204 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 64
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 256
+        output_hidden_dim: 256
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 256
+          d_intermediate: 768
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 32
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_cotrain_sigmoid_3stage_64_128_256_512_peremb.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_cotrain_sigmoid_3stage_64_128_256_512_peremb.yaml
@@ -1,0 +1,238 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 64
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 64
+            output_key: fused_cond
+            cond_proj_widths:
+            - 64
+            - 64
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 64
+            output_hidden_dim: 128
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 128
+            output_hidden_dim: 256
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+        sub_stages:
+          pushshapes_sim:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.hnet.stages.ChunkerStage
+            input_hidden_dim: 256
+            output_hidden_dim: 512
+            target_compression_ratio: 3.0
+            ratio_loss_weight: 0.03
+            cond_key: null
+            down_interface: first_token
+            up_interface: duplicate
+            router_interface: transformer
+            pser_variant: prefix_global
+            pser_T_temp: 2.0
+            grab_prev_end: true
+            residual_mixer: mlp
+            residual_mixer_kwargs:
+              n_layers: 4
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 512
+        output_hidden_dim: 512
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T6
+          d_model: 512
+          d_intermediate: 1536
+          num_heads: 8
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 64
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/hnet_firstend_dup_cossim.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_dup_cossim.yaml
@@ -1,0 +1,123 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-CIRCLE (single embodiment = circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_circle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# Config #4 (bf16) reuses THIS exact model config; only the launcher precision
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: first_token
+          up_interface: duplicate
+          router_interface: cossim
+          grab_prev_end: true   # first + prev-chunk-end chunker
+          residual_mixer: mlp   # expressive per-token transform
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_firstend_dup_sigmoid.yaml
+++ b/egomimic/hydra_configs/model/hnet_firstend_dup_sigmoid.yaml
@@ -1,0 +1,125 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-CIRCLE (single embodiment = circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_circle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# Config #4 (bf16) reuses THIS exact model config; only the launcher precision
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: first_token
+          up_interface: duplicate
+          router_interface: transformer
+          grab_prev_end: true   # first + prev-chunk-end chunker
+          residual_mixer: mlp   # expressive per-token transform
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_gmm_obs_circle_big_c4r8_BA.yaml
+++ b/egomimic/hydra_configs/model/hnet_gmm_obs_circle_big_c4r8_BA.yaml
@@ -1,0 +1,113 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# Single-domain CIRCLE BC, matched to the cotrain c4r8 recipe (chunk_len 4,
+# ratio 8) + the BA interface (scan/spline). Residual stays on (alpha=1, no
+# scheduler) -> isolates "does the BA arch learn single-domain to comparable BC
+# coverage" (correctness gate) from the alpha->0 bottleneck. Based on
+# hnet_gmm_obs_circle_big.yaml. enable_grad_norm on for health monitoring.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 384
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 384
+    action_head_type: gmm
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 384
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 384
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 384
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 384
+          output_key: "fused_cond"
+          cond_proj_widths: [384, 384]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: scan
+          up_interface: spline
+          m_sublatents: 4
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 384
+          output_hidden_dim: 384
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 384
+            d_intermediate: 1152
+            num_heads: 12
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle.yaml
@@ -1,0 +1,129 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-CIRCLE (single embodiment = circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_circle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# Config #4 (bf16) reuses THIS exact model config; only the launcher precision
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: register
+          up_interface: msublatent
+          router_interface: transformer
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+          reg_m: 4
+          reg_trunk_depth: 2
+          reg_trunk_n_heads: 8
+          reg_trunk_ff_mult: 4
+          component_end_norm: true
+          reg_trunk_residual_init: true   # FIX #7: ON for the new arch
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle.yaml.bak_t256
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle.yaml.bak_t256
@@ -1,0 +1,129 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-CIRCLE (single embodiment = circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_circle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# Config #4 (bf16) reuses THIS exact model config; only the launcher precision
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: register
+          up_interface: msublatent
+          router_interface: transformer
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+          reg_m: 4
+          reg_trunk_depth: 2
+          reg_trunk_n_heads: 8
+          reg_trunk_ff_mult: 4
+          component_end_norm: true
+          reg_trunk_residual_init: true   # FIX #7: ON for the new arch
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle_fixed.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle_fixed.yaml
@@ -1,0 +1,131 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-CIRCLE (single embodiment = circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_circle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# Config #4 (bf16) reuses THIS exact model config; only the launcher precision
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: register
+          up_interface: msublatent
+          router_interface: transformer
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+          reg_m: 4
+          trunk_chunk_rate: true   # FIX 1 (capacity grab)
+          residual_mixer: mlp      # FIX 2 (residual bypass)
+          reg_trunk_depth: 2
+          reg_trunk_n_heads: 8
+          reg_trunk_ff_mult: 4
+          component_end_norm: true
+          reg_trunk_residual_init: true   # FIX #7: ON for the new arch
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle_fixed_cossim.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_bc_circle_fixed_cossim.yaml
@@ -1,0 +1,131 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-CIRCLE (single embodiment = circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_circle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# Config #4 (bf16) reuses THIS exact model config; only the launcher precision
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim"]
+  ac_keys:
+    pushshapes_sim: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: register
+          up_interface: msublatent
+          router_interface: cossim
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+          reg_m: 4
+          trunk_chunk_rate: true   # FIX 1 (capacity grab)
+          residual_mixer: mlp      # FIX 2 (residual bypass)
+          reg_trunk_depth: 2
+          reg_trunk_n_heads: 8
+          reg_trunk_ff_mult: 4
+          component_end_norm: true
+          reg_trunk_residual_init: true   # FIX #7: ON for the new arch
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_bc_smallcircle.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_bc_smallcircle.yaml
@@ -1,0 +1,129 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-SMALL_CIRCLE (single embodiment = small_circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim_small_circle"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_smallcircle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# (No bf16 sibling for this embodiment.)
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 128
+          output_hidden_dim: 256
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: register
+          up_interface: msublatent
+          router_interface: transformer
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+          reg_m: 4
+          reg_trunk_depth: 2
+          reg_trunk_n_heads: 8
+          reg_trunk_ff_mult: 4
+          component_end_norm: true
+          reg_trunk_residual_init: true   # FIX #7: ON for the new arch
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_bc_smallcircle.yaml.bak_t256
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_bc_smallcircle.yaml.bak_t256
@@ -1,0 +1,129 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL BC-SMALL_CIRCLE (single embodiment = small_circle_3000 only).
+# Same fixed arch as hnet_regdown_msub_cotrain.yaml (DOWN-only register encoder
+# + bespoke m-sublatents dechunker, taper 256->512, transformer router
+# prefix_global @ pser_T_temp=2.0, reg_m=4, reg_trunk_depth=2,
+# reg_trunk_residual_init=true, component_end_norm=true, ComputeStage T6 @512,
+# GMM head), but a SINGLE embodiment so the per-embodiment wrapper is dropped:
+# ``domains: ["pushshapes_sim_small_circle"]`` + a PLAIN ChunkerStage directly in
+# ``hnet.stages`` (mirrors hnet_gmm_obs_circle.yaml's "plain ChunkerStage, no
+# PerEmbodimentStage" pattern). Launcher: regdown_msub_bc_smallcircle.sh
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500, per-leaf grad-norms).
+# (No bf16 sibling for this embodiment.)
+# differs (bf16-mixed so flash-attn engages).
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.stages.ChunkerStage
+          input_hidden_dim: 256
+          output_hidden_dim: 512
+          target_compression_ratio: 8.0
+          ratio_loss_weight: 0.03
+          cond_key: null
+          down_interface: register
+          up_interface: msublatent
+          router_interface: transformer
+          pser_variant: prefix_global
+          pser_T_temp: 2.0
+          reg_m: 4
+          reg_trunk_depth: 2
+          reg_trunk_n_heads: 8
+          reg_trunk_ff_mult: 4
+          component_end_norm: true
+          reg_trunk_residual_init: true   # FIX #7: ON for the new arch
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain.yaml
@@ -1,0 +1,164 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain.yaml.bak_t256
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain.yaml.bak_t256
@@ -1,0 +1,164 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_64.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_64.yaml
@@ -1,0 +1,164 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 64
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 64
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 64
+          output_key: "fused_cond"
+          cond_proj_widths: [64, 64]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 64
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 64
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_cossim.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_cossim.yaml
@@ -1,0 +1,164 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: cossim
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: cossim
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_fixed.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_fixed.yaml
@@ -1,0 +1,168 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+              trunk_chunk_rate: true   # FIX 1 (capacity grab): trunk runs at chunk-rate (concat m sub-latents)
+              residual_mixer: mlp      # FIX 2 (residual bypass): non-linear mixer; swap to attn/additive here
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+              trunk_chunk_rate: true   # FIX 1 (capacity grab): trunk runs at chunk-rate (concat m sub-latents)
+              residual_mixer: mlp      # FIX 2 (residual bypass): non-linear mixer; swap to attn/additive here
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_fixed_128.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_fixed_128.yaml
@@ -1,0 +1,168 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 128
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 5120
+    d_model: 128
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 128
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 128
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 128
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 128
+          output_key: "fused_cond"
+          cond_proj_widths: [128, 128]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+              trunk_chunk_rate: true   # FIX 1 (capacity grab): trunk runs at chunk-rate (concat m sub-latents)
+              residual_mixer: mlp      # FIX 2 (residual bypass): non-linear mixer; swap to attn/additive here
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 128
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+              trunk_chunk_rate: true   # FIX 1 (capacity grab): trunk runs at chunk-rate (concat m sub-latents)
+              residual_mixer: mlp      # FIX 2 (residual bypass): non-linear mixer; swap to attn/additive here
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_fixed_64.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_cotrain_fixed_64.yaml
@@ -1,0 +1,168 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# FINAL COTRAIN: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+# Arch is BYTE-IDENTICAL to hnet_regdown_msub_smoke.yaml (the validated fixed
+# arch); this is the production-named copy for the 4-run final campaign. The
+# launcher (regdown_msub_cotrain.sh) supplies the real training schedule
+# (max_epochs=2000, warmup-cosine to 200k, reg-off@ep500) + per-leaf grad-norm
+# logging. BOTH embodiments (circle_3000 + small_circle_3000).
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 64
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 64
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 64
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 512
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 64
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 64
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 64
+          output_key: "fused_cond"
+          cond_proj_widths: [64, 64]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 64
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+              trunk_chunk_rate: true   # FIX 1 (capacity grab): trunk runs at chunk-rate (concat m sub-latents)
+              residual_mixer: mlp      # FIX 2 (residual bypass): non-linear mixer; swap to attn/additive here
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 64
+              output_hidden_dim: 256
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+              trunk_chunk_rate: true   # FIX 1 (capacity grab): trunk runs at chunk-rate (concat m sub-latents)
+              residual_mixer: mlp      # FIX 2 (residual bypass): non-linear mixer; swap to attn/additive here
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 256
+          output_hidden_dim: 256
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 256
+            d_intermediate: 768
+            num_heads: 8
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_smoke.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_smoke.yaml
@@ -1,0 +1,159 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# SMOKE: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+#
+# FIX #6: this GMM-head config REQUIRES norm_stats.norm_mode=minmax (the yaml
+#   default is the "quantile trap" — see gmm_head.py header). Enforced in code
+#   at trainHydra.py (GMM head + non-minmax => hard error), so a launch that
+#   forgets the override cannot silently train a broken GMM. The launcher
+#   (regdown_msub_smoke.sh) passes norm_stats.norm_mode=minmax.
+# FIX #3: transformer-router runs need the ratio_loss_scheduler (reg-off) wired
+#   in via callbacks=ckpt_ratio_loss_scheduler (switch_fraction=0.25 => ep500 at
+#   max_epochs=2000). Every prior transformer-router config omitted it.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+              reg_trunk_residual_init: true   # FIX #7: ON for the new arch (BC: default off)
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_msub_smoke.yaml.bak_audit7_20260619_185401
+++ b/egomimic/hydra_configs/model/hnet_regdown_msub_smoke.yaml.bak_audit7_20260619_185401
@@ -1,0 +1,148 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# SMOKE: DOWN-ONLY register encoder + BESPOKE m-sublatents dechunker.
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        up_interface=msublatent (MSublatentDeChunker: per fine token mixes the
+#        chunk's m inner-processed register tokens with phase-driven softmax
+#        weights, then the duplicate's SAME EMA + c_t STE; gated decoder-end
+#        RMSNorm via component_end_norm=true). reg_m=4.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_regdown_smoke.yaml with up_interface duplicate -> msublatent
+# and component_end_norm true. Validates the full combo composes end-to-end.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: msublatent
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: true
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hnet_regdown_smoke.yaml
+++ b/egomimic/hydra_configs/model/hnet_regdown_smoke.yaml
@@ -1,0 +1,147 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+
+# SMOKE: DOWN-ONLY register encoder as the H-Net transformer chunker.
+#   L0 = per-embodiment ChunkerStage: down_interface=register (RegisterInterface
+#        + RegisterTrunk encode_down -> chunk-rate register tokens N*m), taper
+#        256 -> 512, transformer router (PhaseSummaryRouter prefix_global),
+#        PLACEHOLDER up_interface=duplicate (DeChunkLayer on the per-chunk
+#        summary register). The bespoke m-sublatent + EMA dechunker is the NEXT
+#        build step.
+#   L1 = shared ComputeStage(512) inner trunk over the N*m register tokens.
+# Cloned from hnet_cotrain_gmm_obs_big_c4r8_ABC_1stage_taper256 with the down/
+# router/up interfaces swapped. Validates the COMBO composes end-to-end.
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 256
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 256
+    action_head_type: gmm
+
+    gmm_head:
+      _target_: egomimic.models.heads.gmm_head.GMMActionHead
+      d_model: 256
+      action_dim: 2
+      num_modes: 32
+      chunk_len: 4
+      min_std: 1.0e-4
+      std_activation: softplus
+      low_noise_eval: true
+      head_hidden_dim: 1024
+      head_n_layers: 3
+
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 256
+      output_key: "fused_cond"
+      obs_specs: {}
+      img_encoders: {}
+
+    input_modules:
+      - _target_: egomimic.models.stems.input_modules.ObsToken
+        d_model: 256
+        obs_encoder:
+          _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+          d_cond: 256
+          output_key: "fused_cond"
+          cond_proj_widths: [256, 256]
+          obs_specs:
+            state_agent_obj:
+              input_dim: 5
+              embed_dim: 96
+              widths: [192]
+          img_encoders:
+            front_img_1:
+              _target_: egomimic.models.stems.visual_core.VisualCore
+              in_channels: 3
+              image_size: 96
+              num_kp: 48
+              feature_dimension: 96
+              pretrained: false
+              crop_aug: true
+              crop_height: 86
+              crop_width: 86
+              crop_eval_mode: random
+              crop_sample_mode: v02
+
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+        - _target_: egomimic.models.hnet.per_embodiment_stage.PerEmbodimentStage
+          sub_stages:
+            pushshapes_sim:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: duplicate
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: false
+            pushshapes_sim_small_circle:
+              _target_: egomimic.models.hnet.stages.ChunkerStage
+              input_hidden_dim: 256
+              output_hidden_dim: 512
+              target_compression_ratio: 8.0
+              ratio_loss_weight: 0.03
+              cond_key: null
+              down_interface: register
+              up_interface: duplicate
+              router_interface: transformer
+              pser_variant: prefix_global
+              pser_T_temp: 2.0
+              reg_m: 4
+              reg_trunk_depth: 2
+              reg_trunk_n_heads: 8
+              reg_trunk_ff_mult: 4
+              component_end_norm: false
+        - _target_: egomimic.models.hnet.stages.ComputeStage
+          input_hidden_dim: 512
+          output_hidden_dim: 512
+          cond_key: null
+          d_cond: 0
+          causal: true
+          main_network:
+            arch_layout: "T6"
+            d_model: 512
+            d_intermediate: 1536
+            num_heads: 16
+            cond: false
+            rotary_emb_dim: 32
+            dropout: 0.0
+            resid_dropout: 0.0
+
+enable_grad_norm: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 200000
+  warmup_steps: 2000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/hpt_cotrain_pushshapes_flow_shared_head.yaml
+++ b/egomimic/hydra_configs/model/hpt_cotrain_pushshapes_flow_shared_head.yaml
@@ -1,0 +1,149 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hpt.algo.HPT
+  # ``norm_stats`` is injected at runtime by pl_model._instantiate_model.
+  #
+  # HPT cotrain over two pushshapes embodiments (big circle + small circle)
+  # with a SHARED flow (FMPolicy) action head. Cloned from
+  # hpt_pushshapes_circle.yaml (the proven single-pushshapes flow config) and
+  # extended to two domains. Both embodiments share the same 2-dim action key
+  # ("actions") and 5-dim proprio key ("state_agent_obj"), so a single shared
+  # head + shared stems is the natural fit; the trunk's domain embedding
+  # (use_domain_embedding: true) distinguishes the two domains. This is NOT
+  # built on hpt_cotrain_flow_shared_head, which is hardwired for eva/aria
+  # real-robot embodiments (14/12-dim cartesian/joint actions, multiple wrist
+  # cameras, actions_cartesian keys) and does not apply to pushshapes.
+
+  camera_transforms: null
+
+  diffusion: true
+  6dof: false
+
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+  shared_ac_key: "actions"
+
+  trunk:
+    embed_dim: 128
+    num_blocks: 6
+    num_heads: 4
+    token_postprocessing: "action_token"
+    observation_horizon: 1
+    action_horizon: 32
+    no_trunk: false
+    use_domain_embedding: true
+    drop_path: 0.1
+    weight_init_style: "pytorch"
+
+  multitask: false
+  pretrained: false
+  pretrained_checkpoint: ""
+  reverse_kl_samples: 8
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  shared_obs_keys: ["front_img_1"]
+
+  shared_stem_specs:
+    front_img_1:
+      _target_: egomimic.models.stems.hpt_stems.MLPPolicyStem
+      input_dim: 128
+      output_dim: 128
+      widths: [128]
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 4
+          crossattn_dim_head: 32
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 128
+
+  stem_specs:
+    pushshapes_sim:
+      state_agent_obj:
+        _target_: egomimic.models.stems.hpt_stems.MLPPolicyStem
+        input_dim: 5
+        output_dim: 128
+        widths: [128]
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 4
+            crossattn_dim_head: 32
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 128
+    pushshapes_sim_small_circle:
+      state_agent_obj:
+        _target_: egomimic.models.stems.hpt_stems.MLPPolicyStem
+        input_dim: 5
+        output_dim: 128
+        widths: [128]
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 4
+            crossattn_dim_head: 32
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 128
+
+  head_specs:
+    pushshapes_sim: null
+    pushshapes_sim_small_circle: null
+    shared:
+      _target_: egomimic.models.heads.fm_policy.FMPolicy
+      action_horizon: 32
+      num_inference_steps: 50
+      pooling: null
+      time_dist: "beta"
+      infer_ac_dims:
+        pushshapes_sim: 2
+        pushshapes_sim_small_circle: 2
+      model:
+        _target_: egomimic.models.diffusion.denoising_nets.CrossTransformer
+        nblocks: 4
+        cond_dim: 128
+        hidden_dim: 64
+        act_dim: 2
+        act_seq: 32
+        n_heads: 4
+        dropout: 0.1
+        mlp_layers: 4
+        mlp_ratio: 4
+
+  encoder_specs:
+    front_img_1:
+      _target_: egomimic.models.stems.hpt_stems.ResNet
+      output_dim: 128
+
+  train_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+      - _target_: torchvision.transforms.ColorJitter
+        brightness: 0.1
+        contrast: 0.1
+        saturation: 0.1
+        hue: 0.05
+      - _target_: torchvision.transforms.Normalize
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+  eval_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+      - _target_: torchvision.transforms.Normalize
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.LinearLR
+  _partial_: true
+  start_factor: 1
+  end_factor: 1

--- a/egomimic/hydra_configs/model/hpt_cotrain_pushshapes_flow_shared_head_c4_big.yaml
+++ b/egomimic/hydra_configs/model/hpt_cotrain_pushshapes_flow_shared_head_c4_big.yaml
@@ -1,0 +1,163 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hpt.algo.HPT
+  # ``norm_stats`` is injected at runtime by pl_model._instantiate_model.
+  #
+  # HPT-flow COTRAIN over the two pushshapes embodiments (big circle + small
+  # circle) with a SHARED FMPolicy (flow-matching) action head. Derived from
+  # hpt_cotrain_pushshapes_flow_shared_head.yaml (the proven 2-domain pushshapes
+  # flow config, 13.80M). Two deltas vs that base:
+  #
+  #   1. CHUNK-4: predict / execute 4 actions per inference.
+  #        - trunk action_horizon            32 -> 4
+  #        - shared head action_horizon      32 -> 4
+  #        - inner CrossTransformer act_seq  32 -> 4
+  #
+  #   2. BIG trunk -> 63.92M cotrain target. embed_dim is the SHARED bus width:
+  #      it is coupled to every stem in/out + its cross_attn modality_embed_dim,
+  #      the ResNet encoder output_dim, and the head cond_dim, so growing it
+  #      requires bumping all of those in lockstep. We raise:
+  #        - embed_dim   128 -> 384   (trunk + all stems + encoder out + head cond)
+  #        - num_blocks    6 -> 28
+  #      Head/stem STRUCTURE (nblocks/hidden_dim/widths/cross_attn latents) is
+  #      otherwise unchanged. Verified by REAL instantiation (FakeNormStats stub,
+  #      sum over m.nets): 63,442,338 params = 63.44M (-0.75% of 63.92M, within
+  #      the +/-2% band), act_seq = 4.
+
+  camera_transforms: null
+
+  diffusion: true
+  6dof: false
+
+  ac_keys:
+    pushshapes_sim: "actions"
+    pushshapes_sim_small_circle: "actions"
+  shared_ac_key: "actions"
+
+  trunk:
+    embed_dim: 384            # SHARED bus width (was 128)
+    num_blocks: 28            # BIG trunk (was 6)
+    num_heads: 4
+    token_postprocessing: "action_token"
+    observation_horizon: 1
+    action_horizon: 4         # CHUNK-4 (was 32)
+    no_trunk: false
+    use_domain_embedding: true
+    drop_path: 0.1
+    weight_init_style: "pytorch"
+
+  multitask: false
+  pretrained: false
+  pretrained_checkpoint: ""
+  reverse_kl_samples: 8
+
+  domains: ["pushshapes_sim", "pushshapes_sim_small_circle"]
+  shared_obs_keys: ["front_img_1"]
+
+  shared_stem_specs:
+    front_img_1:
+      _target_: egomimic.models.stems.hpt_stems.MLPPolicyStem
+      input_dim: 384          # coupled to embed_dim (was 128)
+      output_dim: 384         # coupled to embed_dim (was 128)
+      widths: [384]           # coupled to embed_dim (was [128])
+      specs:
+        random_horizon_masking: false
+        cross_attn:
+          crossattn_latent: 16
+          crossattn_heads: 4
+          crossattn_dim_head: 32
+          crossattn_modality_dropout: 0.1
+          modality_embed_dim: 384   # coupled to embed_dim (was 128)
+
+  stem_specs:
+    pushshapes_sim:
+      state_agent_obj:
+        _target_: egomimic.models.stems.hpt_stems.MLPPolicyStem
+        input_dim: 5          # proprio data dim (unchanged)
+        output_dim: 384       # coupled to embed_dim (was 128)
+        widths: [384]         # coupled to embed_dim (was [128])
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 4
+            crossattn_dim_head: 32
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 384   # coupled to embed_dim (was 128)
+    pushshapes_sim_small_circle:
+      state_agent_obj:
+        _target_: egomimic.models.stems.hpt_stems.MLPPolicyStem
+        input_dim: 5          # proprio data dim (unchanged)
+        output_dim: 384       # coupled to embed_dim (was 128)
+        widths: [384]         # coupled to embed_dim (was [128])
+        specs:
+          random_horizon_masking: false
+          cross_attn:
+            crossattn_latent: 16
+            crossattn_heads: 4
+            crossattn_dim_head: 32
+            crossattn_modality_dropout: 0.1
+            modality_embed_dim: 384   # coupled to embed_dim (was 128)
+
+  head_specs:
+    pushshapes_sim: null
+    pushshapes_sim_small_circle: null
+    shared:
+      _target_: egomimic.models.heads.fm_policy.FMPolicy
+      action_horizon: 4       # CHUNK-4 (was 32)
+      num_inference_steps: 50
+      pooling: null
+      time_dist: "beta"
+      infer_ac_dims:
+        pushshapes_sim: 2
+        pushshapes_sim_small_circle: 2
+      model:
+        _target_: egomimic.models.diffusion.denoising_nets.CrossTransformer
+        nblocks: 4
+        cond_dim: 384         # coupled to embed_dim / head bus (was 128)
+        hidden_dim: 64
+        act_dim: 2
+        act_seq: 4            # CHUNK-4 (was 32)
+        n_heads: 4
+        dropout: 0.1
+        mlp_layers: 4
+        mlp_ratio: 4
+
+  encoder_specs:
+    front_img_1:
+      _target_: egomimic.models.stems.hpt_stems.ResNet
+      output_dim: 384         # coupled to embed_dim (was 128)
+
+  train_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+      - _target_: torchvision.transforms.ColorJitter
+        brightness: 0.1
+        contrast: 0.1
+        saturation: 0.1
+        hue: 0.05
+      - _target_: torchvision.transforms.Normalize
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+  eval_image_augs:
+    _target_: torchvision.transforms.Compose
+    transforms:
+      - _target_: torchvision.transforms.Normalize
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-4
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  # max_steps is set at launch via ++model.scheduler.max_steps= (= epochs * steps_per_epoch).
+  # steps_per_epoch = trainer.limit_train_batches (100) -> 2000 * 100 = 200000.
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-6

--- a/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml
+++ b/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml
@@ -1,0 +1,136 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 896
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 896
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 896
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 896
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 896
+            output_key: fused_cond
+            cond_proj_widths:
+            - 896
+            - 896
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 896
+            output_key: fused_cond
+            cond_proj_widths:
+            - 896
+            - 896
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 896
+        output_hidden_dim: 896
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T18
+          d_model: 896
+          d_intermediate: 2688
+          num_heads: 14
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 896
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 896
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml.bak
+++ b/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml.bak
@@ -1,0 +1,136 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 1088
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 1088
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 1088
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 1088
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 1088
+            output_key: fused_cond
+            cond_proj_widths:
+            - 1088
+            - 1088
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 1088
+            output_key: fused_cond
+            cond_proj_widths:
+            - 1088
+            - 1088
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1088
+        output_hidden_dim: 1088
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T12
+          d_model: 1088
+          d_intermediate: 3264
+          num_heads: 17
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 1088
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 1088
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml.bak_768
+++ b/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml.bak_768
@@ -1,0 +1,136 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 1088
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 1088
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 1088
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 1088
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 1088
+            output_key: fused_cond
+            cond_proj_widths:
+            - 1088
+            - 1088
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 1088
+            output_key: fused_cond
+            cond_proj_widths:
+            - 1088
+            - 1088
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 1088
+        output_hidden_dim: 1088
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T12
+          d_model: 1088
+          d_intermediate: 3264
+          num_heads: 17
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 1088
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 1088
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml.bak_896
+++ b/egomimic/hydra_configs/model/transformer_rope_peremb_200M.yaml.bak_896
@@ -1,0 +1,136 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.algo.hnet.PackedAlgoBase
+  d_cond: 768
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  loss:
+    _target_: egomimic.algo.hnet.GMMLoss
+  outer_stage:
+    _target_: egomimic.algo.hnet.HNetOuterStage
+    action_dim: 2
+    action_horizon: 2560
+    d_model: 768
+    action_head_type: gmm
+    cond_encoder:
+      _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+      d_cond: 768
+      output_key: fused_cond
+      obs_specs: {}
+      img_encoders: {}
+    input_modules:
+    - _target_: egomimic.models.stems.input_modules.ObsToken
+      d_model: 768
+      obs_encoder:
+        _target_: egomimic.models.stems.cond_encoders.MultiEmbodimentCondEncoder
+        encoders:
+          pushshapes_sim:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 768
+            output_key: fused_cond
+            cond_proj_widths:
+            - 768
+            - 768
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+          pushshapes_sim_small_circle:
+            _target_: egomimic.models.stems.cond_encoders.CondEncoderModule
+            d_cond: 768
+            output_key: fused_cond
+            cond_proj_widths:
+            - 768
+            - 768
+            obs_specs:
+              state_agent_obj:
+                input_dim: 5
+                embed_dim: 96
+                widths:
+                - 192
+            img_encoders:
+              front_img_1:
+                _target_: egomimic.models.stems.visual_core.VisualCore
+                in_channels: 3
+                image_size: 96
+                num_kp: 48
+                feature_dimension: 96
+                pretrained: false
+                crop_aug: true
+                crop_height: 86
+                crop_width: 86
+                crop_eval_mode: random
+                crop_sample_mode: v02
+    hnet:
+      _target_: egomimic.models.hnet.hnet.HNet
+      stages:
+      - _target_: egomimic.models.hnet.stages.ComputeStage
+        input_hidden_dim: 768
+        output_hidden_dim: 768
+        cond_key: null
+        d_cond: 0
+        causal: true
+        main_network:
+          arch_layout: T24
+          d_model: 768
+          d_intermediate: 2304
+          num_heads: 12
+          cond: false
+          rotary_emb_dim: 64
+          dropout: 0.0
+          resid_dropout: 0.0
+    gmm_heads:
+      pushshapes_sim:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 768
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+      pushshapes_sim_small_circle:
+        _target_: egomimic.models.heads.gmm_head.GMMActionHead
+        d_model: 768
+        action_dim: 2
+        num_modes: 32
+        chunk_len: 4
+        min_std: 0.0001
+        std_activation: softplus
+        low_noise_eval: true
+        head_hidden_dim: 512
+        head_n_layers: 3
+enable_grad_norm: true
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 15000
+  warmup_start_factor: 0.1
+  eta_min: 1.0e-06

--- a/egomimic/models/heads/gmm_head.py
+++ b/egomimic/models/heads/gmm_head.py
@@ -36,6 +36,7 @@ range EXACTLY into [-1,+1] so robomimic's tanh assumption holds for every
 target. The unnormalization back to pixels happens in the algo, unchanged.
 """
 
+import math
 from typing import Optional
 
 import torch

--- a/egomimic/models/hnet/blocks.py
+++ b/egomimic/models/hnet/blocks.py
@@ -423,6 +423,52 @@ class MultiHeadAttention(nn.Module):
         out = out.transpose(1, 2).reshape(B, 1, D)
         return self.out_proj(out)
 
+    def forward_masked(
+        self,
+        x,
+        attn_mask_2d,
+        cu_seqlens=None,
+        rope_positions: Optional[torch.Tensor] = None,
+    ):
+        """Eager-SDPA single-sequence attention with an ARBITRARY boolean
+        (L, L) mask (``True`` = query i ALLOWED to attend key j — SDPA bool
+        semantics). Purely additive: reuses ``self.qkv`` / ``self.out_proj`` /
+        ``self.rotary_emb`` exactly like ``_forward_packed`` but drives SDPA
+        with a caller-supplied mask instead of the block-diagonal/causal one.
+
+        Used by the register masked-transformer interface, whose down/inner/up
+        pattern is realized as a single (L,L) mask that flash-attn cannot take.
+        ``cu_seqlens`` is accepted for signature parity / future batched use but
+        the mask already encodes subseq isolation, so it is unused here.
+
+        x: (L, D). attn_mask_2d: (L, L) bool. rope_positions: (L,) long or None
+        (None => no RoPE even if the module has a rotary cache; the register
+        trunk relies on member-phase features + the structural mask for order,
+        keeping TF/AR phase reproducible). Returns (L, D).
+        """
+        L, D = x.shape
+        qkv = self.qkv(x).reshape(L, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=1)  # each (L, H, Dh)
+        if self.rotary_emb is not None and rope_positions is not None:
+            cos, sin = self.rotary_emb.get(rope_positions, q.dtype)  # (L, dim/2)
+            cos = cos[:, None, :]
+            sin = sin[:, None, :]
+            q = _apply_rotary(q, cos, sin)
+            k = _apply_rotary(k, cos, sin)
+        # (L, H, Dh) -> (1, H, L, Dh)
+        q_ = q.transpose(0, 1).unsqueeze(0)
+        k_ = k.transpose(0, 1).unsqueeze(0)
+        v_ = v.transpose(0, 1).unsqueeze(0)
+        # Bool mask broadcast over the (1, H) leading dims: (1, 1, L, L).
+        attn_mask = attn_mask_2d.to(dtype=torch.bool)[None, None]
+        out = F.scaled_dot_product_attention(
+            q_, k_, v_, attn_mask=attn_mask,
+            dropout_p=self.dropout if self.training else 0.0,
+            is_causal=False,
+        )
+        out = out.squeeze(0).transpose(0, 1).reshape(L, D)
+        return self.out_proj(out)
+
 
 class CrossMultiHeadAttention(nn.Module):
     """Cross-attention: queries from x, keys/values from cond_tokens.

--- a/egomimic/models/hnet/hnet.py
+++ b/egomimic/models/hnet/hnet.py
@@ -97,10 +97,14 @@ class HNet(nn.Module):
     @property
     def output_hidden_dim(self) -> int:
         # Chain is recursive (stages[i].inner_stage = stages[i+1]) so the
-        # end-to-end output dim is the outermost stage's output dim, not the
-        # innermost. EncoderDecoder/Compute/Chunker stages each guarantee that
-        # they return to their own output_hidden_dim before their forward ends.
-        return self.stages[0].output_hidden_dim
+        # end-to-end output dim is the OUTERMOST stage's *actual returned* dim.
+        # Most stages return at their output_hidden_dim, but a ChunkerStage
+        # DECHUNKS back to its input_hidden_dim before returning — so we read
+        # ``end_to_end_output_dim`` (polymorphic: ChunkerStage -> input dim,
+        # others -> output dim). Backward-compatible: every existing root stage
+        # is dim-preserving (input==output) so this value is unchanged; it only
+        # lets a tapering chunker (256->512) sit at the chain root.
+        return self.stages[0].end_to_end_output_dim
 
     def forward(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
         return self.root(x, ctx)
@@ -183,15 +187,14 @@ def chunk_stats_from_aux(aux: List[dict]) -> dict:
         and ``num_tokens`` (one chunk covering everything) when F == 0.
 
     Returns a dict with keys per chunker (``avg_chunk_len_0``,
-    ``boundary_rate_0``, ...) plus aggregate ``avg_chunk_len`` /
-    ``boundary_rate`` averaged across chunkers. All values are Python
+    ``boundary_rate_0``, ...) plus aggregate ``boundary_rate`` averaged
+    across chunkers. All values are Python
     floats — these are pure logging stats, not loss terms.
     """
     out: dict = {}
     if not aux:
         return out
     rates = []
-    lens = []
     for i, entry in enumerate(aux):
         bm = entry["bpred"].boundary_mask
         n = max(bm.numel(), 1)
@@ -201,9 +204,7 @@ def chunk_stats_from_aux(aux: List[dict]) -> dict:
         out[f"boundary_rate_{i}"] = f
         out[f"avg_chunk_len_{i}"] = avg_len
         rates.append(f)
-        lens.append(avg_len)
     out["boundary_rate"] = sum(rates) / len(rates)
-    out["avg_chunk_len"] = sum(lens) / len(lens)
     return out
 
 

--- a/egomimic/models/hnet/per_embodiment_stage.py
+++ b/egomimic/models/hnet/per_embodiment_stage.py
@@ -52,18 +52,14 @@ class PerEmbodimentStage(_BaseStage):
     def __init__(self, sub_stages: dict[str, _BaseStage]):
         if not sub_stages:
             raise ValueError("PerEmbodimentStage requires at least one sub-stage.")
-        dims = {
-            (ss.input_hidden_dim, ss.output_hidden_dim) for ss in sub_stages.values()
-        }
+        dims = {(ss.input_hidden_dim, ss.output_hidden_dim) for ss in sub_stages.values()}
         if len(dims) != 1:
             raise ValueError(
                 f"All per-embodiment sub-stages must share input/output hidden "
                 f"dims; got {dims}."
             )
         in_dim, out_dim = next(iter(dims))
-        super().__init__(
-            input_hidden_dim=in_dim, output_hidden_dim=out_dim, cond_key=None
-        )
+        super().__init__(input_hidden_dim=in_dim, output_hidden_dim=out_dim, cond_key=None)
         self.sub_stages = nn.ModuleDict(sub_stages)
 
     # ------------------------------------------------------------------ #

--- a/egomimic/models/hnet/per_embodiment_stage.py
+++ b/egomimic/models/hnet/per_embodiment_stage.py
@@ -52,14 +52,18 @@ class PerEmbodimentStage(_BaseStage):
     def __init__(self, sub_stages: dict[str, _BaseStage]):
         if not sub_stages:
             raise ValueError("PerEmbodimentStage requires at least one sub-stage.")
-        dims = {(ss.input_hidden_dim, ss.output_hidden_dim) for ss in sub_stages.values()}
+        dims = {
+            (ss.input_hidden_dim, ss.output_hidden_dim) for ss in sub_stages.values()
+        }
         if len(dims) != 1:
             raise ValueError(
                 f"All per-embodiment sub-stages must share input/output hidden "
                 f"dims; got {dims}."
             )
         in_dim, out_dim = next(iter(dims))
-        super().__init__(input_hidden_dim=in_dim, output_hidden_dim=out_dim, cond_key=None)
+        super().__init__(
+            input_hidden_dim=in_dim, output_hidden_dim=out_dim, cond_key=None
+        )
         self.sub_stages = nn.ModuleDict(sub_stages)
 
     # ------------------------------------------------------------------ #
@@ -88,6 +92,12 @@ class PerEmbodimentStage(_BaseStage):
         parallel and share the same handoff dim by construction."""
         sub = next(iter(self.sub_stages.values()))
         return sub.inner_working_dim
+
+    @property
+    def end_to_end_output_dim(self) -> int:
+        """Delegate to a representative sub-stage (all parallel, same I/O)."""
+        sub = next(iter(self.sub_stages.values()))
+        return sub.end_to_end_output_dim
 
     # ------------------------------------------------------------------ #
     # Dispatch

--- a/egomimic/models/hnet/register_interface.py
+++ b/egomimic/models/hnet/register_interface.py
@@ -1,0 +1,645 @@
+"""
+Register-token masked-transformer chunk interface (design: vault
+"Expressive Chunk Downsampler-Upsampler", CURRENT PROPOSAL 2026-06-10/11).
+
+Replaces first-token-down + duplicate-up + EMA with ONE masked-attention
+pattern. m learned REGISTER tokens are inserted at each chunk's END; a
+structured mask makes them act as the down/inner/up interface:
+
+  down:  register r of chunk c  -> attends member tokens of chunk c
+  inner: register r of chunk c  -> attends registers of chunks c' <= c
+  up:    member t of chunk c    -> attends PREVIOUS chunk's registers
+                                   + own-chunk earlier-or-equal members
+
+Causality is exact: registers sit AFTER their chunk's members so they may
+see the whole chunk; a member sees only earlier chunks' (complete)
+registers + its own causal prefix -> no future leak, KV-cacheable for AR.
+This is the shift-by-one-chunk semantics realized as a mask.
+
+This module builds the augmented stream + the boolean attention mask; the
+actual attention is a standard transformer block run with that mask. Member
+outputs are recovered by ``out[member_idx]``.
+
+Packed convention: hidden (T, D), cu_seqlens (B+1,), boundary_mask (T,) with
+chunk starts forced True.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from egomimic.models.hnet.blocks import MultiHeadAttention, RMSNorm
+
+
+def _fourier_phase(phase: torch.Tensor, n_freqs: int = 4) -> torch.Tensor:
+    freqs = (2.0 ** torch.arange(n_freqs, device=phase.device)) * math.pi
+    ang = phase[:, None] * freqs[None, :]
+    return torch.cat([torch.sin(ang), torch.cos(ang)], dim=-1)
+
+
+@dataclass
+class RegisterStream:
+    aug_hidden: torch.Tensor      # (L, D) interleaved members+registers
+    attn_mask: torch.Tensor       # (L, L) bool, True = ALLOWED
+    member_idx: torch.Tensor      # (T,) aug positions of original members
+    reg_idx: torch.Tensor         # (m*N,) aug positions of registers
+    seg_id_aug: torch.Tensor      # (L,) chunk id per aug position
+    is_register: torch.Tensor     # (L,) bool
+    aug_cu_seqlens: torch.Tensor  # (B+1,) subseq boundaries in aug space
+    # (m*N,) subseq id per register token, in reg_idx (chunk-major) order. Used
+    # by the DOWN-only encoder to build register-rate cu_seqlens. Optional so
+    # the FUSED forward (which doesn't need it) stays byte-identical.
+    seq_aug_per_register: Optional[torch.Tensor] = None
+
+
+class RegisterInterface(nn.Module):
+    """Builds the augmented register stream + mask, and adds member phase.
+
+    Args:
+      d_model: token dim.
+      m: registers per chunk.
+      n_phase_freqs: fourier features for member phase.
+      component_end_norm: when True, expose an RMSNorm to be applied at the
+        encoder's OUTPUT (the paper's "network normalization" at the
+        component/encoder end). DEFAULT False -> no extra param, byte-identical
+        to the pre-knob arch. Built here (not on the trunk) so it lives next to
+        the register tokens it normalizes; the trunk applies it on the chunk-rate
+        register outputs in the DOWN-only path.
+    """
+
+    def __init__(self, d_model: int, m: int = 4, n_phase_freqs: int = 4,
+                 component_end_norm: bool = False,
+                 device=None, dtype=None):
+        super().__init__()
+        fk = {"device": device, "dtype": dtype}
+        self.d_model = d_model
+        self.m = int(m)
+        self.n_phase_freqs = n_phase_freqs
+        # learned register initial content + a small projection of the
+        # member-phase fourier features added onto member tokens.
+        self.register_emb = nn.Parameter(torch.randn(m, d_model) * 0.02)
+        self.phase_proj = nn.Linear(2 * n_phase_freqs, d_model, **fk)
+        # Gated encoder-end normalization (off by default => no new params).
+        self.component_end_norm = bool(component_end_norm)
+        self.end_norm = RMSNorm(d_model) if self.component_end_norm else None
+
+    @torch.no_grad()
+    def _layout(self, boundary_mask, cu_seqlens, causal_phase: bool = False):
+        """Compute the interleaving layout (index-only, no grad).
+
+        ``causal_phase``: when True, the member phase is the prefix-causal
+        ``offset/(offset+1)`` (a function of the running offset alone,
+        reproducible at AR emit-time) instead of the teacher-forced full-chunk
+        ``offset/chunk_len``. Mirrors ``scan_interface._phase_from_offset_len``
+        so the register AR ``step`` can compare against a TF reference under the
+        SAME phase definition (GATE-1, exact match). Default False keeps the
+        training forward byte-identical to GATE-0."""
+        device = boundary_mask.device
+        T = boundary_mask.shape[0]
+        # ROBUST LAYOUT (cotrain tiling-gap fix): force a boundary at every
+        # subseq start so (a) ``seg`` never goes negative — the first token of
+        # the packed stream is always a chunk start, so ``cumsum(0)-1`` >= 0 —
+        # and (b) no chunk straddles a subseq boundary (every chunk is wholly
+        # contained in one subseq, which ``chunk_seq``/``seq_aug`` rely on). The
+        # real packed routers (cossim/scan/PSER) already set
+        # ``boundary_prob[cu_seqlens[:-1]] = 1.0``, so for a well-formed mask
+        # this OR is a NO-OP and the layout is byte-identical; it only repairs
+        # a mask with a leading/interior tiling gap (negative chunk ids or an
+        # uncovered aug slot feeding ``torch.bincount``). The clone keeps the
+        # caller's tensor intact.
+        boundary_mask = boundary_mask.clone()
+        if T > 0:
+            boundary_mask[cu_seqlens[:-1]] = True
+        seg = (boundary_mask.cumsum(0) - 1)  # (T,) chunk id, global, >= 0
+        N = int(seg[-1].item()) + 1
+        m = self.m
+        # subseq id per token.
+        tok_seq = (torch.arange(T, device=device)[:, None]
+                   >= cu_seqlens[None, 1:]).sum(-1)
+        # First token position of each chunk == the boundary positions, in chunk
+        # order. With every subseq start forced True above, ``boundary_mask`` has
+        # exactly N True entries (one per chunk) so ``nonzero`` yields the N chunk
+        # starts sorted ascending == ``first_pos`` directly. This is DETERMINISTIC
+        # — it replaces the previous ``scatter_`` with duplicate ``seg`` indices,
+        # whose "last writer wins" semantics are UNDEFINED on CUDA (the duplicate
+        # writes raced, giving wrong/negative ``offset`` -> negative ``member_idx``
+        # -> uncovered ``seq_aug`` slots -> the bincount crash). Indices here are
+        # unique, so CPU and GPU agree exactly.
+        first_pos = boundary_mask.nonzero(as_tuple=False).flatten()  # (N,) min pos per chunk
+        # subseq id per chunk = subseq of its first token (deterministic gather).
+        chunk_seq = tok_seq[first_pos]  # (N,)
+        # member offset within chunk.
+        offset = torch.arange(T, device=device) - first_pos[seg]
+        chunk_len = torch.bincount(seg, minlength=N)
+        # ---- build aug order: per subseq, chunks in order, each = members then m regs
+        # aug length
+        L = T + m * N
+        # position of each member and register block in aug space:
+        # walk chunks; member block size = chunk_len[c], then m regs.
+        block_sizes = chunk_len + m  # (N,)
+        chunk_aug_start = F.pad(block_sizes.cumsum(0), (1, 0))[:N]  # (N,)
+        member_idx = chunk_aug_start[seg] + offset  # (T,)
+        reg_local = torch.arange(m, device=device)
+        reg_idx = (chunk_aug_start[:, None] + chunk_len[:, None]
+                   + reg_local[None, :]).reshape(-1)  # (m*N,)
+        # seg/register/phase in aug space. ``zeros`` (not ``empty``) so an
+        # uncovered slot — impossible now that ``offset``/``member_idx`` are
+        # correct, but cheap insurance — is a valid non-negative bincount input
+        # rather than uninitialized garbage. Identical output when coverage is
+        # complete (every slot is overwritten below).
+        seg_aug = torch.zeros(L, dtype=torch.long, device=device)
+        seg_aug[member_idx] = seg
+        seg_aug[reg_idx] = torch.repeat_interleave(torch.arange(N, device=device), m)
+        is_reg = torch.zeros(L, dtype=torch.bool, device=device)
+        is_reg[reg_idx] = True
+        if causal_phase:
+            o = offset.float()
+            phase = o / (o + 1.0)
+        else:
+            phase = (offset.float() / chunk_len[seg].clamp(min=1).float())
+        # aug subseq id + cu. ``zeros`` (not ``empty``) for the same insurance.
+        seq_aug = torch.zeros(L, dtype=torch.long, device=device)
+        seq_aug[member_idx] = tok_seq
+        seq_aug[reg_idx] = torch.repeat_interleave(chunk_seq, m)
+        B = cu_seqlens.shape[0] - 1
+        counts = torch.bincount(seq_aug, minlength=B)
+        aug_cu = F.pad(counts.cumsum(0), (1, 0))
+        return dict(
+            L=L, N=N, seg_aug=seg_aug, is_reg=is_reg, member_idx=member_idx,
+            reg_idx=reg_idx, phase=phase, seq_aug=seq_aug, aug_cu=aug_cu,
+            offset=offset, seg=seg, chunk_len=chunk_len,
+            chunk_aug_start=chunk_aug_start, tok_seq=tok_seq,
+        )
+
+    @torch.no_grad()
+    def _build_mask(self, lay):
+        """(L, L) bool, True = query i ALLOWED to attend key j."""
+        seg = lay["seg_aug"]; is_reg = lay["is_reg"]; seq = lay["seq_aug"]
+        L = lay["L"]; device = seg.device
+        same_subseq = seq[:, None] == seq[None, :]
+        seg_i = seg[:, None]; seg_j = seg[None, :]
+        regi = is_reg[:, None]; regj = is_reg[None, :]
+        memi = ~regi; memj = ~regj
+        # aug position for member causal-prefix test
+        augpos = torch.arange(L, device=device)
+        pos_i = augpos[:, None]; pos_j = augpos[None, :]
+
+        # 1 down: register i attends member j of same chunk
+        down = regi & memj & (seg_i == seg_j)
+        # 2 inner: register i attends register j of chunk <= c
+        inner = regi & regj & (seg_j <= seg_i)
+        # 3a up-members: member i attends member j of same chunk with pos<=i
+        up_mem = memi & memj & (seg_i == seg_j) & (pos_j <= pos_i)
+        # 3b up-registers: member i attends registers of PREVIOUS chunk
+        up_reg = memi & regj & (seg_j == seg_i - 1)
+        allow = (down | inner | up_mem | up_reg) & same_subseq
+        # every token attends itself (numerical safety for softmax rows)
+        allow = allow | torch.eye(L, dtype=torch.bool, device=device)
+        return allow
+
+    def forward(self, hidden_states, boundary_mask, cu_seqlens,
+                causal_phase: bool = False) -> RegisterStream:
+        lay = self._layout(boundary_mask, cu_seqlens, causal_phase=causal_phase)
+        L = lay["L"]; device = hidden_states.device
+        aug = hidden_states.new_zeros(L, self.d_model)
+        # members: token + phase projection
+        ph = self.phase_proj(_fourier_phase(lay["phase"], self.n_phase_freqs))
+        aug[lay["member_idx"]] = hidden_states + ph
+        # registers: learned init (m,D) tiled per chunk
+        reg_init = self.register_emb.repeat(lay["N"], 1)  # (m*N, D)
+        aug[lay["reg_idx"]] = reg_init.to(aug.dtype)
+        mask = self._build_mask(lay)
+        return RegisterStream(
+            aug_hidden=aug, attn_mask=mask, member_idx=lay["member_idx"],
+            reg_idx=lay["reg_idx"], seg_id_aug=lay["seg_aug"],
+            is_register=lay["is_reg"], aug_cu_seqlens=lay["aug_cu"],
+            # subseq id per register, in reg_idx (chunk-major) order — for the
+            # DOWN-only encoder's register-rate cu_seqlens.
+            seq_aug_per_register=lay["seq_aug"][lay["reg_idx"]],
+        )
+
+    # ------------------------------------------------------------------ #
+    # AR helpers — build the per-token member embedding the SAME way the TF
+    # forward does, but from a running offset (prefix-causal phase). Used by
+    # the register AR step so member tokens entering the trunk match the TF
+    # ``aug[member_idx]`` byte-for-byte under causal_phase=True.
+    # ------------------------------------------------------------------ #
+
+    def member_embed_from_offset(
+        self, x_t: torch.Tensor, offset: torch.Tensor
+    ) -> torch.Tensor:
+        """x_t: (B, D) raw member token. offset: (B,) running position within
+        its (still-open) chunk. Returns x_t + phase_proj(fourier(phi)) with the
+        prefix-causal phase phi = offset/(offset+1) — identical to the TF
+        ``forward(causal_phase=True)`` member content."""
+        o = offset.float()
+        phi = o / (o + 1.0)
+        ph = self.phase_proj(_fourier_phase(phi, self.n_phase_freqs))
+        return x_t + ph
+
+    def register_init(self, batch_size: int, device, dtype) -> torch.Tensor:
+        """The learned m-register initial content tiled for ``batch_size``
+        chunks: (B, m, D). Matches the TF ``register_emb.repeat`` content."""
+        return self.register_emb[None].to(device=device, dtype=dtype).expand(
+            batch_size, self.m, self.d_model
+        )
+
+
+# --------------------------------------------------------------------------- #
+# RegisterTrunk — the fused masked transformer over the augmented stream.
+#
+# One stack of ``depth`` prenorm masked-attention + MLP blocks realizes
+# down (registers <- own members) + inner (registers <- earlier registers,
+# the chunk-rate trunk) + up (members <- prev-chunk registers + own causal
+# prefix) through the single (L, L) RegisterStream mask. The TF forward runs
+# the whole augmented stream; the AR path (``step`` machinery in ChunkerStage)
+# uses per-layer KV caches split into a PER-CHUNK REGISTER cache (finalized at
+# each boundary) + a CURRENT-CHUNK MEMBER cache, exploiting that a member never
+# attends its own-chunk registers nor any future token (GATE-0 causality).
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class RegisterTrunkState:
+    """Per-layer KV caches for the register AR step.
+
+    Two caches per layer:
+      * ``reg_kv`` — K/V of all FINALIZED registers so far (prev chunks). A
+        register is finalized JOINTLY with its m siblings at the chunk boundary
+        (same-chunk registers are mutually visible, so they finalize together).
+        Layout (B, H, cap_reg, Dh) with a per-row fill counter ``reg_fill``.
+      * ``mem_kv`` — K/V of the CURRENT (open) chunk's members. Reset to empty
+        when a boundary opens a new chunk. Layout (B, H, cap_mem, Dh) with
+        ``mem_fill``.
+    Plus chunk bookkeeping: ``offset`` (position within the open chunk),
+    ``has_seen`` (episode started), and ``mem_x`` — the raw post-phase member
+    inputs of the open chunk (needed to recompute the chunk through the trunk
+    at finalization, where registers attend members' per-layer reps)."""
+
+    reg_k: list      # depth x (B, H, cap_reg, Dh)
+    reg_v: list      # depth x (B, H, cap_reg, Dh)
+    reg_fill: torch.Tensor  # (B,) long — # finalized register slots
+    mem_k: list      # depth x (B, H, cap_mem, Dh)
+    mem_v: list      # depth x (B, H, cap_mem, Dh)
+    mem_fill: torch.Tensor  # (B,) long — # members in the open chunk
+    mem_x: torch.Tensor     # (B, cap_mem, D) post-phase member inputs (open chunk)
+    offset: torch.Tensor    # (B,) long — running offset within the open chunk
+    has_seen: torch.Tensor  # (B,) bool
+
+
+class RegisterTrunk(nn.Module):
+    """``depth`` prenorm (masked-attn -> MLP) blocks consuming a RegisterStream.
+
+    ``forward(stream)`` runs the full augmented stream with the (L, L) mask and
+    returns the trunk output at every aug position (members recovered by the
+    caller via ``stream.member_idx``). The per-block structure mirrors
+    ``transformer_router``'s self-contained stack (RMSNorm prenorm, repo
+    ``MultiHeadAttention.forward_masked`` for attention, GELU MLP, residual).
+    Attention is bidirectional-within-the-mask (causal=False); the MASK alone
+    enforces causality, exactly as GATE-0 verified."""
+
+    def __init__(
+        self,
+        d_model: int,
+        depth: int = 2,
+        n_heads: int = 4,
+        ff_mult: int = 4,
+        rotary_emb_dim: int = 0,
+        rotary_emb_base: float = 10000.0,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        fk = {"device": device, "dtype": dtype}
+        assert d_model % n_heads == 0, "d_model must be divisible by n_heads"
+        self.d_model = int(d_model)
+        self.depth = int(depth)
+        self.n_heads = int(n_heads)
+        self.head_dim = d_model // n_heads
+        # rotary off by default — the register trunk gets order from the
+        # member-phase features + the structural mask, keeping the AR phase
+        # exactly reproducible. (Exposed as a knob for ablations.)
+        self.rotary_emb_dim = int(rotary_emb_dim)
+        self.attn_norms = nn.ModuleList([RMSNorm(d_model) for _ in range(self.depth)])
+        self.attns = nn.ModuleList(
+            [
+                MultiHeadAttention(
+                    d_model, n_heads, causal=False, dropout=0.0,
+                    rotary_emb_dim=self.rotary_emb_dim,
+                    rotary_emb_base=rotary_emb_base,
+                )
+                for _ in range(self.depth)
+            ]
+        )
+        self.mlp_norms = nn.ModuleList([RMSNorm(d_model) for _ in range(self.depth)])
+        ff_dim = int(ff_mult * d_model)
+        self.mlps = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(d_model, ff_dim, **fk),
+                    nn.GELU(),
+                    nn.Linear(ff_dim, d_model, **fk),
+                )
+                for _ in range(self.depth)
+            ]
+        )
+
+    def forward(self, stream: "RegisterStream") -> torch.Tensor:
+        """Run the augmented stream through the masked trunk. Returns (L, D)."""
+        x = stream.aug_hidden
+        mask = stream.attn_mask
+        for i in range(self.depth):
+            x = x + self.attns[i].forward_masked(self.attn_norms[i](x), mask)
+            x = x + self.mlps[i](self.mlp_norms[i](x))
+        return x
+
+    def n_residual_adds(self) -> int:
+        """# residual-stream adds this trunk contributes: 2 per block (attn +
+        MLP) over ``depth`` blocks (mirrors the Isotropic ``height`` counting in
+        ``_init_isotropic_linears``)."""
+        return 2 * self.depth
+
+    def _init_weights(self, initializer_range: float, n_residuals: int) -> None:
+        """FIX #7: residual-aware init. The trunk's attn ``out_proj`` and each
+        MLP's second Linear (``fc2`` — the residual-stream writer) are scaled by
+        ``initializer_range / sqrt(n_residuals)`` so the residual norm stays
+        bounded with depth; all other Linears use ``initializer_range``. Mirrors
+        ``_init_isotropic_linears`` but matches the RegisterTrunk's own module
+        naming (the MLP is an ``nn.Sequential`` so its second Linear is at index
+        2, not named ``fc2``). ``n_residuals`` is the CUMULATIVE count (parent
+        residuals + this trunk's ``n_residual_adds()``).
+
+        GATED at the call site (``ChunkerStage.reg_trunk_residual_init``): OFF by
+        default so existing register configs are byte-unchanged. Param count is
+        unaffected — only init values change.
+        """
+        scaled_std = initializer_range / max(n_residuals, 1) ** 0.5
+        for i in range(self.depth):
+            # Attention out-projection writes into the residual stream.
+            op = getattr(self.attns[i], "out_proj", None)
+            if op is not None and not getattr(op.weight, "_no_reinit", False):
+                nn.init.normal_(op.weight, mean=0.0, std=scaled_std)
+                if op.bias is not None:
+                    nn.init.zeros_(op.bias)
+            # Other attention Linears (q/k/v/in projections) use base range.
+            for name, mod in self.attns[i].named_modules():
+                if not isinstance(mod, nn.Linear):
+                    continue
+                if "out_proj" in name:
+                    continue  # already handled above (scaled)
+                if getattr(mod.weight, "_no_reinit", False):
+                    continue
+                nn.init.normal_(mod.weight, mean=0.0, std=initializer_range)
+                if mod.bias is not None:
+                    nn.init.zeros_(mod.bias)
+            # MLP: Sequential(Linear_in, GELU, Linear_out). Linear_out (idx 2,
+            # the "fc2") writes the residual -> scaled; Linear_in -> base range.
+            mlp = self.mlps[i]
+            fc1, fc2 = mlp[0], mlp[2]
+            if not getattr(fc1.weight, "_no_reinit", False):
+                nn.init.normal_(fc1.weight, mean=0.0, std=initializer_range)
+                if fc1.bias is not None:
+                    nn.init.zeros_(fc1.bias)
+            if not getattr(fc2.weight, "_no_reinit", False):
+                nn.init.normal_(fc2.weight, mean=0.0, std=scaled_std)
+                if fc2.bias is not None:
+                    nn.init.zeros_(fc2.bias)
+
+    # ------------------------------------------------------------------ #
+    # DOWN-ONLY encoder use.
+    #
+    # The same masked trunk, but the caller consumes the REGISTER outputs
+    # (chunk-rate tokens, m per chunk) instead of the member outputs. This is
+    # the H-Net "transformer chunker": the register encoder produces the
+    # contextualized chunk-rate stream (down + register<-register inner) which a
+    # SEPARATE inner_stage + up_interface + router then consume — exactly the
+    # role ``ChunkScanEncoder`` plays for the scan/spline path (it returns a
+    # ``chunked`` (N, D) tensor), here at register rate (N*m, D).
+    #
+    # The member ("up") outputs are simply DISCARDED in this mode: the bespoke
+    # dechunker (NEXT build step) reconstructs members from the inner-processed
+    # register tokens via its own attention, so the trunk's own up-rule is not
+    # used. Computing it is cheap and keeps the TF path a single attention call;
+    # gating it out would only complicate the mask for no param savings.
+    # ------------------------------------------------------------------ #
+
+    def encode_down(
+        self,
+        interface: "RegisterInterface",
+        hidden_states: torch.Tensor,   # (T, D)
+        boundary_mask: torch.Tensor,   # (T,) bool
+        cu_seqlens: torch.Tensor,      # (B+1,)
+        causal_phase: bool = False,
+    ):
+        """DOWN-only forward: returns ``(reg_tokens, next_cu, next_max, stream)``.
+
+          reg_tokens (N*m, D): trunk outputs at the m register positions of each
+            chunk, in chunk-major / register-minor order (chunk 0 regs 0..m-1,
+            chunk 1 regs 0..m-1, ...). This is the chunk-rate stream the inner
+            stage + up_interface consume.
+          next_cu (B+1,): register-rate cu_seqlens = m * (chunks per subseq).
+          next_max (int): max registers per subseq = m * max chunks per subseq.
+          stream: the RegisterStream (member_idx / reg_idx / aug_cu / masks) so
+            the up_interface / dechunker can map chunk-rate tokens back to tokens.
+
+        Same masked attention as ``forward``; only the GATHER differs (reg_idx
+        not member_idx) plus the optional encoder-end RMSNorm."""
+        stream = interface(
+            hidden_states, boundary_mask, cu_seqlens, causal_phase=causal_phase
+        )
+        trunk_out = self.forward(stream)             # (L, D)
+        reg_tokens = trunk_out[stream.reg_idx]        # (N*m, D), chunk-major
+        if interface.end_norm is not None:
+            reg_tokens = interface.end_norm(reg_tokens)
+        # register-rate cu_seqlens: m registers per chunk. ``reg_idx`` is built
+        # chunk-major (chunk c contributes slots [c*m .. c*m+m)); ``seq_aug`` at
+        # those slots is the subseq id per register, already in reg_idx order. So
+        # per-subseq register counts are bincount(seq_aug[reg_idx]). This is the
+        # register-rate analogue of ChunkScanEncoder.next_cu (which counts chunks
+        # per subseq) and equals m * (chunks per subseq) because every chunk
+        # contributes exactly m registers and no chunk straddles a subseq (the
+        # layout forces a boundary at each subseq start).
+        reg_seq = stream.seq_aug_per_register      # (N*m,) subseq id per register
+        B = cu_seqlens.shape[0] - 1
+        counts = torch.bincount(reg_seq, minlength=B)  # registers per subseq
+        next_cu = F.pad(counts.cumsum(0), (1, 0))
+        next_max = int(counts.max().item()) if B > 0 else 0
+        return reg_tokens, next_cu, next_max, stream
+
+    # ------------------------------------------------------------------ #
+    # AR inference (chunk-incremental KV cache).
+    #
+    # Exactness rests on the GATE-0 causality of the mask: a member attends
+    # only own-chunk earlier-or-equal members + PREVIOUS chunks' (finalized)
+    # registers — never its own-chunk registers, never future tokens. So a
+    # member is fully computable token-by-token (output one-per-step) from the
+    # finalized-register cache + the open-chunk member cache. Registers of a
+    # chunk are mutually visible, so they finalize JOINTLY at the boundary,
+    # attending [finalized prev registers] + [their own chunk's member KV] +
+    # [the m same-chunk registers]. After finalization their KV is appended to
+    # the register cache to serve the NEXT chunk.
+    # ------------------------------------------------------------------ #
+
+    def allocate(self, batch_size, cap_reg, cap_mem, d_model, device, dtype):
+        H, Dh = self.n_heads, self.head_dim
+        mk = lambda cap: [  # noqa: E731
+            torch.zeros(batch_size, H, cap, Dh, device=device, dtype=dtype)
+            for _ in range(self.depth)
+        ]
+        return RegisterTrunkState(
+            reg_k=mk(cap_reg), reg_v=mk(cap_reg),
+            reg_fill=torch.zeros(batch_size, device=device, dtype=torch.long),
+            mem_k=mk(cap_mem), mem_v=mk(cap_mem),
+            mem_fill=torch.zeros(batch_size, device=device, dtype=torch.long),
+            mem_x=torch.zeros(batch_size, cap_mem, d_model, device=device, dtype=dtype),
+            offset=torch.zeros(batch_size, device=device, dtype=torch.long),
+            has_seen=torch.zeros(batch_size, device=device, dtype=torch.bool),
+        )
+
+    def _qkv(self, attn: MultiHeadAttention, h):
+        """Project (B, n, D) -> q,k,v each (B, H, n, Dh). No RoPE (trunk default)."""
+        B, n, _ = h.shape
+        qkv = attn.qkv(h).reshape(B, n, 3, attn.num_heads, attn.head_dim)
+        q, k, v = qkv.unbind(dim=2)
+        return q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+
+    def step_member(self, x_t, state: RegisterTrunkState, m: int):
+        """Emit ONE member token. ``x_t``: (B, D) post-phase member input for the
+        CURRENT open chunk. ``m``: registers per chunk. Appends the member's
+        per-layer KV to the open-chunk member cache and returns the member's
+        trunk output (B, D).
+
+        At each layer the member attends [the immediately-PREVIOUS chunk's m
+        finalized registers] ++ [open-chunk member KV INCLUDING itself].
+        Mirrors the TF up-rule (members <- prev-chunk regs + own causal prefix);
+        the prev chunk is the LAST m finalized register slots. Chunk/reset
+        bookkeeping is owned by the caller (ChunkerStage._step_register)."""
+        B = x_t.shape[0]
+        # Stash the raw post-phase member input at the current member slot so the
+        # boundary finalization can recompute this chunk through the trunk for the
+        # register side.
+        slot = state.mem_fill  # (B,)
+        bidx = torch.arange(B, device=x_t.device)
+        state.mem_x[bidx, slot] = x_t.to(state.mem_x.dtype)
+        # immediately-previous chunk's register window [reg_fill - m, reg_fill).
+        reg_lo = (state.reg_fill - m).clamp(min=0)
+        reg_hi = state.reg_fill
+        mem_hi = slot + 1  # include self
+
+        x = x_t.unsqueeze(1)  # (B, 1, D)
+        for i in range(self.depth):
+            h = self.attn_norms[i](x)  # (B, 1, D)
+            q, k, v = self._qkv(self.attns[i], h)  # (B, H, 1, Dh)
+            # scatter this member's k/v into the open-chunk member cache.
+            state.mem_k[i][bidx, :, slot] = k.squeeze(2).to(state.mem_k[i].dtype)
+            state.mem_v[i][bidx, :, slot] = v.squeeze(2).to(state.mem_v[i].dtype)
+            attn_out = self._attend(
+                q, state, i,
+                reg_lo=reg_lo, reg_hi=reg_hi,
+                mem_lo=None, mem_hi=mem_hi,
+            )  # (B, 1, D)
+            x = x + self.attns[i].out_proj(attn_out)
+            x = x + self.mlps[i](self.mlp_norms[i](x))
+        # advance the open-chunk member counters.
+        state.mem_fill = state.mem_fill + 1
+        return x.squeeze(1)
+
+    def finalize_chunk(self, state: RegisterTrunkState, finished_mask,
+                       reg_interface: "RegisterInterface"):
+        """Finalize the just-completed chunk's m registers for the rows in
+        ``finished_mask`` and append their per-layer KV to the register cache.
+
+        Processes the m registers JOINTLY through the trunk. At layer i the
+        registers attend [finalized prev regs] + [this chunk's member KV at
+        layer i] + [the m same-chunk registers (mutually visible)]. After all
+        layers their KV is appended to ``reg_k/reg_v`` and ``reg_fill += m``.
+        Then resets the open-chunk member cache for the rows that finalized
+        (a fresh chunk is about to open).
+
+        Runs on ALL B rows (cheap) and writes back only ``finished_mask`` rows
+        so the per-batch slice/scatter stays uniform."""
+        B = state.reg_fill.shape[0]
+        m = reg_interface.m
+        device = state.reg_fill.device
+        dtype = state.mem_x.dtype
+        # register initial content (B, m, D) — same as TF register_emb tile.
+        x = reg_interface.register_init(B, device, dtype)  # (B, m, D)
+        bidx = torch.arange(B, device=device)
+        for i in range(self.depth):
+            h = self.attn_norms[i](x)  # (B, m, D)
+            q, k, v = self._qkv(self.attns[i], h)  # (B, H, m, Dh)
+            # registers attend: ALL prior finalized regs (inner: seg_j<=seg_i,
+            # the j<seg_i part) + this chunk's members (down) + the m same-chunk
+            # registers (the seg_j==seg_i part of inner, mutually visible).
+            attn_out = self._attend(
+                q, state, i,
+                reg_lo=None, reg_hi=state.reg_fill,
+                mem_lo=None, mem_hi=state.mem_fill,
+                extra_k=k, extra_v=v,  # full m x m visibility
+            )  # (B, m, D)
+            x = x + self.attns[i].out_proj(attn_out)
+            x = x + self.mlps[i](self.mlp_norms[i](x))
+            # cache the FINALIZED register k/v at this layer (append at reg_fill).
+            # write all rows into a scratch then scatter only finished rows.
+            for j in range(m):
+                pos = state.reg_fill + j  # (B,)
+                fk = state.reg_k[i]
+                fv = state.reg_v[i]
+                # only write finished rows; others keep their (unused) slots.
+                kj = k[:, :, j].to(fk.dtype)  # (B, H, Dh)
+                vj = v[:, :, j].to(fv.dtype)
+                wmask = finished_mask.view(B, 1, 1)
+                fk[bidx, :, pos] = torch.where(wmask, kj, fk[bidx, :, pos])
+                fv[bidx, :, pos] = torch.where(wmask, vj, fv[bidx, :, pos])
+        # bump register fill + reset member cache for finalized rows.
+        state.reg_fill = torch.where(
+            finished_mask, state.reg_fill + m, state.reg_fill
+        )
+        state.mem_fill = torch.where(
+            finished_mask, torch.zeros_like(state.mem_fill), state.mem_fill
+        )
+        # DECHUNK-AR: return the post-trunk register representations (B, m, D) of
+        # the just-finalized chunk (previously discarded). The inner stage +
+        # msublatent dechunker consume these; caller reads only finished rows.
+        return x
+
+    def _attend(self, q, state, layer, reg_lo, reg_hi, mem_lo, mem_hi,
+                extra_k=None, extra_v=None):
+        """SDPA of ``q`` (B, H, n, Dh) over the concatenation of
+        [register-cache slots in [reg_lo, reg_hi)] ++ [member-cache slots in
+        [mem_lo, mem_hi)] ++ optional ``extra`` KV (the m same-chunk registers,
+        fully visible, used only in finalize). All ranges are per-row (B,) long
+        tensors (or None => 0 lo). Per-row masks select each row's valid window;
+        softmax is permutation-invariant over keys so the concat order is
+        irrelevant. Returns (B, n, D)."""
+        B, H, n, Dh = q.shape
+        device = q.device
+        keys, vals, masks = [], [], []
+
+        def _window(kc, vc, lo, hi):
+            cap = kc.shape[2]
+            ar = torch.arange(cap, device=device)[None, :]  # (1, cap)
+            lo_t = torch.zeros(B, 1, dtype=torch.long, device=device) if lo is None else lo[:, None]
+            valid = (ar >= lo_t) & (ar < hi[:, None])  # (B, cap)
+            keys.append(kc); vals.append(vc); masks.append(valid)
+
+        if reg_hi is not None:
+            _window(state.reg_k[layer], state.reg_v[layer], reg_lo, reg_hi)
+        if mem_hi is not None:
+            _window(state.mem_k[layer], state.mem_v[layer], mem_lo, mem_hi)
+        if extra_k is not None:
+            keys.append(extra_k); vals.append(extra_v)
+            masks.append(torch.ones(B, extra_k.shape[2], dtype=torch.bool, device=device))
+
+        K = torch.cat(keys, dim=2)  # (B, H, S, Dh)
+        V = torch.cat(vals, dim=2)
+        M = torch.cat(masks, dim=1)  # (B, S)
+        attn_mask = M[:, None, None, :]  # broadcast over (H, n)
+        out = F.scaled_dot_product_attention(q, K, V, attn_mask=attn_mask, dropout_p=0.0)
+        return out.transpose(1, 2).reshape(B, n, H * Dh)

--- a/egomimic/models/hnet/residual_mixer.py
+++ b/egomimic/models/hnet/residual_mixer.py
@@ -10,7 +10,6 @@ ALL variants start ``~= up + residual`` at init (the extra path is zero-gated)
 so the change is training-stable from step 0. Add a new variant by registering
 it in ``_MIXERS``.  See vault: 30_Projects/RL2/Transformer HNet/Findings.md.
 """
-
 import torch
 import torch.nn as nn
 
@@ -64,9 +63,7 @@ class AttnMixer(nn.Module):
 
 
 _MIXERS = {
-    "additive": AdditiveMixer,
-    "add": AdditiveMixer,
-    "none": AdditiveMixer,
+    "additive": AdditiveMixer, "add": AdditiveMixer, "none": AdditiveMixer,
     "mlp": MLPMixer,
     "attn": AttnMixer,
 }

--- a/egomimic/models/hnet/scan_interface.py
+++ b/egomimic/models/hnet/scan_interface.py
@@ -36,13 +36,19 @@ cu_seqlens (B+1,), boundary_mask (T_total,) with subseq starts forced True.
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .routing import RoutingModuleOutput, get_seq_idx
+from .routing import DeChunkLayer, RoutingModuleOutput, get_seq_idx
+
+try:  # RMSNorm for the gated decoder-end normalization (paper "network norm").
+    from .blocks import RMSNorm  # type: ignore
+except Exception:  # pragma: no cover - blocks always present in the live repo.
+    RMSNorm = None  # type: ignore
 
 
 def _fourier_phase(phase: torch.Tensor, n_freqs: int = 4) -> torch.Tensor:
@@ -50,6 +56,89 @@ def _fourier_phase(phase: torch.Tensor, n_freqs: int = 4) -> torch.Tensor:
     freqs = (2.0 ** torch.arange(n_freqs, device=phase.device)) * math.pi
     ang = phase[:, None] * freqs[None, :]
     return torch.cat([torch.sin(ang), torch.cos(ang)], dim=-1)
+
+
+# --------------------------------------------------------------------------- #
+# Phase definitions: teacher-forced (full-chunk) vs prefix-causal (AR).
+#
+# TF forward uses phase = offset / chunk_len, where chunk_len is the FULL
+# (post-completion) chunk length. That value is NOT known at AR emit-time
+# (the chunk hasn't ended), so a strict one-output-per-step ``step`` cannot
+# reproduce it for non-final tokens. The reconciliation (see vault
+# "Expressive Chunk Downsampler-Upsampler", §"constraint: causality"): use a
+# PREFIX-CAUSAL phase that is a function of the running offset ALONE,
+#
+#     phi_t = offset_t / (offset_t + 1)         (in [0, 1), monotone)
+#
+# This is reproducible identically in TF (offset known per token) and AR
+# (running offset known). It agrees with the TF full-chunk phase at the
+# chunk's FIRST token (0) and LAST token ((L-1)/L); interior positions
+# legitimately differ (TF's interior phase looks ahead to the final length;
+# the causal phase cannot, by construction). ``forward(..., causal_phase=True)``
+# selects it so the consistency test can compare AR ``step`` against a TF
+# reference under the SAME definition (exact match, no tolerance fudge). The
+# training path keeps ``causal_phase=False`` (byte-identical to before).
+# --------------------------------------------------------------------------- #
+
+
+def _phase_from_offset_len(
+    offset: torch.Tensor, len_tok: torch.Tensor, causal_phase: bool
+) -> torch.Tensor:
+    """phase per token. TF: offset/len_tok. Causal: offset/(offset+1)."""
+    if causal_phase:
+        o = offset.float()
+        return o / (o + 1.0)
+    return offset.float() / len_tok.clamp(min=1).float()
+
+
+def _causal_phase_scalar(offset: torch.Tensor) -> torch.Tensor:
+    """Prefix-causal phase from a per-batch running offset (B,) -> (B,)."""
+    o = offset.float()
+    return o / (o + 1.0)
+
+
+@dataclass
+class ScanRouterState:
+    """AR state for ``ScanRouter``. ``has_seen_tokens`` forces a boundary on
+    the first step of each episode (subseq start), mirroring the packed
+    forward's ``boundary_prob[cu_seqlens[:-1]] = 1.0``. ``gru_h`` is the GRU
+    hidden carry (None on the Mamba backend, which uses ``mamba_cache``).
+    ``h_prev`` is the scan state BEFORE the current token (h_{t-1}); on the
+    Mamba path it stashes the previous step's mixer output (the GRU path reads
+    it directly from ``gru_h``)."""
+
+    has_seen_tokens: torch.Tensor  # (B,) bool
+    gru_h: Optional[torch.Tensor] = None  # (1, B, d_state) GRU carry
+    mamba_cache: Optional["object"] = None  # MambaCache on the CUDA path
+    h_prev: Optional[torch.Tensor] = None  # (B, d_state) carry for Mamba path
+
+
+@dataclass
+class ChunkScanEncoderState:
+    """AR state for ``ChunkScanEncoder``. Per-chunk GRU carry + running offset
+    + a FIXED-capacity buffer of this chunk's per-token GRU outputs (needed to
+    extract the m sub-latents at chunk completion, when the full chunk length
+    is known). A batched ``(B, cap, H)`` tensor (not a Python list) so nested
+    slice/scatter of this state is trivial. ``cap`` bounds the max chunk
+    length the AR path can summarize exactly; a chunk longer than ``cap``
+    triggers an assert (raise ``max_chunk_len`` in the config / allocate)."""
+
+    gru_h: torch.Tensor  # (1, B, H) per-chunk GRU carry
+    offset: torch.Tensor  # (B,) running position within the current chunk
+    buf: torch.Tensor  # (B, cap, H) per-token outputs of the current chunk
+
+
+@dataclass
+class SplineUpsamplerState:
+    """AR state for ``SplineUpsampler``. ``prev_inner_sub`` is the most
+    recently COMPLETED chunk's inner-processed m sub-latents (B, m, d_inner),
+    used as the basis for the current chunk's tokens (shift-by-one). Zero
+    until the first chunk completes (first chunk of an episode = no basis).
+    ``offset`` is the running position within the current chunk."""
+
+    prev_inner_sub: torch.Tensor  # (B, m, d_inner)
+    have_prev: torch.Tensor  # (B,) bool — a previous chunk exists
+    offset: torch.Tensor  # (B,) running position within the current chunk
 
 
 def _segment_meta(
@@ -99,15 +188,11 @@ class ScanRouter(nn.Module):
     tests, NOT the training path). ``backend='auto'`` picks at call time.
     """
 
-    def __init__(
-        self,
-        d_model: int,
-        d_state: Optional[int] = None,
-        mlp_hidden: int = 128,
-        backend: str = "auto",
-        device=None,
-        dtype=None,
-    ):
+    def __init__(self, d_model: int, d_state: Optional[int] = None,
+                 mlp_hidden: int = 128, backend: str = "auto",
+                 n_layer: int = 1, use_block: bool = False,
+                 has_mlp: bool = False, mlp_dim: Optional[int] = None,
+                 device=None, dtype=None):
         super().__init__()
         fk = {"device": device, "dtype": dtype}
         if backend not in ("auto", "mamba", "gru"):
@@ -115,18 +200,63 @@ class ScanRouter(nn.Module):
         self.backend = backend
         self.d_model = d_model
         self.d_state = int(d_state or d_model)
+        # Optional MambaBlock-stack scan (gated; DEFAULT use_block=False ->
+        # the bare ``self._mamba`` mixer path below is built EXACTLY as before,
+        # byte-identical to the current behaviour). When enabled, the scan is
+        # routed through ``n_layer`` MambaBlocks instead -- each provides
+        # pre-norm RMSNorm + residual + (optional, has_mlp) SwiGLU MLP, which
+        # adds the normalization/residual the bare mixer lacks.
+        self.use_block = bool(use_block)
+        self.n_layer = int(n_layer)
+        self.blocks = None
         self._mamba = None
         if backend in ("auto", "mamba"):
             try:
                 from .blocks import Mamba2Mixer
 
-                # Mixer outputs (T, d_model): scan state dim == d_model.
-                self._mamba = Mamba2Mixer(d_model=d_model, layer_idx=0, **fk)
-                self.d_state = d_model
+                if self.use_block:
+                    from .blocks import MambaBlock
+
+                    # MambaBlock has no ``has_mlp`` kwarg -- the MLP is enabled
+                    # by passing d_intermediate > 0 (SwiGLU width). Default the
+                    # width to d_model when has_mlp is on and no explicit dim is
+                    # given.
+                    d_int = (
+                        int(mlp_dim if mlp_dim is not None else d_model)
+                        if has_mlp
+                        else 0
+                    )
+                    self.blocks = nn.ModuleList(
+                        [
+                            MambaBlock(
+                                d_model=d_model,
+                                layer_idx=i,
+                                d_intermediate=d_int,
+                                **fk,
+                            )
+                            for i in range(self.n_layer)
+                        ]
+                    )
+                    # The block stack's Mamba2 mixer outputs (T, d_model), so the
+                    # running scan-state dim is still d_model.
+                    self.d_state = d_model
+                else:
+                    # Mixer outputs (T, d_model): scan state dim == d_model.
+                    self._mamba = Mamba2Mixer(
+                        d_model=d_model, layer_idx=0, **fk
+                    )
+                    self.d_state = d_model
             except Exception:
                 if backend == "mamba":
                     raise
-        self.gru = nn.GRU(d_model, self.d_state, batch_first=True, **fk)
+        # Only create the GRU fallback when neither the bare mixer nor the block
+        # stack is available. Keeping an unused GRU on the GPU/Mamba path leaves
+        # its params untouched by the loss -> Lightning/DDP "unused parameters".
+        self.gru = (
+            nn.GRU(d_model, self.d_state, batch_first=True, **fk)
+            if (self._mamba is None and self.blocks is None)
+            else None
+        )
         self.head = nn.Sequential(
             nn.Linear(self.d_state + d_model, mlp_hidden, **fk),
             nn.GELU(),
@@ -135,11 +265,22 @@ class ScanRouter(nn.Module):
 
     def _scan(self, hidden_states, cu_seqlens, seq_id, offset, seq_len):
         """Returns per-token state AFTER consuming x_t, (T, d_state)."""
-        use_mamba = self._mamba is not None and hidden_states.is_cuda
+        use_mamba = (
+            (self._mamba is not None or self.blocks is not None)
+            and hidden_states.is_cuda
+        )
         if self.backend == "gru":
             use_mamba = False
         if use_mamba:
             max_seqlen = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
+            if self.blocks is not None:
+                # Block-stack path: each MambaBlock handles its own pre-norm
+                # RMSNorm + residual (and optional SwiGLU). Sequential over the
+                # stack; the packed-scan resets are carried via cu_seqlens.
+                x = hidden_states
+                for blk in self.blocks:
+                    x = blk(x, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+                return x
             return self._mamba(
                 hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
             )
@@ -181,6 +322,98 @@ class ScanRouter(nn.Module):
             selected_probs=selected_probs,
         )
 
+    # --------------------------- AR inference --------------------------- #
+
+    def allocate_inference_cache(self, batch_size, device, dtype=None):
+        gru_h = None
+        mamba_cache = None
+        if self.gru is not None:
+            gru_h = torch.zeros(1, batch_size, self.d_state, device=device, dtype=dtype)
+        h_prev = None
+        if self._mamba is not None:
+            # max_seqlen unused by Mamba2Mixer.allocate; pass 1.
+            mamba_cache = self._mamba.allocate_inference_cache(
+                batch_size, 1, device, dtype
+            )
+            h_prev = torch.zeros(
+                batch_size, self.d_state, device=device, dtype=dtype
+            )
+        elif self.blocks is not None:
+            # Block-stack path: one MambaCache per block's mixer (a list stashed
+            # in the same ``mamba_cache`` field). ``h_prev`` stashes the previous
+            # step's stacked-block output (= h_{t-1}), zeros at episode start.
+            mamba_cache = [
+                blk.mixer.allocate_inference_cache(batch_size, 1, device, dtype)
+                for blk in self.blocks
+            ]
+            h_prev = torch.zeros(
+                batch_size, self.d_state, device=device, dtype=dtype
+            )
+        return ScanRouterState(
+            has_seen_tokens=torch.zeros(batch_size, device=device, dtype=torch.bool),
+            gru_h=gru_h,
+            mamba_cache=mamba_cache,
+            h_prev=h_prev,
+        )
+
+    def step(self, x_t: torch.Tensor, state: ScanRouterState) -> RoutingModuleOutput:
+        """One AR step. ``x_t``: (B, 1, D) or (B, D). Returns a per-batch
+        RoutingModuleOutput (boundary_prob (B, 2) etc.). Boundary forced True
+        on the first step of each episode (``has_seen_tokens`` False).
+
+        The boundary logit uses h_{t-1} (the carry BEFORE consuming x_t),
+        matching the forward's strictly prefix-causal ``h_prev``; the carry is
+        then advanced by consuming x_t.
+        """
+        if x_t.dim() == 3:
+            x_t = x_t.squeeze(1)
+        B = x_t.shape[0]
+        h_prev = self._step_carry(state)  # (B, d_state), state BEFORE x_t
+        logit = self.head(torch.cat([h_prev, x_t], dim=-1)).squeeze(-1)
+        p = torch.sigmoid(logit)
+        # Advance the carry by consuming x_t (so the NEXT step sees h_t).
+        self._step_advance(x_t, state)
+        # Force a boundary on the first token of each episode.
+        p = torch.where(state.has_seen_tokens, p, torch.ones_like(p))
+        state.has_seen_tokens.fill_(True)
+        boundary_prob = torch.stack((1 - p, p), dim=-1)  # (B, 2)
+        boundary_mask = boundary_prob[..., 1] > 0.5
+        selected_probs = boundary_prob.max(dim=-1).values.unsqueeze(-1)
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_mask,
+            selected_probs=selected_probs,
+        )
+
+    def _step_carry(self, state: ScanRouterState) -> torch.Tensor:
+        """Hidden state BEFORE consuming the current token (h_{t-1}).
+
+        GRU path: the carry IS h_{t-1} (advanced only after the logit).
+        Mamba path: ``h_prev`` stashes the previous step's mixer output
+        (= h_{t-1}); zeros at episode start, matching the forward's
+        ``h_prev[subseq_start] = 0``.
+        """
+        if state.gru_h is not None:
+            return state.gru_h[0]  # (B, d_state)
+        return state.h_prev
+
+    def _step_advance(self, x_t: torch.Tensor, state: ScanRouterState) -> None:
+        """Consume x_t, advancing the carry to h_t."""
+        if state.gru_h is not None:
+            _, h_new = self.gru(x_t.unsqueeze(1), state.gru_h)
+            state.gru_h = h_new
+            return
+        if self.blocks is not None:
+            # Block-stack path: run each MambaBlock's recurrent step in order,
+            # threading the per-block cache (residual handled inside .step()).
+            h = x_t.unsqueeze(1)  # (B, 1, D)
+            for blk, cache in zip(self.blocks, state.mamba_cache):
+                h = blk.step(h, cache)
+            state.h_prev = h.squeeze(1)
+            return
+        out = self._mamba.step(x_t.unsqueeze(1), state.mamba_cache)  # (B,1,D)
+        state.h_prev = out.squeeze(1)
+
 
 class ChunkScanEncoder(nn.Module):
     """Downsampler: per-chunk causal GRU (reset at every boundary) + phase
@@ -190,57 +423,165 @@ class ChunkScanEncoder(nn.Module):
     kept for the upsampler.
     """
 
-    def __init__(
-        self,
-        d_model: int,
-        d_out: int,
-        m_sublatents: int = 4,
-        n_phase_freqs: int = 4,
-        device=None,
-        dtype=None,
-    ):
+    def __init__(self, d_model: int, d_out: int, m_sublatents: int = 4,
+                 n_phase_freqs: int = 4, layernorm: bool = False,
+                 device=None, dtype=None):
         super().__init__()
         fk = {"device": device, "dtype": dtype}
         self.m = int(m_sublatents)
         self.n_phase_freqs = n_phase_freqs
         d_in = d_model + 2 * n_phase_freqs
         self.gru = nn.GRU(d_in, d_out, batch_first=True, **fk)
+        # Optional post-GRU stability LayerNorm (per-token over the feature dim,
+        # so it preserves the per-chunk reset, token ordering and causality).
+        # Re-added (gated, DEFAULT OFF -> byte-identical to the bare GRU path)
+        # because unnormalized GRU states explode (raw grad norms ~250 observed
+        # live). This is post-norm on the recurrent OUTPUT, NOT transformer
+        # pre-norm -- pre-norming the GRU input would not bound output
+        # explosion. Applied to ``outs`` before h_tok / sub-latents are gathered.
+        self.norm = nn.LayerNorm(d_out, **fk) if layernorm else None
 
     def forward(
         self,
         hidden_states: torch.Tensor,  # (T, D)
         boundary_mask: torch.Tensor,  # (T,) bool, subseq starts True
         cu_seqlens: torch.Tensor,  # (B+1,)
+        causal_phase: bool = False,
     ):
         """Returns (h_tok, sub_latents, chunk_summary, next_cu, next_max):
-        h_tok        (T, H)    running state per token (prefix-causal).
-        sub_latents  (N, m, H) scan states at the m sub-span ends.
-        chunk_summary (N, H)   = sub_latents[:, -1] (inner-stage input).
-        next_cu      (B+1,)    chunked-space cu_seqlens (ChunkLayer parity).
-        next_max     int       max chunks per subseq.
+          h_tok        (T, H)    running state per token (prefix-causal).
+          sub_latents  (N, m, H) scan states at the m sub-span ends.
+          chunk_summary (N, H)   = sub_latents[:, -1] (inner-stage input).
+          next_cu      (B+1,)    chunked-space cu_seqlens (ChunkLayer parity).
+          next_max     int       max chunks per subseq.
+
+        ``causal_phase``: use the prefix-causal phase offset/(offset+1)
+        instead of the full-chunk offset/len_tok, so the per-token GRU input
+        (and thus h_tok) is reproducible by the AR ``step``. Sub-latent end
+        positions (ceil(len*k/m)-1) are unchanged — they are finalized at
+        chunk completion, when the full length is known in AR too.
         """
         seg_id = boundary_mask.cumsum(0) - 1  # (T,) chunk index
         offset, len_tok, seg_len = _segment_meta(seg_id)
-        phase = offset.float() / len_tok.clamp(min=1).float()
+        phase = _phase_from_offset_len(offset, len_tok, causal_phase)
         x = torch.cat(
             [hidden_states, _fourier_phase(phase, self.n_phase_freqs)], dim=-1
         )
         padded = _pad_by_segment(x, seg_id, offset, seg_len)  # (N, L_max, d_in)
-        outs, _ = self.gru(padded)  # (N, L_max, H)
+        L_max = padded.shape[1]
+        # Run the GRU on a PACKED sequence so cuDNN's training reserve scales
+        # with the total number of real tokens, NOT N*L_max. Critical at INIT:
+        # the identity-init router fires boundaries only at subseq starts, so
+        # every subseq is ~one giant chunk (L_max == subseq length); the dense
+        # (N, L_max, H) GRU reserve otherwise OOMs (~24 GiB). Padded positions
+        # are never read below (we gather at valid offsets only), so this is
+        # numerically identical to self.gru(padded).
+        packed = nn.utils.rnn.pack_padded_sequence(
+            padded, seg_len.to("cpu"), batch_first=True, enforce_sorted=False
+        )
+        packed_out, _ = self.gru(packed)
+        outs, _ = nn.utils.rnn.pad_packed_sequence(
+            packed_out, batch_first=True, total_length=L_max
+        )  # (N, L_max, H)
+        if self.norm is not None:
+            outs = self.norm(outs)
         h_tok = outs[seg_id, offset]  # (T, H)
         # Sub-span end offsets per chunk: ceil(len * k / m) - 1, k = 1..m.
         N = seg_len.shape[0]
         ks = torch.arange(1, self.m + 1, device=seg_len.device)  # (m,)
         ends = (
-            (torch.ceil(seg_len[:, None].float() * ks[None, :] / self.m) - 1)
-            .long()
-            .clamp(min=0)
-        )  # (N, m)
+            torch.ceil(seg_len[:, None].float() * ks[None, :] / self.m) - 1
+        ).long().clamp(min=0)  # (N, m)
         sub_latents = outs[torch.arange(N, device=outs.device)[:, None], ends]
         chunk_summary = sub_latents[:, -1]
         next_cu = F.pad(boundary_mask.cumsum(0)[cu_seqlens[1:] - 1], (1, 0))
         next_max = int((next_cu[1:] - next_cu[:-1]).max())
         return h_tok, sub_latents, chunk_summary, next_cu, next_max
+
+    # --------------------------- AR inference --------------------------- #
+
+    def allocate_inference_cache(self, batch_size, device, dtype=None, max_chunk_len=256):
+        H = self.gru.hidden_size
+        return ChunkScanEncoderState(
+            gru_h=torch.zeros(1, batch_size, H, device=device, dtype=dtype),
+            offset=torch.zeros(batch_size, device=device, dtype=torch.long),
+            buf=torch.zeros(batch_size, int(max_chunk_len), H, device=device, dtype=dtype),
+        )
+
+    def _sub_positions(self, length: int) -> torch.Tensor:
+        """Offsets ceil(length*k/m)-1 for k=1..m (same rule as forward)."""
+        ks = torch.arange(1, self.m + 1)
+        return (torch.ceil(length * ks.float() / self.m) - 1).long().clamp(min=0)
+
+    def step(
+        self,
+        x_t: torch.Tensor,  # (B, D) or (B, 1, D)
+        state: ChunkScanEncoderState,
+        boundary_t: torch.Tensor,  # (B,) bool — boundary fired at THIS token
+    ):
+        """One AR step.
+
+        Order within a step (mirrors TF chunk timing):
+          1. For elements whose ``boundary_t`` is True AND have a non-empty
+             open chunk: that chunk just COMPLETED -> extract its m sub-latents
+             + summary from the buffered per-token outputs (full length now
+             known), mark it in ``finished_mask``, reset the GRU carry/offset.
+          2. Consume x_t into the (freshly-reset-if-boundary) per-chunk GRU
+             with the causal phase feature -> running h_t; append to buffer.
+
+        Returns (h_t, finished_sub, finished_summary, finished_mask):
+          h_t            (B, H)     running state after consuming x_t.
+          finished_sub   (B, m, H)  completed chunk's sub-latents (0 where not).
+          finished_summary (B, H)   = finished_sub[:, -1].
+          finished_mask  (B,) bool  which elements completed a chunk this step.
+        """
+        if x_t.dim() == 3:
+            x_t = x_t.squeeze(1)
+        B, D = x_t.shape
+        H = self.gru.hidden_size
+        cap = state.buf.shape[1]
+        device = x_t.device
+
+        finished_mask = boundary_t & (state.offset > 0)
+        finished_sub = x_t.new_zeros(B, self.m, H)
+        # ----- 1. finalize completed chunks (per-element; B is small) ----- #
+        if finished_mask.any():
+            for b in torch.nonzero(finished_mask, as_tuple=False).flatten().tolist():
+                L_b = int(state.offset[b].item())  # # tokens consumed in the chunk
+                pos = self._sub_positions(L_b).to(device)  # (m,) sub-span ends
+                finished_sub[b] = state.buf[b, pos]
+        finished_summary = finished_sub[:, -1]
+
+        # ----- 2. consume x_t (reset carry/offset where boundary) ----- #
+        if boundary_t.any():
+            reset = boundary_t.view(1, B, 1).to(state.gru_h.dtype)
+            state.gru_h = state.gru_h * (1.0 - reset)
+            state.offset = torch.where(
+                boundary_t, torch.zeros_like(state.offset), state.offset
+            )
+        phase = _causal_phase_scalar(state.offset)  # (B,) offset BEFORE this token
+        pf = _fourier_phase(phase, self.n_phase_freqs)  # (B, 2*n_freqs)
+        gin = torch.cat([x_t, pf], dim=-1).unsqueeze(1)  # (B, 1, d_in)
+        out, h_new = self.gru(gin, state.gru_h)  # out (B,1,H)
+        state.gru_h = h_new
+        h_t = out.squeeze(1)
+        # Mirror the TF forward's post-GRU LayerNorm (gated, default OFF). The
+        # normed h_t is what gets buffered, so the sub-latents gathered from the
+        # buffer at chunk completion are also normed -- exactly as forward
+        # gathers sub_latents from the normed ``outs``. Keeps the AR step and
+        # the TF forward numerically consistent when the norm is enabled.
+        if self.norm is not None:
+            h_t = self.norm(h_t)
+        # Write this token's output into the per-row buffer slot at its offset.
+        off = state.offset  # (B,) offset of THIS token (0 at a chunk start)
+        if int(off.max().item()) >= cap:
+            raise RuntimeError(
+                f"ChunkScanEncoder AR buffer capacity {cap} exceeded by a chunk "
+                f"of length >{cap}; raise max_chunk_len in allocate_inference_cache."
+            )
+        state.buf[torch.arange(B, device=device), off] = h_t
+        state.offset = off + 1
+        return h_t, finished_sub, finished_summary, finished_mask
 
 
 class SplineUpsampler(nn.Module):
@@ -259,16 +600,9 @@ class SplineUpsampler(nn.Module):
     zeroed there (gate path only).
     """
 
-    def __init__(
-        self,
-        d_inner: int,
-        d_state: int,
-        d_model: int,
-        m_sublatents: int = 4,
-        n_phase_freqs: int = 4,
-        device=None,
-        dtype=None,
-    ):
+    def __init__(self, d_inner: int, d_state: int, d_model: int,
+                 m_sublatents: int = 4, n_phase_freqs: int = 4,
+                 device=None, dtype=None):
         super().__init__()
         fk = {"device": device, "dtype": dtype}
         self.m = int(m_sublatents)
@@ -295,11 +629,12 @@ class SplineUpsampler(nn.Module):
         boundary_mask: torch.Tensor,  # (T,)
         boundary_prob: torch.Tensor,  # (T, 2)
         cu_seqlens: torch.Tensor,  # (B+1,) TOKEN-space
+        causal_phase: bool = False,
     ) -> torch.Tensor:
         T = x_outer.shape[0]
         seg_id = boundary_mask.cumsum(0) - 1  # (T,)
         offset, len_tok, seg_len = _segment_meta(seg_id)
-        phase = offset.float() / len_tok.clamp(min=1).float()
+        phase = _phase_from_offset_len(offset, len_tok, causal_phase)
         pf = _fourier_phase(phase, self.n_phase_freqs)
 
         # Previous-chunk latents, zeroed for each subseq's first chunk.
@@ -321,3 +656,392 @@ class SplineUpsampler(nn.Module):
         p = boundary_prob[..., -1]
         c = torch.where(boundary_mask, p, 1.0 - p).clamp(1e-4, 1 - 1e-4)
         return out * c.unsqueeze(-1)
+
+    # --------------------------- AR inference --------------------------- #
+
+    def allocate_inference_cache(self, batch_size, d_inner, device, dtype=None):
+        return SplineUpsamplerState(
+            prev_inner_sub=torch.zeros(
+                batch_size, self.m, d_inner, device=device, dtype=dtype
+            ),
+            have_prev=torch.zeros(batch_size, device=device, dtype=torch.bool),
+            offset=torch.zeros(batch_size, device=device, dtype=torch.long),
+        )
+
+    def update_prev(
+        self,
+        state: SplineUpsamplerState,
+        finished_inner_sub: torch.Tensor,  # (B, m, d_inner)
+        finished_mask: torch.Tensor,  # (B,) bool
+    ) -> None:
+        """Cache a just-completed chunk's inner-processed sub-latents as the
+        basis for the upcoming chunk's tokens (shift-by-one)."""
+        if finished_mask.any():
+            m = finished_mask.view(-1, 1, 1)
+            state.prev_inner_sub = torch.where(
+                m, finished_inner_sub.to(state.prev_inner_sub.dtype),
+                state.prev_inner_sub,
+            )
+            state.have_prev = state.have_prev | finished_mask
+
+    def step(
+        self,
+        x_t: torch.Tensor,  # (B, d_model) or (B, 1, d_model) outer query
+        h_t: torch.Tensor,  # (B, d_state) own-chunk running state
+        boundary_t: torch.Tensor,  # (B,) bool
+        boundary_prob_t: torch.Tensor,  # (B, 2)
+        state: SplineUpsamplerState,
+    ) -> torch.Tensor:
+        """One AR step. Uses the cached previous-chunk basis + own h_t + the
+        prefix-causal phase of the running offset. The basis is zeroed for
+        elements with no completed previous chunk (episode's first chunk)."""
+        if x_t.dim() == 3:
+            x_t = x_t.squeeze(1)
+        B = x_t.shape[0]
+        # Reset the running offset at chunk starts; phase uses the offset
+        # BEFORE this token (offset 0 at a boundary).
+        if boundary_t.any():
+            state.offset = torch.where(
+                boundary_t, torch.zeros_like(state.offset), state.offset
+            )
+        phase = _causal_phase_scalar(state.offset)  # (B,)
+        pf = _fourier_phase(phase, self.n_phase_freqs)  # (B, 2*nf)
+
+        basis_all = self.w_v(state.prev_inner_sub)  # (B, m, d_model)
+        # Zero the basis for elements with no previous chunk yet.
+        basis_all = basis_all * state.have_prev.view(B, 1, 1).to(basis_all.dtype)
+
+        w = torch.softmax(self.w_weights(pf), dim=-1)  # (B, m)
+        mix = torch.einsum("bm,bmd->bd", w, basis_all)  # (B, d_model)
+        fresh = self.w_h(h_t)  # (B, d_model)
+        g = torch.sigmoid(self.gate(torch.cat([x_t, fresh], dim=-1)))  # (B,1)
+        ctx = (1 - g) * mix + g * fresh
+        gamma, beta = self.film(pf).chunk(2, dim=-1)
+        out = (1.0 + gamma) * self.w_o(ctx) + beta
+        p = boundary_prob_t[..., -1]
+        c = torch.where(boundary_t, p, 1.0 - p).clamp(1e-4, 1 - 1e-4)
+        out = out * c.unsqueeze(-1)
+        state.offset = state.offset + 1
+        return out
+
+
+@dataclass
+class MSublatentDeChunkerState:
+    """AR state for ``MSublatentDeChunker.step`` (DECHUNK-AR). Mirrors
+    ``SplineUpsamplerState`` plus a chunk-rate EMA carry (``ema_prev``)."""
+    prev_inner_sub: torch.Tensor  # (B, m, d_inner) POST-EMA sub-latents = W_v basis source (shift-by-one)
+    ema_prev: torch.Tensor        # (B, m*d_inner)  chunk-rate EMA carry
+    offset: torch.Tensor          # (B,) long       within-chunk phase index (prefix-causal)
+    have_prev: torch.Tensor       # (B,) bool       a completed previous chunk exists
+
+
+class MSublatentDeChunker(nn.Module):
+    """Bespoke m-sublatents phase-weighted dechunker (design: vault "Expressive
+    Chunk Downsampler-Upsampler", §"m sub-latents per chunk").
+
+    Takes the paper's ``DeChunkLayer`` (duplicate + EMA + c_t STE) and changes
+    ONLY the token-reconstruction step: instead of *broadcasting the single
+    chunk token* to every fine token of the chunk, each fine token mixes the
+    chunk's ``m`` inner-processed sub-latents (register tokens) with phase-driven
+    weights::
+
+        recon_t = sum_{k=1..m} softmax(w_weights(fourier(phi_t)))_k * W_v(V_{j,k})
+
+    where ``V_{j,k}`` is the k-th inner-processed register token of token t's OWN
+    chunk j (TF-only — no shift-by-one; the AR step is a deferred follow-up) and
+    ``phi_t`` is the within-chunk phase (offset / chunk_len in [0, 1)).
+
+    The EMA recurrence + kernel knobs are REUSED from ``DeChunkLayer`` via
+    composition (an owned ``DeChunkLayer`` whose ``_ema_kernel`` / ``_ema_loop``
+    are untouched). FIX #1: the EMA now runs at CHUNK rate over the flattened m
+    sub-latents ``(N, m*d_inner)`` and is applied BEFORE the phase m-mix —
+    mirroring the canonical ``DeChunkLayer._forward_packed`` (chunk-rate EMA
+    then expand). Pipeline: EMA(chunk-rate sub-latents) -> w_v + phase-softmax
+    m-mix to fine tokens -> c_t gate. Because the per-token m-mix happens AFTER
+    the smoothing, the within-chunk variation it introduces SURVIVES into the
+    output (the prior order — m-mix then a fine-rate EMA — damped it away; that
+    was the design tension the variance probe flagged, now resolved).
+
+    FIX #4: the c_t confidence gate uses the straight-through form
+    ``out = recon * _ste(c)`` (forward multiplier ≡ 1, so the output is NOT
+    attenuated; gradient routed through c), matching the canonical
+    ``_ste(selected_probs)`` paths — not the prior literal ``recon * c`` multiply.
+
+    The borrowed phase machinery (``_fourier_phase``, ``_segment_meta``, the
+    ``w_v`` projection and the softmax-over-m ``w_weights`` MLP on the Fourier
+    phase features) comes from ``SplineUpsampler``; the gate / FiLM / fresh-h
+    paths are intentionally NOT borrowed (minimal build).
+
+    Packed convention: chunk-rate sub-latents (N, m, d_inner); boundary_mask
+    (T_total,), boundary_prob (T_total, 2); ``cu_seqlens`` is TOKEN-space (B+1,)
+    for the phase machinery, ``chunk_cu_seqlens`` is CHUNK-space (B+1,) for the
+    chunk-rate EMA.
+    """
+
+    def __init__(self, d_inner: int, d_model: int, m_sublatents: int = 4,
+                 n_phase_freqs: int = 4, component_end_norm: bool = False,
+                 dtype=torch.bfloat16, block_size: int = 256, headdim: int = 32,
+                 device=None, _dtype=None):
+        super().__init__()
+        fk = {"device": device, "dtype": _dtype}
+        self.m = int(m_sublatents)
+        self.n_phase_freqs = n_phase_freqs
+        pf = 2 * n_phase_freqs
+        # Phase-mix params borrowed from SplineUpsampler (W_v + softmax-over-m).
+        self.w_v = nn.Linear(d_inner, d_model, **fk)
+        self.w_weights = nn.Sequential(
+            nn.Linear(pf, 64, **fk), nn.GELU(), nn.Linear(64, self.m, **fk)
+        )
+        # Reuse the paper's DeChunkLayer EMA (recurrence + kernel knobs) verbatim
+        # via composition. It owns NO Linear params (only the EMA), so this adds
+        # no parameters beyond w_v / w_weights / the optional end-norm.
+        #
+        # FIX #1: the EMA now runs at CHUNK rate over the flattened m sub-latents
+        # (N, m*d_inner), BEFORE the phase m-mix — mirroring the canonical
+        # DeChunkLayer._forward_packed (chunk-rate EMA then expand). So it is
+        # built for ``m * d_inner`` (the flattened sub-latent dim), NOT d_model.
+        # m*d_inner must be divisible by headdim; default headdim=32 divides
+        # 4*256=1024 cleanly. DeChunkLayer has zero parameters, so the dim change
+        # is param-count-neutral (BC preserved).
+        ema_dim = self.m * int(d_inner)
+        assert ema_dim % headdim == 0, (
+            f"m*d_inner ({ema_dim}) must be divisible by EMA headdim ({headdim}); "
+            f"set a compatible headdim for the chunk-rate sub-latent EMA."
+        )
+        self.ema = DeChunkLayer(
+            ema_dim, dtype=dtype, block_size=block_size, headdim=headdim
+        )
+        # Gated decoder-end RMSNorm (paper "network normalization" at the
+        # component end). DEFAULT OFF -> no new param, byte-identical when unset.
+        self.component_end_norm = bool(component_end_norm)
+        if self.component_end_norm:
+            assert RMSNorm is not None, "RMSNorm unavailable; cannot enable component_end_norm"
+            # Repo RMSNorm takes (d_model, eps) only — no device/dtype kwargs
+            # (matches register_interface's ``RMSNorm(d_model)`` construction).
+            self.end_norm = RMSNorm(d_model)
+        else:
+            self.end_norm = None
+
+    def _residual_adds(self) -> int:
+        """FIX #7 (faithfulness): # residual-stream adds this UP-interface
+        (dechunker) contributes, mirroring ``RegisterTrunk.n_residual_adds()``
+        on the down side. The bare softmax m-mix dechunker has NO residual-block
+        stack — its ``w_v`` / ``w_weights`` MLP write the output directly (not
+        into a depth-stacked residual stream) and the owned EMA is parameterless
+        — so it adds ZERO residual depth. Returns 2*n_blocks for a future
+        has_mlp / residual-block dechunker variant. Used by
+        ``ChunkerStage._init_weights`` to make the encoder-rule
+        (``parent + encoder.height + decoder.height``) faithful for non-root /
+        residual-dechunker topologies; the numeric value here is 0, so the
+        register-down arch's ``n_residuals`` (and scaled_std=0.01) is unchanged."""
+        return 0
+
+    def forward(
+        self,
+        inner_sub_latents: torch.Tensor,  # (N, m, d_inner) inner-processed regs
+        boundary_mask: torch.Tensor,      # (T_total,) bool, subseq starts True
+        boundary_prob: torch.Tensor,      # (T_total, 2)
+        cu_seqlens: torch.Tensor,         # (B+1,) TOKEN-space (phase machinery)
+        chunk_cu_seqlens: Optional[torch.Tensor] = None,  # (B+1,) CHUNK-space (EMA)
+        causal_phase: bool = False,
+        return_diagnostics: bool = False,
+    ) -> torch.Tensor:
+        """Packed TF forward. Returns the dechunked tokens (T_total, d_model).
+
+        FIX #1 pipeline (mirrors the canonical ``DeChunkLayer._forward_packed``,
+        which EMAs at CHUNK rate then expands):
+
+          inner_sub_latents (N, m, d_inner)
+            -> reshape (N, m*d_inner)
+            -> chunk-rate EMA over the N chunks (chunk-space cu_seqlens, chunk-
+               rate boundary probs = boundary_prob[...,-1][boundary_mask])
+            -> reshape back (N, m, d_inner)
+            -> w_v + softmax phase-mix to fine tokens (T, d_model)
+            -> c_t straight-through gate (FIX #4: ema * _ste(c), forward mult==1)
+
+        The EMA runs BEFORE the m-mix, so the within-chunk variation introduced
+        by the per-token phase weights ``w(phi_t)`` SURVIVES into the output
+        (the m-mix happens after the smoothing). This is the design fix the
+        variance probe checks.
+
+        ``chunk_cu_seqlens`` is REQUIRED (kept Optional for signature evolution):
+        the register-down call site passes ``reg_cu // m``. The EMA kernel's
+        ``dt = log(1/(1-p))`` reparam is rate-agnostic, so the same kernel runs
+        at chunk rate unchanged.
+
+        ``return_diagnostics`` (test/smoke hook): also return within-chunk
+        variance of the FINAL fine-token output (post m-mix, post EMA) and of a
+        no-EMA reference, to confirm the m-mix variation is RETAINED.
+        """
+        assert chunk_cu_seqlens is not None, (
+            "MSublatentDeChunker.forward requires chunk_cu_seqlens (chunk-space "
+            "cu_seqlens) for the chunk-rate sub-latent EMA (FIX #1)."
+        )
+        device = boundary_mask.device
+        T = boundary_mask.shape[0]
+        N, m, D_in = inner_sub_latents.shape
+        seg_id = boundary_mask.cumsum(0) - 1                  # (T,) chunk id
+
+        # FIX #5: guard the N-coupling. The dechunker derives N from the raw
+        # ``boundary_mask`` (subseq starts forced True upstream), while the
+        # encoder forces register/subseq starts independently. If a future
+        # non-forcing router de-syncs them, the seg_id <-> sub-latent index map
+        # would silently misalign. Assert they agree.
+        assert int(seg_id.max().item()) + 1 == N, (
+            f"N-coupling broken: boundary_mask implies {int(seg_id.max().item())+1} "
+            f"chunks but inner_sub_latents has N={N}. The router must force subseq "
+            f"starts (boundary_prob[cu_seqlens[:-1]]=1) so chunk ids align with the "
+            f"register encoder's chunk-major layout."
+        )
+
+        # --- FIX #1: chunk-rate EMA over the flattened m sub-latents, BEFORE the
+        #     m-mix. Chunk-space boundary probs = boundary_prob[...,-1] at the
+        #     boundary positions (one per chunk), exactly as the canonical
+        #     DeChunkLayer._forward_packed gathers them. ---
+        sub_flat = inner_sub_latents.reshape(N, m * D_in)     # (N, m*d_inner)
+        p_chunk = torch.clamp(
+            boundary_prob[..., -1][boundary_mask], min=1e-4, max=1 - 1e-4
+        )  # (N,) chunk-rate boundary probs
+        from .routing import _HAS_MAMBA_SCAN  # module-level kernel availability flag
+        if _HAS_MAMBA_SCAN and sub_flat.is_cuda and N > 0:
+            pos = torch.arange(N, device=device)
+            seq_idx = (
+                pos[:, None] >= chunk_cu_seqlens[None, 1:]
+            ).sum(dim=-1).to(torch.int32)
+            ema_flat = self.ema._ema_kernel(
+                sub_flat.unsqueeze(0), p_chunk.unsqueeze(0), seq_idx=seq_idx.unsqueeze(0)
+            ).squeeze(0)
+        else:
+            ema_flat = self.ema._ema_loop(
+                sub_flat.unsqueeze(0),
+                p_chunk.unsqueeze(0),
+                seq_starts=(
+                    chunk_cu_seqlens[1:-1] if chunk_cu_seqlens.numel() > 2 else None
+                ),
+            ).squeeze(0)
+        ema_sub = ema_flat.reshape(N, m, D_in)                # (N, m, d_inner)
+
+        # --- phase m-mix to fine tokens (AFTER the EMA). ---
+        offset, len_tok, _seg_len = _segment_meta(seg_id)
+        phase = _phase_from_offset_len(offset, len_tok, causal_phase)
+        pf = _fourier_phase(phase, self.n_phase_freqs)        # (T, 2*n_freqs)
+        basis_all = self.w_v(ema_sub)                         # (N, m, d_model)
+        basis_tok = basis_all[seg_id]                         # (T, m, d_model)
+        w = torch.softmax(self.w_weights(pf), dim=-1)         # (T, m)
+        out = torch.einsum("tm,tmd->td", w, basis_tok)        # (T, d_model)
+
+        # --- FIX #4: c_t straight-through gate (paper form). _ste(c) has forward
+        #     value == 1 (output UNSCALED in the forward pass; no attenuation),
+        #     gradient routed through c — matching the canonical _ste(probs)
+        #     paths. (Previously: ``out = ema * c`` literal multiply, which
+        #     attenuated the forward output.) ---
+        from .stages import _ste  # canonical _STE (forward==1, grad pass-through)
+        p = boundary_prob[..., -1]
+        c = torch.where(boundary_mask, p, 1.0 - p).clamp(1e-4, 1 - 1e-4)  # (T,)
+        out = out * _ste(c).unsqueeze(-1)
+
+        if self.end_norm is not None:
+            out = self.end_norm(out)
+
+        if return_diagnostics:
+            # The variance probe measures within-chunk variation of the FINAL
+            # fine-token output (post m-mix, post EMA). Compare against a no-EMA
+            # reference (same m-mix straight off the raw sub-latents) so the
+            # retention ratio = how much within-chunk structure survives the
+            # (now chunk-rate, pre-m-mix) EMA. Both are pre-c_t-gate (the STE
+            # gate is forward-identity, so it does not change the variance).
+            basis_no_ema = self.w_v(inner_sub_latents)[seg_id]   # (T, m, d_model)
+            out_no_ema = torch.einsum("tm,tmd->td", w, basis_no_ema)  # (T, d_model)
+            diag = {
+                # Final output within-chunk variance (post chunk-rate EMA, post m-mix).
+                "within_chunk_var_out": _within_chunk_var(out, seg_id),
+                # Reference: same m-mix WITHOUT the EMA (raw sub-latents).
+                "within_chunk_var_no_ema": _within_chunk_var(out_no_ema, seg_id),
+                # Pre/post names kept for backward-compat with the probe wording:
+                # "pre" = no-EMA m-mix reference, "post" = the real output.
+                "within_chunk_var_pre_ema": _within_chunk_var(out_no_ema, seg_id),
+                "within_chunk_var_post_ema": _within_chunk_var(out, seg_id),
+            }
+            return out, diag
+        return out
+
+    # --------------------------- AR inference --------------------------- #
+
+    def allocate_inference_cache(self, batch_size, d_inner, device, dtype=None):
+        return MSublatentDeChunkerState(
+            prev_inner_sub=torch.zeros(batch_size, self.m, d_inner, device=device, dtype=dtype),
+            ema_prev=torch.zeros(batch_size, self.m * d_inner, device=device, dtype=dtype),
+            offset=torch.zeros(batch_size, device=device, dtype=torch.long),
+            have_prev=torch.zeros(batch_size, device=device, dtype=torch.bool),
+        )
+
+    def update_prev(self, state, finished_inner_sub, boundary_prob_t, finished_mask):
+        """One chunk-rate EMA step on the just-completed chunk's m sub-latents,
+        then promote the EMA'd result to the shift-by-one basis. The recurrence
+        ``ema = p*sub + (1-p)*ema_prev`` reproduces the TF chunk-rate EMA
+        (``DeChunkLayer._ema_loop``) one chunk at a time; ``p`` is the chunk-rate
+        boundary prob = ``boundary_prob[...,-1]`` at the finalizing token. Rows
+        not finalizing this step are left untouched (p=0 => identity)."""
+        if not finished_mask.any():
+            return
+        B = finished_mask.shape[0]
+        sub_flat = finished_inner_sub.reshape(B, -1).to(state.ema_prev.dtype)  # (B, m*d_inner)
+        p = torch.zeros(B, device=sub_flat.device, dtype=state.ema_prev.dtype)
+        p[finished_mask] = boundary_prob_t[finished_mask, -1].clamp(1e-4, 1 - 1e-4).to(p.dtype)
+        p_b = p.unsqueeze(-1)
+        new_ema = p_b * sub_flat + (1 - p_b) * state.ema_prev                  # (B, m*d_inner)
+        state.ema_prev = torch.where(finished_mask.unsqueeze(-1), new_ema, state.ema_prev)
+        fm = finished_mask.view(B, 1, 1)
+        state.prev_inner_sub = torch.where(
+            fm, state.ema_prev.reshape(B, self.m, -1).to(state.prev_inner_sub.dtype),
+            state.prev_inner_sub,
+        )
+        state.have_prev = state.have_prev | finished_mask
+
+    def step(self, boundary_t, boundary_prob_t, state):
+        """One AR fine-token output. Decodes against the cached PREVIOUS chunk's
+        EMA'd ``W_v`` basis (shift-by-one — the AR causality cost) using the
+        prefix-causal phase of the running offset. Mirrors the TF forward's
+        m-mix -> c_t gate -> end_norm. Equality with TF holds under
+        ``causal_phase=True`` (the prefix phase ``o/(o+1)``)."""
+        B = boundary_t.shape[0]
+        if boundary_t.any():  # reset within-chunk phase at chunk starts
+            state.offset = torch.where(boundary_t, torch.zeros_like(state.offset), state.offset)
+        phase = _causal_phase_scalar(state.offset)            # (B,)
+        pf = _fourier_phase(phase, self.n_phase_freqs)        # (B, 2*nf)
+        basis = self.w_v(state.prev_inner_sub)                # (B, m, d_model)
+        basis = basis * state.have_prev.view(B, 1, 1).to(basis.dtype)  # zero if no prev chunk
+        w = torch.softmax(self.w_weights(pf), dim=-1)         # (B, m)
+        out = torch.einsum("bm,bmd->bd", w, basis)            # (B, d_model)
+        # c_t straight-through gate (forward value == 1; matches TF order: gate then end_norm).
+        from .stages import _ste
+        p = boundary_prob_t[..., -1]
+        c = torch.where(boundary_t, p, 1.0 - p).clamp(1e-4, 1 - 1e-4)
+        out = out * _ste(c).unsqueeze(-1)
+        if self.end_norm is not None:
+            out = self.end_norm(out)
+        state.offset = state.offset + 1
+        return out
+
+
+def _within_chunk_var(x: torch.Tensor, seg_id: torch.Tensor) -> float:
+    """Mean (over feature dims, then over chunks) within-chunk variance of a
+    packed (T, D) tensor grouped by ``seg_id`` (T,). Chunks of length 1
+    contribute 0. Returned as a python float for logging."""
+    xf = x.float()
+    N = int(seg_id.max().item()) + 1 if seg_id.numel() > 0 else 0
+    if N == 0:
+        return 0.0
+    D = xf.shape[-1]
+    counts = torch.bincount(seg_id, minlength=N).clamp(min=1).float()  # (N,)
+    sum_ = torch.zeros(N, D, device=xf.device, dtype=xf.dtype)
+    sum_.index_add_(0, seg_id, xf)
+    mean = sum_ / counts[:, None]                                      # (N, D)
+    sq = torch.zeros(N, D, device=xf.device, dtype=xf.dtype)
+    sq.index_add_(0, seg_id, xf * xf)
+    var = sq / counts[:, None] - mean * mean                          # (N, D)
+    # Average over chunks of length > 1 only (length-1 chunks have no spread).
+    multi = torch.bincount(seg_id, minlength=N) > 1
+    if multi.any():
+        return float(var[multi].clamp(min=0).mean().item())
+    return 0.0

--- a/egomimic/models/hnet/stages.py
+++ b/egomimic/models/hnet/stages.py
@@ -42,11 +42,6 @@ from egomimic.models.hnet.blocks import (
 )
 from egomimic.models.hnet.context import HNetContext
 from egomimic.models.hnet.isotropic_builder import build_isotropic
-from egomimic.models.hnet.register_interface import (
-    RegisterInterface,
-    RegisterTrunk,
-    RegisterTrunkState,
-)
 from egomimic.models.hnet.routing import (
     ChunkLayer,
     DeChunkLayer,
@@ -66,6 +61,11 @@ from egomimic.models.hnet.scan_interface import (
 from egomimic.models.hnet.transformer_router import (
     PhaseSummaryRouter,
     PhaseSummaryRouterState,
+)
+from egomimic.models.hnet.register_interface import (
+    RegisterInterface,
+    RegisterTrunk,
+    RegisterTrunkState,
 )
 
 # --------------------------------------------------------------------------- #
@@ -679,9 +679,9 @@ class ChunkerStage(_BaseStage):
         #     params created, live-job requeue safe). Used only on the scan
         #     down-encoder / scan router respectively. ---
         encoder_layernorm: bool = False,  # ChunkScanEncoder post-GRU LayerNorm
-        router_n_layer: int = 1,  # ScanRouter MambaBlock-stack depth
-        router_use_block: bool = False,  # ScanRouter: wrap scan in MambaBlock(s)
-        router_has_mlp: bool = False,  # ScanRouter MambaBlock: add SwiGLU MLP
+        router_n_layer: int = 1,          # ScanRouter MambaBlock-stack depth
+        router_use_block: bool = False,   # ScanRouter: wrap scan in MambaBlock(s)
+        router_has_mlp: bool = False,     # ScanRouter MambaBlock: add SwiGLU MLP
         router_mlp_dim: Optional[int] = None,  # SwiGLU width (None -> d_model)
         # --- PhaseSummaryRouter ("transformer" / PSER) knobs. Used ONLY when
         #     router_interface == "transformer"; ignored otherwise so existing
@@ -852,8 +852,9 @@ class ChunkerStage(_BaseStage):
         # running state + m sub-latents, so the encoder must run whenever the
         # DOWN side is scan OR the UP side is spline. The register interface is
         # fused (own trunk) and bypasses scan/spline entirely.
-        self._needs_scan_encoder = chunk_interface != "register" and (
-            (down_interface == "scan") or (up_interface == "spline")
+        self._needs_scan_encoder = (
+            chunk_interface != "register"
+            and ((down_interface == "scan") or (up_interface == "spline"))
         )
         self.scan_down = (
             ChunkScanEncoder(
@@ -960,8 +961,7 @@ class ChunkerStage(_BaseStage):
             self.proj_in = None
             self.proj_out = (
                 nn.Linear(self.output_hidden_dim, self.input_hidden_dim)
-                if self.input_hidden_dim != self.output_hidden_dim
-                else None
+                if self.input_hidden_dim != self.output_hidden_dim else None
             )
         elif self.trunk_chunk_rate and self.register_interface is not None:
             # FIX 1: trunk runs at chunk-rate over the concat'd m sub-latents, so
@@ -988,11 +988,9 @@ class ChunkerStage(_BaseStage):
         self.residual_scale: float = 1.0
         # FIX 2: swappable residual mixer (out = mix(up, residual)).
         from egomimic.models.hnet.residual_mixer import build_residual_mixer
-
         self.residual_mixer_kind = str(residual_mixer)
         self.residual_mixer = build_residual_mixer(
-            residual_mixer, self.input_hidden_dim, **(residual_mixer_kwargs or {})
-        )
+            residual_mixer, self.input_hidden_dim, **(residual_mixer_kwargs or {}))
 
     @property
     def inner_working_dim(self) -> int:
@@ -1028,11 +1026,8 @@ class ChunkerStage(_BaseStage):
         return self._forward_padded(x, ctx)
 
     def _forward_padded(self, x: torch.Tensor, ctx: HNetContext) -> torch.Tensor:
-        if (
-            self.down_interface != "first_token"
-            or self.up_interface != "duplicate"
-            or self.router_interface != "cossim"
-        ):
+        if (self.down_interface != "first_token" or self.up_interface != "duplicate"
+                or self.router_interface != "cossim"):
             raise NotImplementedError(
                 "scan/spline/scan-router interfaces are implemented for PACKED "
                 "training only; padded forward not supported yet."
@@ -1110,7 +1105,9 @@ class ChunkerStage(_BaseStage):
 
         # --- REGISTER DOWN-ONLY encoder (chunker) + separate up/inner/router. --
         if self.down_interface == "register":
-            return self._forward_packed_register_down(x, ctx, cu, bpred, residual, cp)
+            return self._forward_packed_register_down(
+                x, ctx, cu, bpred, residual, cp
+            )
 
         # --- DOWN: produce the inner-stage input + (optionally) scan features. --
         h_tok = sub_latents = None
@@ -1150,12 +1147,12 @@ class ChunkerStage(_BaseStage):
             inner_sub = sub_latents.clone()
             inner_sub[:, -1] = inner_out
             up = self.spline_up(
-                inner_sub,  # (N, m, D_in)
-                h_tok,  # (T, D_in)
-                x,  # (T, D_in) outer query
+                inner_sub,            # (N, m, D_in)
+                h_tok,                # (T, D_in)
+                x,                    # (T, D_in) outer query
                 bpred.boundary_mask,
                 bpred.boundary_prob,
-                cu,  # TOKEN-space cu_seqlens
+                cu,                   # TOKEN-space cu_seqlens
                 causal_phase=cp,
             )
             # SplineUpsampler already applies the confidence gate c_t internally
@@ -1200,7 +1197,9 @@ class ChunkerStage(_BaseStage):
         runs as a single (L,L) attention. ``cp`` selects the prefix-causal member
         phase so this forward is directly comparable to the AR ``step`` (GATE-1).
         """
-        stream = self.register_interface(x, bpred.boundary_mask, cu, causal_phase=cp)
+        stream = self.register_interface(
+            x, bpred.boundary_mask, cu, causal_phase=cp
+        )
         trunk_out = self.register_trunk(stream)  # (L, D_in)
         up = trunk_out[stream.member_idx]  # (T, D_in) member outputs, token order
         # Confidence gate (mirrors SplineUpsampler / the plan): keeps the p_t
@@ -1266,9 +1265,7 @@ class ChunkerStage(_BaseStage):
         if self.proj_out is not None:
             chunked = self.proj_out(chunked)
         if self.trunk_chunk_rate:
-            chunked = chunked.reshape(
-                -1, chunked.shape[-1] // m
-            )  # (N, m*D) -> (N*m, D)
+            chunked = chunked.reshape(-1, chunked.shape[-1] // m)  # (N, m*D) -> (N*m, D)
         inner_out = chunked  # (N*m, D_in)
         if self.up_interface == "spline":
             raise NotImplementedError(
@@ -1297,7 +1294,7 @@ class ChunkerStage(_BaseStage):
                 inner_sub,
                 bpred.boundary_mask,
                 bpred.boundary_prob,
-                cu,  # TOKEN-space cu_seqlens (phase machinery)
+                cu,                      # TOKEN-space cu_seqlens (phase machinery)
                 chunk_cu_seqlens=chunk_cu,  # CHUNK-space cu_seqlens (chunk-rate EMA)
                 causal_phase=cp,
             )
@@ -1349,11 +1346,8 @@ class ChunkerStage(_BaseStage):
         # The scan/spline AR orchestration is required iff the DOWN or UP
         # interface is scan/spline. The router choice (cossim|scan|transformer)
         # is orthogonal — any router can drive either down/up path.
-        is_scan = (
-            self.down_interface == "scan"
-            or self.up_interface == "spline"
-            or self.router_interface == "scan"
-        )
+        is_scan = (self.down_interface == "scan" or self.up_interface == "spline"
+                   or self.router_interface == "scan")
         if is_scan:
             return self._step_scan(x, ctx, state)
         return self._step_first_token(x, ctx, state)
@@ -1368,9 +1362,8 @@ class ChunkerStage(_BaseStage):
         is_start = torch.isin(pos, cu[:-1])
         # first chunk of each sequence has no prev -> this stage's learned no_prev
         # token (per-emb: each embodiment's ChunkerStage owns its own no_prev).
-        prev_end = torch.where(
-            is_start.unsqueeze(-1), self.no_prev.to(prev_end.dtype), prev_end
-        )
+        prev_end = torch.where(is_start.unsqueeze(-1),
+                               self.no_prev.to(prev_end.dtype), prev_end)
         cat = torch.cat([chunked, prev_end], dim=-1).float()
         return self.prev_end_combine(cat).to(chunked.dtype)
 
@@ -1381,11 +1374,9 @@ class ChunkerStage(_BaseStage):
         inner_in = self.chunk_layer.step(x, bpred.boundary_mask)
         if self.grab_prev_end:
             if inner_in.shape[0] > 0:
-                prev_end = (
-                    state.prev_x[bpred.boundary_mask]
-                    if state.prev_x is not None
-                    else self.no_prev.to(inner_in.dtype).expand_as(inner_in)
-                )
+                prev_end = (state.prev_x[bpred.boundary_mask]
+                            if state.prev_x is not None
+                            else self.no_prev.to(inner_in.dtype).expand_as(inner_in))
                 cat = torch.cat([inner_in, prev_end], dim=-1).float()
                 inner_in = self.prev_end_combine(cat).to(x.dtype)  # concat -> trunk dim
             state.prev_x = x  # update for next step (every step, boundary or not)
@@ -1567,7 +1558,7 @@ class ChunkerStage(_BaseStage):
           * msublatent dechunker decodes x_t against the cached PREVIOUS chunk's
             basis + the prefix-causal phase; out = residual_mixer(up, residual).
         x may be (B,1,D) or (B,D); returns (B,1,D)."""
-        x_t = x.squeeze(1) if x.dim() == 3 else x  # (B, D_in)
+        x_t = x.squeeze(1) if x.dim() == 3 else x          # (B, D_in)
         B = x_t.shape[0]
         residual = self.residual_scale * self.residual_proj(x_t.float())  # (B, D_in)
         m = self.register_interface.m
@@ -1575,44 +1566,39 @@ class ChunkerStage(_BaseStage):
         mstate = state.msublatent_state
 
         bpred = self._router.step(x_t, state.routing_state)
-        boundary_t = bpred.boundary_mask  # (B,)
-        boundary_prob_t = bpred.boundary_prob  # (B, 2)
+        boundary_t = bpred.boundary_mask                   # (B,)
+        boundary_prob_t = bpred.boundary_prob              # (B, 2)
 
         # --- finalize the just-completed chunk (returns its post-trunk m reps) ---
         finished_mask = boundary_t & (rstate.mem_fill > 0)
         reg_reps = self.register_trunk.finalize_chunk(
             rstate, finished_mask, self.register_interface
-        )  # (B, m, D_in)
+        )                                                  # (B, m, D_in)
 
         if bool(finished_mask.any()):
-            reg_sub = reg_reps  # (B, m, D_in)
+            reg_sub = reg_reps                             # (B, m, D_in)
             D_in = reg_sub.shape[-1]
             if self.trunk_chunk_rate:
                 # Fix-1: concat the m sub-latents -> one chunk token -> 1 inner step.
                 inner_out = self._inner_step_rows(
                     reg_sub.reshape(B, m * D_in), ctx, state, finished_mask
-                )  # (B, m*D_in)
+                )                                          # (B, m*D_in)
                 inner_sub = inner_out.reshape(B, m, D_in)
             else:
                 # pre-Fix-1: inner stage at REGISTER rate -- the m registers run
                 # one-by-one (causal over the register stream / inner KV cache).
-                inner_sub = torch.stack(
-                    [
-                        self._inner_step_rows(reg_sub[:, j], ctx, state, finished_mask)
-                        for j in range(m)
-                    ],
-                    dim=1,
-                )  # (B, m, D_in)
+                inner_sub = torch.stack([
+                    self._inner_step_rows(reg_sub[:, j], ctx, state, finished_mask)
+                    for j in range(m)
+                ], dim=1)                                  # (B, m, D_in)
             inner_sub = torch.where(
                 finished_mask.view(B, 1, 1), inner_sub.to(reg_sub.dtype), reg_sub
             )
             # chunk-rate EMA + promote as the upcoming chunk's msublatent basis.
-            self.msublatent_up.update_prev(
-                mstate, inner_sub, boundary_prob_t, finished_mask
-            )
+            self.msublatent_up.update_prev(mstate, inner_sub, boundary_prob_t, finished_mask)
 
         # --- DOWN: emit x_t into the (reset) open chunk; trunk_out discarded. ---
-        offset = rstate.mem_fill  # (B,)
+        offset = rstate.mem_fill                           # (B,)
         mem_emb = self.register_interface.member_embed_from_offset(x_t, offset)
         _ = self.register_trunk.step_member(mem_emb, rstate, m)
         rstate.offset = rstate.mem_fill
@@ -1622,13 +1608,11 @@ class ChunkerStage(_BaseStage):
         up = self.msublatent_up.step(boundary_t, boundary_prob_t, mstate)  # (B, D_in)
         out = self.residual_mixer(up.float(), residual).to(x_t.dtype)
 
-        ctx.register_aux(
-            {
-                "bpred": bpred,
-                "target_ratio": self.target_compression_ratio,
-                "weight": self.ratio_loss_weight,
-            }
-        )
+        ctx.register_aux({
+            "bpred": bpred,
+            "target_ratio": self.target_compression_ratio,
+            "weight": self.ratio_loss_weight,
+        })
         return out.unsqueeze(1)
 
     def _inner_step_rows(self, inner_in, ctx, state, finished_mask):

--- a/egomimic/models/hnet/stages.py
+++ b/egomimic/models/hnet/stages.py
@@ -735,10 +735,18 @@ class ChunkerStage(_BaseStage):
         #     replacing additive `up + residual`. "additive" (default = current)
         #     | "mlp" | "attn"; mlp/attn start ~= additive. See residual_mixer.py.
         residual_mixer: str = "additive",
+        # extra kwargs forwarded to the mixer ctor (e.g. {n_layers: 4,
+        # hidden_mult: 4.0} for mlp). Empty = the mixer's own defaults.
+        residual_mixer_kwargs: dict | None = None,
         # first_token chunker: also fold in the PREVIOUS chunk's end token (the
         # token just before each boundary) via a zero-init proj (starts as
         # first-token-only). Causal; gives the high-level each chunk's start+end.
         grab_prev_end: bool = False,
+        # Depth of the prev_end_combine downsampler MLP (used ONLY when
+        # grab_prev_end is True). DEFAULT 3 reproduces the original hardcoded
+        # 3-Linear MLP exactly (byte-identical params). n_layers=4 adds one
+        # extra hidden Linear+GELU.
+        prev_end_combine_n_layers: int = 3,
     ):
         super().__init__(input_hidden_dim, output_hidden_dim, cond_key=cond_key)
         self.target_compression_ratio = float(target_compression_ratio)
@@ -836,6 +844,7 @@ class ChunkerStage(_BaseStage):
         # below -- it REPLACES proj_in (2*input -> trunk dim), preserving both
         # boundary tokens instead of summing them (no info-lossy add).
         self.grab_prev_end = bool(grab_prev_end)
+        self.prev_end_combine_n_layers = int(prev_end_combine_n_layers)
         if self.grab_prev_end and down_interface != "first_token":
             raise ValueError("grab_prev_end requires down_interface='first_token'")
 
@@ -932,13 +941,18 @@ class ChunkerStage(_BaseStage):
             # (= trunk dim). REPLACES proj_in: the combine IS the bridge, so both
             # boundary tokens are preserved (no info-lossy sum). proj_out stays.
             _h = 2 * self.input_hidden_dim
-            self.prev_end_combine = nn.Sequential(
-                nn.Linear(2 * self.input_hidden_dim, _h),
-                nn.GELU(),
-                nn.Linear(_h, _h),
-                nn.GELU(),
-                nn.Linear(_h, self.output_hidden_dim),
-            )
+            # Configurable-depth MLP. n_layers counts Linear layers:
+            #   first Linear(2*input -> _h) + GELU,
+            #   (n_layers - 2) x [Linear(_h -> _h) + GELU],
+            #   final Linear(_h -> output).
+            # n_layers=3 reproduces the original 3-Linear MLP exactly.
+            _n = self.prev_end_combine_n_layers
+            assert _n >= 2, f"prev_end_combine_n_layers must be >= 2, got {_n}"
+            _layers = [nn.Linear(2 * self.input_hidden_dim, _h), nn.GELU()]
+            for _ in range(_n - 2):
+                _layers += [nn.Linear(_h, _h), nn.GELU()]
+            _layers += [nn.Linear(_h, self.output_hidden_dim)]
+            self.prev_end_combine = nn.Sequential(*_layers)
             # Learned "no previous chunk" token: fed as the prev-end half for the
             # first chunk of a sequence (instead of zeros) -> unambiguous BOS-like
             # signal the MLP can key on.
@@ -977,7 +991,7 @@ class ChunkerStage(_BaseStage):
 
         self.residual_mixer_kind = str(residual_mixer)
         self.residual_mixer = build_residual_mixer(
-            residual_mixer, self.input_hidden_dim
+            residual_mixer, self.input_hidden_dim, **(residual_mixer_kwargs or {})
         )
 
     @property

--- a/egomimic/models/hnet/transformer_router.py
+++ b/egomimic/models/hnet/transformer_router.py
@@ -1,0 +1,479 @@
+"""
+Phase-Summary Boundary Router ("PSER") for the H-Net dynamic-chunking model.
+
+A drop-in alternative to ``scan_interface.ScanRouter`` / ``routing.RoutingModule``
+(packed mode) that decides boundaries from a *causal Transformer* summary of the
+stream so far plus a *hard-reset running segment summary* and a *duration prior*:
+
+    u_t   = W_in(x_t)                                   (linear embed -> d_model)
+    h     = R(u)                                        (depth causal xformer layers)
+    h_t  := LayerNorm(h_t)                              (prenorm before any head)
+    r_{t-1} = mean{ h_j : last_cut < j <= t-1 }         (HARD-RESET segment summary)
+    tau_t = t - last_cut                                (segment dwell time)
+    ell_t = MLP([h_t; r; h_t-r; h_t*r]) + w_l*g_dwell(tau_t)   (variant "pser")
+          = MLP(h_t)                                            (variant "prefix_global")
+    p_t   = sigmoid(ell_t / T_temp)
+    p_t  <- 0  where tau_t < L_min                      (min-length mask; pser ONLY)
+    p_t  <- 1  at every subseq start                    (forced boundary, contract)
+    b_t   = 1[p_t > 0.5]                                (STE-hard forward decision)
+
+Returns a ``RoutingModuleOutput`` (boundary_prob (T,2), boundary_mask (T,),
+selected_probs (T,1)) so everything downstream (STE, ratio loss, confidence) is
+unchanged. Mirrors ScanRouter's (forward, step, allocate_inference_cache) and the
+ScanRouterState dataclass shape.
+
+VARIANT ``prefix_global`` (the one we run) is FULLY PARALLEL: ``ell_t = MLP(h_t)``
+depends only on the per-token ``h_t`` (no segment summary, no dwell, no b0), and
+there is NO L_min — so boundaries = ``sigmoid(MLP(h)/T_temp) > 0.5`` + forced
+subseq-starts, computed in ONE GPU pass (``_forward_prefix_global``), exactly like
+the upstream cos-sim ``RoutingModule``. No scan, no per-token ``.item()``.
+
+THE PARALLEL-SCAN CAUSALITY INVARIANT below applies to variant ``pser`` ONLY:
+``b_k`` and ``tau_{k+1}`` / the segment reset all depend on ``b_k``, so there is
+ONE genuine left-to-right dependency (the segmentation cannot be parallelized —
+exactly as in the EMA / scan-router path). We resolve it identically:
+
+  1. compute ``h`` FULLY in parallel (the causal transformer);
+  2. then ONE segmented left-to-right pass that, at each token k, reads ``p_k``
+     from the SAME ``ell_k = MLP(...) + w_l*g_dwell(tau_k)`` that ``step`` uses,
+     thresholds to ``b_k``, and updates segment-id / tau / running-mean.
+
+The cut decision thresholds on the IDENTICAL ``ell`` that ``step`` produces (the
+``_logit`` core is shared verbatim). Thresholding before adding dwell, or using a
+stale tau, would make TF and AR diverge and GATE-1 fail.
+
+Gradient flows through the ``h_j`` values that build ``r`` (pser) and through the
+MLP; the segment IDs (the reset *structure*) are detached — only the membership is
+non-differentiable, the summed values are not.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .blocks import IsotropicInferenceParams, KVCache, MultiHeadAttention, RMSNorm
+from .routing import RoutingModuleOutput, get_seq_idx
+
+
+# --------------------------------------------------------------------------- #
+# Duration prior.
+# --------------------------------------------------------------------------- #
+
+
+def _g_dwell(
+    tau: torch.Tensor,
+    target_len: float,
+    L_min: int,
+    sigma: float = 0.5,
+    floor: float = -30.0,
+) -> torch.Tensor:
+    """Log-normal-shaped dwell bonus on the boundary logit.
+
+    Very negative for ``tau < L_min`` (a cut there is hard-masked anyway, but the
+    prior also discourages it softly); peaks near the target chunk length
+    ``N = 1/target_rate`` and decays for longer dwell. Shape (matches ``tau``).
+
+    g(tau) = -((log tau - log N)^2) / (2 sigma^2),  with g(tau<L_min) = floor.
+
+    The peak (==0) sits at tau==N; it is a *relative* bonus (a constant offset is
+    absorbed by ``b0``). ``floor`` keeps the pre-L_min region finite for autograd.
+    """
+    tau_f = tau.float()
+    logN = math.log(max(float(target_len), 1.0))
+    safe_tau = tau_f.clamp(min=1.0)
+    g = -((safe_tau.log() - logN) ** 2) / (2.0 * sigma * sigma)
+    g = torch.where(tau_f < float(L_min), tau_f.new_full((), floor), g)
+    return g
+
+
+# --------------------------------------------------------------------------- #
+# AR state (mirrors ScanRouterState).
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class PhaseSummaryRouterState:
+    """AR state for ``PhaseSummaryRouter`` (mirror of ``ScanRouterState``).
+
+    ``has_seen_tokens`` forces a boundary on the first step of each episode
+    (subseq start), matching the packed forward's ``p[cu_seqlens[:-1]] = 1``.
+    ``kv`` is one ``KVCache`` per causal-attention layer (RoPE applied at the
+    running position ``t_idx``). ``seg_sum`` / ``seg_count`` accumulate the
+    hard-reset running mean ``r`` of the post-LayerNorm ``h`` within the OPEN
+    segment; ``last_cut_pos`` / ``t_idx`` drive ``tau``.
+    """
+
+    has_seen_tokens: torch.Tensor  # (B,) bool
+    kv: List[KVCache]              # per-layer KV caches
+    last_cut_pos: torch.Tensor    # (B,) long — position of the current segment start
+    t_idx: torch.Tensor           # (B,) long — running token position within the subseq
+    seg_sum: torch.Tensor         # (B, d_model) sum of h over the open segment
+    seg_count: torch.Tensor       # (B,) long — # tokens in the open segment
+
+
+class PhaseSummaryRouter(nn.Module):
+    """Phase-summary boundary router. RoutingModuleOutput-compatible drop-in for
+    ScanRouter (packed mode). Every dimension is a constructor arg with a sane
+    default (build-for-the-future)."""
+
+    def __init__(
+        self,
+        d_model: int,
+        depth: int = 3,
+        n_heads: int = 4,
+        ff_mult: int = 4,
+        L_min: int = 2,
+        target_rate: float = 0.125,
+        T_temp: float = 1.0,
+        causal: bool = True,
+        variant: str = "pser",
+        rotary_emb_dim: Optional[int] = None,
+        rotary_emb_base: float = 10000.0,
+        mlp_hidden: int = 128,
+        w_l: float = 1.0,
+        dwell_sigma: float = 0.5,
+        residual_mlp_init_scale: float = 1e-3,
+        win_init_scale: float = 1e-2,
+        calibrate_b0: bool = True,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        fk = {"device": device, "dtype": dtype}
+        if variant not in ("pser", "prefix_global"):
+            raise ValueError(f"variant must be pser|prefix_global, got {variant}")
+        assert d_model % n_heads == 0, "d_model must be divisible by n_heads"
+        self.d_model = int(d_model)
+        self.depth = int(depth)
+        self.n_heads = int(n_heads)
+        self.L_min = int(L_min)
+        self.target_rate = float(target_rate)
+        self.target_len = 1.0 / max(self.target_rate, 1e-6)
+        self.T_temp = float(T_temp)
+        self.causal = bool(causal)
+        self.variant = variant
+        self.w_l = float(w_l)
+        self.dwell_sigma = float(dwell_sigma)
+        head_dim = d_model // n_heads
+        if rotary_emb_dim is None:
+            # Default: rotate the full head (even) — gives the AR KV path
+            # position awareness without extra config burden.
+            rotary_emb_dim = head_dim - (head_dim % 2)
+        self.rotary_emb_dim = int(rotary_emb_dim)
+
+        # 1. Linear embed to d_model.
+        self.W_in = nn.Linear(d_model, d_model, **fk)
+
+        # 2. ``depth`` causal Transformer layers (REUSE the repo attention block).
+        #    Pre-norm self-attn + GELU MLP, mirroring TransformerBlock's structure
+        #    but kept self-contained here so PSER owns its stack. Attention is the
+        #    repo's MultiHeadAttention with RoPE + KV-cache .step().
+        self.attn_norms = nn.ModuleList(
+            [RMSNorm(d_model) for _ in range(self.depth)]
+        )
+        self.attns = nn.ModuleList(
+            [
+                MultiHeadAttention(
+                    d_model,
+                    n_heads,
+                    causal=causal,
+                    dropout=0.0,
+                    rotary_emb_dim=self.rotary_emb_dim,
+                    rotary_emb_base=rotary_emb_base,
+                )
+                for _ in range(self.depth)
+            ]
+        )
+        self.mlp_norms = nn.ModuleList(
+            [RMSNorm(d_model) for _ in range(self.depth)]
+        )
+        ff_dim = int(ff_mult * d_model)
+        self.mlps = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(d_model, ff_dim, **fk),
+                    nn.GELU(),
+                    nn.Linear(ff_dim, d_model, **fk),
+                )
+                for _ in range(self.depth)
+            ]
+        )
+        # Per-token prenorm before the head (mirrors the scan_interface prenorm
+        # fix that stopped grad spikes).
+        self.head_norm = nn.LayerNorm(d_model, **fk)
+
+        # 5. LOGIT MLP. pser: [h; r; h-r; h*r] -> 4*d_model. prefix_global: [h].
+        feat_dim = 4 * d_model if variant == "pser" else d_model
+        self.logit_mlp = nn.Sequential(
+            nn.Linear(feat_dim, mlp_hidden, **fk),
+            nn.GELU(),
+            nn.Linear(mlp_hidden, 1, **fk),
+        )
+        # INIT: residual MLP final layer ~0 + small W_in so the boundary logit is
+        # near 0 early → p_t ~ 0.5 uniformly, exactly like the upstream cos-sim
+        # router at init (random projections → cos_sim~0 → prob~0.5). No
+        # target-rate bias: the ratio loss drives the boundary rate to target.
+        # The MLP's own final-layer bias is the only additive offset, learned.
+        with torch.no_grad():
+            self.logit_mlp[-1].weight.mul_(residual_mlp_init_scale)
+            self.logit_mlp[-1].bias.zero_()
+            self.logit_mlp[0].weight.mul_(residual_mlp_init_scale)
+            self.W_in.weight.mul_(win_init_scale)
+            self.W_in.bias.zero_()
+
+    # ------------------------------------------------------------------ #
+    # Shared logit core (TF parallel pass AND AR step read THIS exact fn).
+    # ------------------------------------------------------------------ #
+
+    def _logit(self, h: torch.Tensor, r: torch.Tensor, tau: torch.Tensor) -> torch.Tensor:
+        """ell from post-LayerNorm h, running segment summary r (= h's mean over
+        the open segment, BEFORE the current token), and dwell tau.
+
+        h, r: (..., d_model). tau: (...). Returns (...,) logit (pre-sigmoid,
+        pre-temperature, pre-b0 are folded in here so callers just sigmoid)."""
+        if self.variant == "pser":
+            feat = torch.cat([h, r, h - r, h * r], dim=-1)
+        else:  # prefix_global
+            feat = h
+        ell = self.logit_mlp(feat).squeeze(-1)
+        if self.variant == "pser":
+            g = _g_dwell(tau, self.target_len, self.L_min, sigma=self.dwell_sigma)
+            ell = ell + self.w_l * g
+        return ell / self.T_temp
+
+    def _encode(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        """Run W_in + ``depth`` causal transformer layers + head LayerNorm.
+        Returns post-LayerNorm h, (T, d_model)."""
+        x = self.W_in(hidden_states)
+        for i in range(self.depth):
+            x = x + self.attns[i](
+                self.attn_norms[i](x), cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+            x = x + self.mlps[i](self.mlp_norms[i](x))
+        return self.head_norm(x)
+
+    # ------------------------------------------------------------------ #
+    # Teacher-forced packed forward.
+    # ------------------------------------------------------------------ #
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        inference_params=None,
+    ) -> RoutingModuleOutput:
+        assert cu_seqlens is not None, "PhaseSummaryRouter implements packed mode only"
+        assert inference_params is None, "packed mode takes no inference_params"
+        device = hidden_states.device
+        T = hidden_states.shape[0]
+        D = self.d_model
+        max_seqlen = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
+        h = self._encode(hidden_states, cu_seqlens, max_seqlen)  # (T, D)
+
+        # prefix_global: ell_t = MLP(h_t) is purely PER-TOKEN — no segment
+        # summary, and (since L_min was dropped) no min-length constraint — so
+        # boundaries compute in ONE parallel GPU pass, exactly like the upstream
+        # cos-sim RoutingModule (threshold + forced-start scatter + argmax). No
+        # CPU, no .item(), fully torch.compile / CUDA-graph friendly.
+        if self.variant == "prefix_global":
+            return self._forward_prefix_global(h, cu_seqlens)
+
+        # ---- pser variant ONLY past here: genuine left-to-right segment
+        # recurrence (ell depends on the running segment mean r), so it cannot be
+        # parallelized; kept as the eager loop. (We run prefix_global.) ----
+        seq_id = get_seq_idx(cu_seqlens)  # (T,)
+        starts = set(int(s) for s in cu_seqlens[:-1].tolist())
+
+        # ONE segmented left-to-right pass. The segmentation is data-dependent
+        # (b_k feeds tau_{k+1} and the reset), so this recurrence is genuinely
+        # sequential — exactly as the scan/EMA path. h is already parallel; this
+        # loop only does scalar/vector bookkeeping + the shared _logit core.
+        p = torch.empty(T, device=device, dtype=h.dtype)
+        seg_sum = h.new_zeros(D)
+        seg_count = 0
+        last_cut = 0
+        for k in range(T):
+            if k in starts:
+                # Forced boundary at subseq start: open a fresh segment AT k.
+                seg_sum = h[k]
+                seg_count = 1
+                last_cut = k
+                p[k] = 1.0
+                continue
+            # r_{k-1}: mean of h over the OPEN segment (last_cut < j <= k-1).
+            # Detach the count/structure; gradient flows through seg_sum values.
+            if seg_count > 0:
+                r = seg_sum / float(seg_count)
+            else:
+                r = torch.zeros_like(h[k])
+            tau = torch.tensor(float(k - last_cut), device=device)
+            ell = self._logit(h[k], r, tau)
+            p_k = torch.sigmoid(ell)
+            # HARD MASK: p<-0 where tau < L_min (cannot cut before min length).
+            if (k - last_cut) < self.L_min:
+                p_k = p_k * 0.0
+            p[k] = p_k
+            b_k = bool(p_k.item() > 0.5)
+            if b_k:
+                seg_sum = h[k]
+                seg_count = 1
+                last_cut = k
+            else:
+                seg_sum = seg_sum + h[k]
+                seg_count += 1
+
+        boundary_prob = torch.stack((1 - p, p), dim=-1)  # (T, 2)
+        selected_idx = torch.argmax(boundary_prob, dim=-1)
+        boundary_mask = selected_idx == 1
+        selected_probs = boundary_prob.gather(-1, selected_idx.unsqueeze(-1))
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_mask,
+            selected_probs=selected_probs,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Parallel TF forward for variant="prefix_global" (pure GPU, no L_min).
+    # ------------------------------------------------------------------ #
+
+    def _forward_prefix_global(
+        self,
+        h: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+    ) -> RoutingModuleOutput:
+        """Boundaries for variant='prefix_global', fully on the GPU.
+
+        ``ell_t = MLP(h_t)/T_temp`` is purely per-token (no segment summary, no
+        dwell, no b0 bias), so all probabilities compute in ONE batched op. With L_min
+        dropped there is no sequential min-length constraint left, so this exactly
+        mirrors the upstream ``RoutingModule._forward_packed``: threshold every
+        position + force a boundary at each subseq start via a scatter, then
+        argmax. No Python loop, no ``.item()`` per token, no host sync.
+
+        Grad: forced-start positions get a constant 1.0 (MLP grad severed there,
+        as in upstream); every other position carries the sigmoid(MLP) gradient.
+        """
+        ell = self.logit_mlp(h).squeeze(-1) / self.T_temp  # (T,)
+        p = torch.sigmoid(ell)                             # (T,)
+        # Force a boundary at the first token of every subseq (upstream parity:
+        # ``boundary_prob[cu_seqlens[:-1]] = 1.0``). Clone first so the in-place
+        # scatter is autograd-safe.
+        p = p.clone()
+        p[cu_seqlens[:-1]] = 1.0
+        boundary_prob = torch.stack((1 - p, p), dim=-1)  # (T, 2)
+        selected_idx = torch.argmax(boundary_prob, dim=-1)
+        boundary_mask = selected_idx == 1
+        selected_probs = boundary_prob.gather(-1, selected_idx.unsqueeze(-1))
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_mask,
+            selected_probs=selected_probs,
+        )
+
+    # ------------------------------------------------------------------ #
+    # AR inference.
+    # ------------------------------------------------------------------ #
+
+    def allocate_inference_cache(self, batch_size, device, dtype=None, T_max=None):
+        if T_max is None:
+            raise ValueError(
+                "PhaseSummaryRouter.allocate_inference_cache needs T_max (the KV "
+                "cache length). ChunkerStage passes max_seqlen through."
+            )
+        if not self.causal:
+            raise AssertionError(
+                "PhaseSummaryRouter.step is only supported for causal=True; the "
+                "causal=False arm is a training/TF-only bidirectional ABLATION "
+                "(see module docstring)."
+            )
+        kv = [
+            self.attns[i].allocate_inference_cache(
+                batch_size, int(T_max), device, dtype
+            )
+            for i in range(self.depth)
+        ]
+        return PhaseSummaryRouterState(
+            has_seen_tokens=torch.zeros(batch_size, device=device, dtype=torch.bool),
+            kv=kv,
+            last_cut_pos=torch.zeros(batch_size, device=device, dtype=torch.long),
+            t_idx=torch.zeros(batch_size, device=device, dtype=torch.long),
+            seg_sum=torch.zeros(batch_size, self.d_model, device=device, dtype=dtype),
+            seg_count=torch.zeros(batch_size, device=device, dtype=torch.long),
+        )
+
+    def _encode_step(self, x_t: torch.Tensor, state: PhaseSummaryRouterState) -> torch.Tensor:
+        """One AR token through W_in + causal layers (KV-cache) + head LayerNorm.
+        x_t: (B, D). Returns post-LayerNorm h_t (B, D). RoPE is applied inside
+        each attention at the per-row position ``cache.offsets`` (== t_idx)."""
+        x = self.W_in(x_t).unsqueeze(1)  # (B, 1, D)
+        for i in range(self.depth):
+            h = self.attn_norms[i](x)
+            x = x + self.attns[i].step(h, state.kv[i])  # KVCache scatter + masked attn
+            x = x + self.mlps[i](self.mlp_norms[i](x))
+        return self.head_norm(x.squeeze(1))  # (B, D)
+
+    def step(self, x_t: torch.Tensor, state: PhaseSummaryRouterState) -> RoutingModuleOutput:
+        """One AR step. ``x_t``: (B, 1, D) or (B, D). Returns a per-batch
+        RoutingModuleOutput. Boundary forced True on the first step of each
+        episode (``has_seen_tokens`` False). Reads p_t from the SAME ``_logit``
+        core as the TF forward so GATE-1 (TF=AR) holds exactly."""
+        if not self.causal:
+            raise AssertionError(
+                "PhaseSummaryRouter.step requires causal=True (causal=False is a "
+                "TF-only bidirectional ablation)."
+            )
+        if x_t.dim() == 3:
+            x_t = x_t.squeeze(1)
+        B = x_t.shape[0]
+        h_t = self._encode_step(x_t, state)  # (B, D)
+
+        # r = running mean of the OPEN segment BEFORE this token; 0 if empty
+        # (first-of-segment) so the residual ~ 0 there.
+        cnt = state.seg_count.clamp(min=1).unsqueeze(-1).to(h_t.dtype)
+        r = state.seg_sum / cnt
+        r = torch.where(state.seg_count.unsqueeze(-1) > 0, r, torch.zeros_like(r))
+
+        tau = (state.t_idx - state.last_cut_pos).to(h_t.dtype)  # (B,)
+        ell = self._logit(h_t, r, tau)  # (B,)
+        p = torch.sigmoid(ell)
+        # HARD MASK: p<-0 where tau < L_min. pser ONLY — prefix_global dropped
+        # L_min in the TF forward, so skip it here too to keep GATE-1 (TF=AR).
+        if self.variant == "pser":
+            p = torch.where(tau < float(self.L_min), torch.zeros_like(p), p)
+        # Force p=1 at the first token of each episode (subseq start).
+        p = torch.where(state.has_seen_tokens, p, torch.ones_like(p))
+
+        b_t = p > 0.5  # (B,) STE-hard decision
+
+        # UPDATE accumulators (mirror the TF segmented pass exactly).
+        #   boundary fired  -> open a fresh segment AT this token: seg=h_t, cnt=1,
+        #                       last_cut = t_idx.
+        #   no boundary     -> append h_t to the open segment.
+        state.seg_sum = torch.where(b_t.unsqueeze(-1), h_t, state.seg_sum + h_t)
+        state.seg_count = torch.where(
+            b_t, torch.ones_like(state.seg_count), state.seg_count + 1
+        )
+        state.last_cut_pos = torch.where(b_t, state.t_idx, state.last_cut_pos)
+        state.t_idx = state.t_idx + 1
+        state.has_seen_tokens.fill_(True)
+
+        boundary_prob = torch.stack((1 - p, p), dim=-1)  # (B, 2)
+        boundary_mask = boundary_prob[..., 1] > 0.5
+        selected_probs = boundary_prob.max(dim=-1).values.unsqueeze(-1)
+        return RoutingModuleOutput(
+            boundary_prob=boundary_prob,
+            boundary_mask=boundary_mask,
+            selected_probs=selected_probs,
+        )

--- a/egomimic/models/stems/dino_core.py
+++ b/egomimic/models/stems/dino_core.py
@@ -1,0 +1,123 @@
+"""DINO (v2/v3) visual encoder, a DROP-IN for ``VisualCore`` — same shape contract
+``(..., C, H, W) -> (..., feature_dimension)`` so the H-Net trunk is untouched; only
+the ``_target_`` in the obs-encoder config changes.
+
+Design (confirmed by the 2026-06-24 encoder sweep): interpolate input -> ``image_size``
+(DINO/14|16 wants >=224, not 96), ImageNet-normalize, take the FROZEN backbone's patch
+tokens and pool them on a SPATIAL grid (``feature='grid7'`` -> 7x7), flatten, then
+``Linear(g*g*dino_dim -> feature_dimension) + LayerNorm`` to the trunk width. The sweep
+showed spatial-grid features ~HALVE object orient/pos error vs mean-pool (mean-pool is
+the worst mode), so grid is the default. Freeze by default: cheap, and it preserves the
+frozen-encoder property the exact-logp PPO pipeline relies on (features can be cached).
+
+DINOv3 weights are loaded by PATH (the torch-hub entrypoint needs ``weights=<.pth>``;
+``pretrained=True`` only works for v2). Ungated mirror weights live under
+``~/.cache/dinov3_weights/`` (see ``V3W``). To use v3: hub_repo='facebookresearch/dinov3',
+model_name='dinov3_vitl16' (or vitb16/vits16), image_size a multiple of 16 (224).
+"""
+from __future__ import annotations
+import os
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# Ungated DINOv3 weight files (downloaded from the Fanqi-Lin-IR mirror). Keyed by
+# torch-hub model name; the v3 entrypoint takes these via ``weights=``.
+V3W = {
+    "dinov3_vits16": "~/.cache/dinov3_weights/dinov3_vits16_pretrain.pth",
+    "dinov3_vitb16": "~/.cache/dinov3_weights/dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth",
+    "dinov3_vitl16": "~/.cache/dinov3_weights/dinov3_vitl16_pretrain_lvd1689m-8aa4cbdd.pth",
+}
+
+
+def _load_dino(hub_repo: str, model_name: str, weights_path: str = ""):
+    """Load a DINO backbone, preferring the local torch-hub cache so it works on
+    offline compute nodes; fall back to the normal github fetch. DINOv3 is loaded by
+    weight path; DINOv2 via ``pretrained=True``."""
+    cached = os.path.join(torch.hub.get_dir(), hub_repo.replace("/", "_") + "_main")
+    src = "local" if os.path.isdir(cached) else "github"
+    repo = cached if src == "local" else hub_repo
+    if "dinov3" in model_name:
+        w = weights_path or V3W.get(model_name, "")
+        assert w, f"no DINOv3 weights path for {model_name}"
+        return torch.hub.load(repo, model_name, source=src,
+                              weights=os.path.expanduser(w), verbose=False)
+    return torch.hub.load(repo, model_name, source=src, pretrained=True, verbose=False)
+
+
+class DinoVisualCore(nn.Module):
+    """Frozen DINO spatial-grid encoder. Output: (..., feature_dimension)."""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        image_size: int = 224,
+        feature_dimension: int = 96,
+        hub_repo: str = "facebookresearch/dinov3",
+        model_name: str = "dinov3_vitb16",
+        weights_path: str = "",            # DINOv3 .pth; defaults from V3W by model_name
+        freeze: bool = True,
+        feature: str = "grid7",            # grid<g> (spatial) | patch_mean | cls
+        unfreeze_last_n: int = 0,          # >0 -> fine-tune last N transformer blocks
+    ):
+        super().__init__()
+        assert in_channels == 3, "DINO expects 3-channel RGB"
+        assert feature in ("patch_mean", "cls") or feature.startswith("grid"), \
+            f"bad feature {feature}"
+        self.image_size = image_size
+        self.feature = feature
+        self.freeze = freeze and unfreeze_last_n == 0
+        self.embed_dim = feature_dimension          # matches VisualCore's output-dim attr
+
+        self.dino = _load_dino(hub_repo, model_name, weights_path)
+        dino_dim = self.dino.embed_dim
+        for p in self.dino.parameters():
+            p.requires_grad_(False)
+        if unfreeze_last_n > 0:
+            for blk in self.dino.blocks[-unfreeze_last_n:]:
+                for p in blk.parameters():
+                    p.requires_grad_(True)
+        if self.freeze:
+            self.dino.eval()
+
+        if feature.startswith("grid"):
+            self.grid = int(feature[4:])
+            proj_in = dino_dim * self.grid * self.grid
+        else:
+            self.grid = 0
+            proj_in = dino_dim
+        self.proj = nn.Sequential(nn.Linear(proj_in, feature_dimension),
+                                  nn.LayerNorm(feature_dimension))
+        self.register_buffer("mean", torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1))
+        self.register_buffer("std", torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        if self.freeze:                 # keep frozen backbone in eval (BN/dropout-free)
+            self.dino.eval()
+        return self
+
+    def _pool(self, out) -> torch.Tensor:
+        if self.feature == "cls":
+            return out["x_norm_clstoken"]
+        pt = out["x_norm_patchtokens"]                  # (B, N, D)
+        if self.feature == "patch_mean":
+            return pt.mean(1)
+        B, N, D = pt.shape                              # grid<g>: spatial avg-pool to g x g
+        s = int(round(N ** 0.5))
+        pt = pt.transpose(1, 2).reshape(B, D, s, s)
+        return F.adaptive_avg_pool2d(pt, self.grid).reshape(B, -1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (..., 3, H, W), RGB in [0, 1]
+        leading = x.shape[:-3]
+        x = x.reshape(-1, *x.shape[-3:])
+        if x.shape[-1] != self.image_size or x.shape[-2] != self.image_size:
+            x = F.interpolate(x, size=self.image_size, mode="bilinear", align_corners=False)
+        x = (x - self.mean) / self.std
+        ctx = torch.no_grad() if self.freeze else torch.enable_grad()
+        with ctx:
+            out = self.dino.forward_features(x)
+        feat = self.proj(self._pool(out))
+        return feat.reshape(*leading, self.embed_dim)

--- a/egomimic/models/stems/input_modules.py
+++ b/egomimic/models/stems/input_modules.py
@@ -18,7 +18,6 @@ double-counting.
 encoder (``MultiEmbodimentCondEncoder``) can route the obs to the right
 embodiment's encoder. Modules whose encoder is shared accept-and-ignore it.
 """
-
 from __future__ import annotations
 
 from typing import Optional
@@ -104,22 +103,12 @@ class ActionInToken(InputModule):
         return x
 
     def forward_packed(
-        self,
-        *,
-        actions_packed,
-        obs_packed,
-        cu_seqlens,
-        T_total,
-        device,
-        dtype,
+        self, *, actions_packed, obs_packed, cu_seqlens, T_total, device, dtype,
         embodiment_id=None,
     ):
         a_emb = self.action_in(actions_packed)  # (T_total, D)
         x_shifted = torch.cat(
-            [
-                torch.zeros(1, self.d_model, device=device, dtype=a_emb.dtype),
-                a_emb[:-1],
-            ],
+            [torch.zeros(1, self.d_model, device=device, dtype=a_emb.dtype), a_emb[:-1]],
             dim=0,
         )
         bos = self.bos.squeeze(0).squeeze(0).to(a_emb.dtype)  # (D,)
@@ -128,9 +117,7 @@ class ActionInToken(InputModule):
         x_shifted[starts] = bos
         return x_shifted
 
-    def step(
-        self, *, prev_action_norm, obs_norm, t, B, device, dtype, embodiment_id=None
-    ):
+    def step(self, *, prev_action_norm, obs_norm, t, B, device, dtype, embodiment_id=None):
         if t == 0 or prev_action_norm is None:
             return self.bos.expand(B, 1, self.d_model).to(dtype)
         return self.action_in(prev_action_norm).to(dtype)
@@ -180,14 +167,7 @@ class ObsToken(InputModule):
         return c.to(dtype)
 
     def forward_packed(
-        self,
-        *,
-        actions_packed,
-        obs_packed,
-        cu_seqlens,
-        T_total,
-        device,
-        dtype,
+        self, *, actions_packed, obs_packed, cu_seqlens, T_total, device, dtype,
         embodiment_id=None,
     ):
         obs_for_encode = {k: v.unsqueeze(0) for k, v in obs_packed.items()}
@@ -196,8 +176,6 @@ class ObsToken(InputModule):
         )  # (1, T_total, D)
         return c_padded.squeeze(0).to(dtype)
 
-    def step(
-        self, *, prev_action_norm, obs_norm, t, B, device, dtype, embodiment_id=None
-    ):
+    def step(self, *, prev_action_norm, obs_norm, t, B, device, dtype, embodiment_id=None):
         c_seq = self._encode(obs_norm, T_action=1, embodiment_id=embodiment_id)
         return c_seq.to(dtype)

--- a/egomimic/pl_utils/callbacks/ratio_loss_scheduler.py
+++ b/egomimic/pl_utils/callbacks/ratio_loss_scheduler.py
@@ -11,7 +11,6 @@ Epoch-based so "halfway through training" is robust to the exact steps/epoch.
 By default switches at ``switch_fraction * trainer.max_epochs``. Config-gated;
 compose via ``callbacks=[checkpoints, ratio_loss_scheduler]``.
 """
-
 from __future__ import annotations
 
 from typing import Optional
@@ -53,15 +52,10 @@ class RatioLossScheduler(pl.Callback):
             if isinstance(m, ChunkerStage):
                 m.ratio_loss_weight = value
                 n += 1
-        print(
-            f"[RatioLossScheduler] set ratio_loss_weight={value} on {n} ChunkerStage(s)",
-            flush=True,
-        )
+        print(f"[RatioLossScheduler] set ratio_loss_weight={value} on {n} ChunkerStage(s)", flush=True)
 
     def on_train_epoch_start(self, trainer, pl_module):
         sw = self._switch_epoch(trainer)
         value = self.on_value if int(trainer.current_epoch) < sw else self.off_value
         self._apply(pl_module, value)
-        pl_module.log(
-            self.log_key, float(value), on_step=False, on_epoch=True, prog_bar=False
-        )
+        pl_module.log(self.log_key, float(value), on_step=False, on_epoch=True, prog_bar=False)

--- a/egomimic/pl_utils/pl_model.py
+++ b/egomimic/pl_utils/pl_model.py
@@ -62,16 +62,13 @@ class ModelWrapper(LightningModule):
         # threads a mutable HNetContext + many .item()/dynamic packed shapes, so
         # compile will graph-break heavily; measure before trusting any speedup.
         import os
-
         if os.environ.get("EGO_COMPILE", "0") == "1":
             _mode = os.environ.get("EGO_COMPILE_MODE", "default")
             self.model.nets["outer_stage"] = torch.compile(
                 self.model.nets["outer_stage"], dynamic=True, mode=_mode
             )
             self.nets = self.model.nets
-            print(
-                f"[ModelWrapper] torch.compile(outer_stage, dynamic=True, mode={_mode}) ENABLED"
-            )
+            print(f"[ModelWrapper] torch.compile(outer_stage, dynamic=True, mode={_mode}) ENABLED")
         try:
             self.params = self.model.nets["policy"].params
         except Exception:
@@ -91,7 +88,9 @@ class ModelWrapper(LightningModule):
         cfg = self._as_config(config_tree)
         if cfg is not None and OmegaConf.select(cfg, "model") is not None:
             self.log_per_layer_grad_norms = bool(
-                OmegaConf.select(cfg, "model.log_per_layer_grad_norms", default=False)
+                OmegaConf.select(
+                    cfg, "model.log_per_layer_grad_norms", default=False
+                )
             )
 
         self.epoch_memory_stats = []  # Store memory stats per epoch

--- a/egomimic/pl_utils/pl_model.py
+++ b/egomimic/pl_utils/pl_model.py
@@ -56,12 +56,43 @@ class ModelWrapper(LightningModule):
         self.nets = (
             self.model.nets
         )  # to ensure the lightning module has access to the model's parameters
+        # Optional torch.compile of the heavy net (the HNetOuterStage that
+        # forward_training calls via the `outer_stage` property). Env-gated and
+        # default-off so all existing runs are byte-identical. NOTE: the H-Net
+        # threads a mutable HNetContext + many .item()/dynamic packed shapes, so
+        # compile will graph-break heavily; measure before trusting any speedup.
+        import os
+
+        if os.environ.get("EGO_COMPILE", "0") == "1":
+            _mode = os.environ.get("EGO_COMPILE_MODE", "default")
+            self.model.nets["outer_stage"] = torch.compile(
+                self.model.nets["outer_stage"], dynamic=True, mode=_mode
+            )
+            self.nets = self.model.nets
+            print(
+                f"[ModelWrapper] torch.compile(outer_stage, dynamic=True, mode={_mode}) ENABLED"
+            )
         try:
             self.params = self.model.nets["policy"].params
         except Exception:
             pass
         self.enable_grad_norm = enable_grad_norm
         self.grad_norm_history = deque(maxlen=self.grad_norm_mad_window)
+
+        # Optional PER-LEAF raw grad-norm logging. Gated by a model-config flag
+        # so default runs are byte-identical (no new columns, no extra compute).
+        # Read from the config tree the same way ``scheduler`` is, with a hard
+        # default of False. Enable via CLI/config override
+        # ``model.log_per_layer_grad_norms=true``. When on, logs one grad-norm
+        # per parameterized LEAF module (every nn.Linear / norm / conv /
+        # embedding / direct-param block) rather than a handful of coarse
+        # depth-collapsed groups.
+        self.log_per_layer_grad_norms = False
+        cfg = self._as_config(config_tree)
+        if cfg is not None and OmegaConf.select(cfg, "model") is not None:
+            self.log_per_layer_grad_norms = bool(
+                OmegaConf.select(cfg, "model.log_per_layer_grad_norms", default=False)
+            )
 
         self.epoch_memory_stats = []  # Store memory stats per epoch
         self.evaluator = evaluator
@@ -144,7 +175,62 @@ class ModelWrapper(LightningModule):
 
         return losses["action_loss"]
 
+    @staticmethod
+    def _grad_norm_group_key(name: str) -> str:
+        """Derive a PER-LEAF module-group key from a parameter name.
+
+        Robust to ANY arch: the key is simply the OWNING MODULE PATH, i.e. the
+        full dotted ``named_parameters`` path with the trailing tensor name
+        (``.weight`` / ``.bias`` / ``.A_log`` / ...) stripped. This yields one
+        group per parameterized leaf module -- every ``nn.Linear``,
+        ``LayerNorm`` / ``RMSNorm``, conv, embedding, and any module that owns
+        parameters directly -- so a leaf's weight + bias combine in quadrature
+        while siblings stay separate. No depth collapsing: the residual /
+        projection linears (taper ``proj_in`` / ``proj_out``, dechunker
+        ``w_v`` / ``w_h`` / ``w_o`` / gate-MLP / FiLM-MLP, router ``W_in`` +
+        head, every block's ``attn.{q,k,v,out}_proj`` + ``mlp.*``) each get
+        their own entry instead of being bucketed into one trunk group.
+        """
+        path = name.rsplit(".", 1)[0]  # drop trailing tensor name -> owning module
+        return path if path else name
+
+    def _log_per_layer_grad_norms(self):
+        """Log the L2 norm of each LEAF module's raw parameter grads.
+
+        Computed from ``.grad`` after backward and before any clipping, so it
+        mirrors ``policy_grad_norms_raw`` and reflects the raw per-leaf learning
+        signal. Iterates ``self.nets.named_parameters()`` (the policy's
+        ModuleDict — the canonical learnable-parameter tree, same source the
+        optimizer's ``parameter_groups`` walks), groups each param under its
+        owning leaf-module path, and logs the per-leaf norm under
+        ``Train/grad_norm/<full.module.path>``. The quadrature sum over ALL
+        per-leaf norms equals ``policy_grad_norms_raw``.
+        """
+        sq_sums: "OrderedDict[str, torch.Tensor]" = OrderedDict()
+        for name, p in self.nets.named_parameters():
+            if p.grad is None:
+                continue
+            key = self._grad_norm_group_key(name)
+            sq = p.grad.detach().pow(2).sum()
+            if key in sq_sums:
+                sq_sums[key] = sq_sums[key] + sq
+            else:
+                sq_sums[key] = sq
+        for key, sq in sq_sums.items():
+            self.log(
+                f"Train/grad_norm/{key}",
+                torch.sqrt(sq),
+                on_step=False,
+                on_epoch=True,
+                sync_dist=True,
+            )
+
     def on_after_backward(self):
+        # Per-layer raw grad norms are gated by their own flag and taken here
+        # (after backward, before any clipping) independent of the global
+        # grad-norm/MAD machinery below.
+        if self.log_per_layer_grad_norms:
+            self._log_per_layer_grad_norms()
         if not self.enable_grad_norm:
             return
         grad_norm = torch.nn.utils.clip_grad_norm_(

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -567,3 +567,4 @@ class NumpyToTensor(Transform):
                     f"NumpyToTensor expects key '{key}' to be a numpy array or torch tensor, got {type(batch[key])}"
                 )
         return batch
+

--- a/egomimic/trainHydra.py
+++ b/egomimic/trainHydra.py
@@ -22,6 +22,11 @@ from egomimic.pl_utils.logging_utils import log_hyperparameters
 from egomimic.utils.pylogger import RankedLogger
 from egomimic.pl_utils.utils import extras, task_wrapper
 
+# Gated TF32: NO-OP unless EGOMIMIC_TF32=1 in env. Enables TensorFloat-32 matmuls
+# (~1.5-2x on A40 tensor cores) without changing other experiments numerics.
+if os.environ.get("EGOMIMIC_TF32") == "1":
+    torch.set_float32_matmul_precision("high")
+
 OmegaConf.register_new_resolver("eval", eval)
 log = RankedLogger(__name__, rank_zero_only=True)
 
@@ -103,9 +108,26 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
 
     # Stats-only MultiDataset (no graph of its own; explicitly populated from
     # datamodule.train_datasets). MultiDataset now owns NormStats's role too.
+    _norm_mode = OmegaConf.select(cfg, "norm_stats.norm_mode", default="quantile")
+    # FIX #6: GMM action heads assume targets pre-normalized to [-1,1] (robomimic
+    # tanh on the mode means). norm_mode="quantile" (the yaml default — the
+    # "quantile trap") maps q1/q99 -> -1/+1, leaving ~2% tail actions OUTSIDE
+    # [-1,1] that the tanh'd means can never reach (see gmm_head.py header).
+    # minmax maps the FULL action range into [-1,+1]. Fail fast so a launch that
+    # forgets ``norm_stats.norm_mode=minmax`` can't silently train a broken GMM.
+    _head_type = OmegaConf.select(
+        cfg, "model.robomimic_model.outer_stage.action_head_type", default=None
+    )
+    if _head_type == "gmm" and _norm_mode != "minmax":
+        raise ValueError(
+            f"GMM action head requires norm_stats.norm_mode='minmax' (got "
+            f"'{_norm_mode}'). The quantile mapping leaves tail actions outside "
+            f"[-1,1] that the GMM tanh means cannot reach. Set "
+            f"norm_stats.norm_mode=minmax (launcher or config)."
+        )
     norm_stats = MultiDataset(
         state={},
-        norm_mode=OmegaConf.select(cfg, "norm_stats.norm_mode", default="quantile"),
+        norm_mode=_norm_mode,
     )
     norm_stats.populate_from_datasets(datamodule.train_datasets)
 
@@ -150,6 +172,7 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     log.info(f"Instantiating model <{cfg.model._target_}>")
     model: LightningModule = ModelWrapper(
         config_tree=_build_model_config_tree(cfg),
+        enable_grad_norm=cfg.model.get("enable_grad_norm", True),
         norm_stats_state=norm_stats.to_state(),
         scheduler_interval=cfg.model.get("scheduler_interval", "step"),
     )

--- a/goal_daemon_v2.sh
+++ b/goal_daemon_v2.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# v2: keep-alive for 3 tx (baseline7) + 4 hnet_ed (baseline8 encdec arch) cells until ep2000.
+# Detects a dead cell (metrics frozen > STALE AND no running/pending slurm job) and
+# resubmits it (launcher resumes from last.ckpt). Safeguards: per-cell cooldown,
+# resubmit cap, and controller-down skip (never blind-resubmit during a slurm outage).
+# Logs a status line every cycle. Exits once ALL cells have reached ep TARGET.
+cd /coc/flash7/paphiwetsa3/projects/EgoVerse-gmm
+CELLS="tx_bc_big tx_bc_small tx_cotrain hnet_ed2_cotrain hnet_b1_cotrain hnet_b3_cotrain hnet_b4_cotrain"
+TARGET=2000
+COOLDOWN=2400   # >=40 min between resubmits of the same cell
+MAXSUB=8        # give up a cell after this many resubmits (needs a human)
+STALE=1200      # metrics frozen >20 min => candidate dead
+declare -A LAST_SUB COUNT_SUB
+
+log(){ echo "$(date +%m-%d_%H:%M:%S) $*"; }
+
+submit_cell(){
+  # Recoveries go to overcap (broad scavenger capacity) + --requeue so a preemption
+  # auto-resumes via the launcher's ckpt-resume hook. hoffman-lab is saturated by our
+  # own 6 long-running cells, so recovery jobs pend there indefinitely.
+  sbatch --parsable \
+    --partition=overcap --account=overcap --qos=scavenger_qos --time=2-00:00:00 \
+    --nodes=1 --ntasks-per-node=3 --cpus-per-task=12 --mem=378G --gres=gpu:a40:3 \
+    --requeue --exclude=baymax,cyborg,ig-88,hk47 \
+    --job-name=indomain_c4_200m_v5_$1 \
+    --output=logs/slurm/v5_$1_%j.out \
+    $( [ "${1#hnet_}" != "$1" ] && echo hnet_ed_launch.sh || echo indomain_c4_200m_v5_launch.sh ) "$1"
+}
+
+log "GOAL_DAEMON start target=ep$TARGET pid=$$"
+for iter in $(seq 1 100000); do
+  now=$(date +%s)
+  free=$(df --output=avail -BG /coc/flash7 2>/dev/null | tail -1 | tr -dc '0-9')
+  alldone=1; line=""
+  for cell in $CELLS; do
+    csv=$(find logs/indomain_c4_200m_v5/${cell}_2026* -name metrics.csv -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2)
+    if [ -n "$csv" ]; then
+      mt=$(stat -c %Y "$csv" 2>/dev/null); age=$((now-mt))
+      ep=$(awk -F, 'NR==1{for(i=1;i<=NF;i++)if($i=="epoch")c=i} c&&NR>1&&$c~/^[0-9]/{e=$c} END{print e+0}' "$csv")
+    else ep=0; age=999999; fi
+    st="ok"
+    if [ "$ep" -ge "$TARGET" ]; then st="DONE"; else
+      alldone=0
+      if [ "$age" -gt "$STALE" ]; then
+        sq=$(squeue -h -n indomain_c4_200m_v5_${cell} -o "%T" 2>&1)
+        if echo "$sq" | grep -qiE "error|controller|invalid"; then st="sqdown_skip"
+        elif echo "$sq" | grep -qE "RUNNING|PENDING|CONFIGURING|COMPLETING"; then st="reviving"
+        else
+          last=${LAST_SUB[$cell]:-0}; cnt=${COUNT_SUB[$cell]:-0}
+          if [ "$cnt" -ge "$MAXSUB" ]; then st="GIVEUP@ep$ep"
+          elif [ $((now-last)) -gt "$COOLDOWN" ]; then
+            jid=$(submit_cell "$cell")
+            LAST_SUB[$cell]=$now; COUNT_SUB[$cell]=$((cnt+1))
+            st="RESUB#$((cnt+1))->$jid"
+            log "RECOVER $cell dead ep$ep age${age}s -> $jid (attempt $((cnt+1))/$MAXSUB)"
+          else st="dead_cooldown"; fi
+        fi
+      fi
+    fi
+    line="$line ${cell}:${ep}(${st})"
+  done
+  [ -n "$free" ] && [ "$free" -lt 60 ] && log "DISK_CRITICAL ${free}G — ENOSPC risk, consider scratch migration"
+  log "STATUS free=${free}G |$line"
+  [ "$alldone" -eq 1 ] && { log "ALL_REACHED_ep$TARGET — exiting"; break; }
+  sleep 600
+done

--- a/hnet_ed.sbatch
+++ b/hnet_ed.sbatch
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --account=hoffman-lab
+#SBATCH --partition=hoffman-lab
+#SBATCH --qos=long
+#SBATCH --time=7-00:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=3
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=378G
+#SBATCH --gres=gpu:a40:3
+#SBATCH --requeue
+#SBATCH --exclude=cyborg,ig-88,hk47
+#SBATCH --output=/coc/flash7/paphiwetsa3/projects/EgoVerse-gmm/logs/launcher_logs/%x_%j.out
+mkdir -p /coc/flash7/paphiwetsa3/projects/EgoVerse-gmm/logs/launcher_logs
+bash /coc/flash7/paphiwetsa3/projects/EgoVerse-gmm/hnet_ed_launch.sh "$1"

--- a/hnet_ed_launch.sh
+++ b/hnet_ed_launch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# 200M H-Net + Tx launcher (BASELINE v5). Relaunch of v2/v4 with the obs_stride bug fixed
+# in code (egomimic/algo/hnet/algo.py now defaults obs_stride to the GMM head chunk_len=4,
+# was silently 1). FRESH runs (cannot resume obs_stride=1 ckpts) under NEW name
+# indomain_c4_200m_v5 + wandb group indomain_c4_baseline8. Changes vs v2/v4:
+#   - 3-GPU DDP (gpus_per_node=3, ntasks-per-node=3)
+#   - per-GPU batch 11 -> global 33 (~2x the old 8/GPU x 2 = 16) via per-cell dataloader keys
+#   - limit_train_batches=1.0 (full pass, no 100-batch cap)
+#   - max_epochs=min_epochs=2500, ckpt+val every 25 (= 100/4)
+#   - num_workers=12 (was 8) on the dataloaders
+#   - scheduler max_steps/warmup_steps = <FILL FROM SMOKE: 100*B / round(0.05*100*B)>
+# obs_stride must resolve to 4 (verify in log). RatioLossScheduler (switch_fraction=0.35)
+# auto-scales off-epoch to round(0.35*max_epochs)=35 with max_epochs=2500 (no rescale needed).
+cd /coc/flash7/paphiwetsa3/projects/EgoVerse-gmm
+export PYTHONPATH=.
+export TORCH_NCCL_ENABLE_MONITORING=0
+export WANDB_INIT_TIMEOUT=300
+PY=/coc/flash7/paphiwetsa3/projects/EgoVerse7/.venv/bin/python
+cell=$1
+
+# SMOKE branch: when SMOKE=1, append fast overrides (last-wins in Hydra) to verify a
+# ckpt saves WITHOUT val before the real relaunch. Reuses ALL v5 overrides untouched.
+SMOKE_OV=""
+if [ "$SMOKE" = "1" ]; then
+  SMOKE_OV="++trainer.limit_train_batches=5 ++trainer.max_epochs=4 ++trainer.min_epochs=4 ++callbacks.model_checkpoint.every_n_epochs=2 ++trainer.limit_val_batches=0 ++norm_stats.sample_frac=0.1 ++model.scheduler.max_steps=4 ++model.scheduler.warmup_steps=1 name=v5_ckpttest description=${cell}_smoke"
+fi
+
+# FRESH v5: resume only from v5 logs (so it never picks up a baseline4 obs_stride=1 ckpt).
+CKPT=$(ls -t logs/indomain_c4_200m_v5/${cell}_2026*/checkpoints/last.ckpt 2>/dev/null | head -1)
+RES=""
+if [ -n "$CKPT" ]; then RES="ckpt_path=$CKPT"; echo "[RESUME] $cell <- $CKPT"; else echo "[FRESH] $cell"; fi
+
+case $cell in tx_*) export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True;; esac
+
+# Per-cell dataloader batch_size + num_workers overrides. bc_big -> pushshapes_sim only;
+# bc_small -> pushshapes_sim_small_circle only; cotrain/dino -> both (a phantom key on a
+# single-dataset cell is a silent no-op, but we key it correctly to avoid surprises).
+BS=11; NW=12
+DL=""
+case $cell in
+  *bc_big*|tx_bc_big)
+    DL="++data.train_dataloader_params.pushshapes_sim.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim.num_workers=$NW";;
+  *bc_small*)
+    DL="++data.train_dataloader_params.pushshapes_sim_small_circle.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim_small_circle.num_workers=$NW";;
+  *cotrain*)
+    DL="++data.train_dataloader_params.pushshapes_sim.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim.num_workers=$NW ++data.train_dataloader_params.pushshapes_sim_small_circle.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim_small_circle.num_workers=$NW";;
+esac
+
+srun $PY -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/$cell $RES logger=csv_wandb callbacks=ckpt_ratio_loss_scheduler_700 ++callbacks.model_checkpoint.every_n_epochs=250 ++callbacks.model_checkpoint.save_on_train_epoch_end=True ++trainer.precision=32 ++trainer.limit_train_batches=1.0 ++trainer.limit_val_batches=0 ++trainer.num_sanity_val_steps=0 ++trainer.max_epochs=2500 ++trainer.min_epochs=2500 ++trainer.check_val_every_n_epoch=250 ++model.scheduler_interval=epoch ++model.scheduler.max_steps=2500 ++model.scheduler.warmup_steps=125 ++model.log_per_layer_grad_norms=true ++model.enable_grad_norm=false ++callbacks.ratio_loss_scheduler.on_value=1.0 ++callbacks.ratio_loss_scheduler.off_value=1.0 ++norm_stats.norm_mode=minmax $DL launch_params.gpus_per_node=3 ++trainer.strategy=ddp_find_unused_parameters_true ++logger.wandb.project=pushshapes-indomain-c4 ++logger.wandb.id=indomain_c4_baseline8_$cell ++logger.wandb.name=${cell}_200m_ed ++logger.wandb.group=indomain_c4_baseline8 ++logger.wandb.resume=allow name=indomain_c4_200m_v5 description=$cell $SMOKE_OV

--- a/indomain_c4_200m_v5_launch.sh
+++ b/indomain_c4_200m_v5_launch.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# 200M H-Net + Tx launcher (BASELINE v5). Relaunch of v2/v4 with the obs_stride bug fixed
+# in code (egomimic/algo/hnet/algo.py now defaults obs_stride to the GMM head chunk_len=4,
+# was silently 1). FRESH runs (cannot resume obs_stride=1 ckpts) under NEW name
+# indomain_c4_200m_v5 + wandb group indomain_c4_baseline7. Changes vs v2/v4:
+#   - 3-GPU DDP (gpus_per_node=3, ntasks-per-node=3)
+#   - per-GPU batch 11 -> global 33 (~2x the old 8/GPU x 2 = 16) via per-cell dataloader keys
+#   - limit_train_batches=1.0 (full pass, no 100-batch cap)
+#   - max_epochs=min_epochs=2500, ckpt+val every 25 (= 100/4)
+#   - num_workers=12 (was 8) on the dataloaders
+#   - scheduler max_steps/warmup_steps = <FILL FROM SMOKE: 100*B / round(0.05*100*B)>
+# obs_stride must resolve to 4 (verify in log). RatioLossScheduler (switch_fraction=0.35)
+# auto-scales off-epoch to round(0.35*max_epochs)=35 with max_epochs=2500 (no rescale needed).
+cd /coc/flash7/paphiwetsa3/projects/EgoVerse-gmm
+export PYTHONPATH=.
+export TORCH_NCCL_ENABLE_MONITORING=0
+PY=/coc/flash7/paphiwetsa3/projects/EgoVerse7/.venv/bin/python
+cell=$1
+
+# SMOKE branch: when SMOKE=1, append fast overrides (last-wins in Hydra) to verify a
+# ckpt saves WITHOUT val before the real relaunch. Reuses ALL v5 overrides untouched.
+SMOKE_OV=""
+if [ "$SMOKE" = "1" ]; then
+  SMOKE_OV="++trainer.limit_train_batches=5 ++trainer.max_epochs=4 ++trainer.min_epochs=4 ++callbacks.model_checkpoint.every_n_epochs=2 ++trainer.limit_val_batches=0 ++norm_stats.sample_frac=0.1 ++model.scheduler.max_steps=4 ++model.scheduler.warmup_steps=1 name=v5_ckpttest description=${cell}_smoke"
+fi
+
+# FRESH v5: resume only from v5 logs (so it never picks up a baseline4 obs_stride=1 ckpt).
+CKPT=$(ls -t logs/indomain_c4_200m_v5/${cell}_2026*/checkpoints/last.ckpt 2>/dev/null | head -1)
+RES=""
+if [ -n "$CKPT" ]; then RES="ckpt_path=$CKPT"; echo "[RESUME] $cell <- $CKPT"; else echo "[FRESH] $cell"; fi
+
+case $cell in tx_*) export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True;; esac
+
+# Per-cell dataloader batch_size + num_workers overrides. bc_big -> pushshapes_sim only;
+# bc_small -> pushshapes_sim_small_circle only; cotrain/dino -> both (a phantom key on a
+# single-dataset cell is a silent no-op, but we key it correctly to avoid surprises).
+BS=11; NW=12
+DL=""
+case $cell in
+  *bc_big*|tx_bc_big)
+    DL="++data.train_dataloader_params.pushshapes_sim.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim.num_workers=$NW";;
+  *bc_small*)
+    DL="++data.train_dataloader_params.pushshapes_sim_small_circle.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim_small_circle.num_workers=$NW";;
+  *cotrain*)
+    DL="++data.train_dataloader_params.pushshapes_sim.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim.num_workers=$NW ++data.train_dataloader_params.pushshapes_sim_small_circle.batch_size=$BS ++data.train_dataloader_params.pushshapes_sim_small_circle.num_workers=$NW";;
+esac
+
+srun $PY -m egomimic.trainHydra --config-name=train_zarr_cartesian +experiment=indomain_c4/$cell $RES logger=csv_wandb callbacks=ckpt_ratio_loss_scheduler_700 ++callbacks.model_checkpoint.every_n_epochs=250 ++callbacks.model_checkpoint.save_on_train_epoch_end=True ++trainer.precision=32 ++trainer.limit_train_batches=1.0 ++trainer.limit_val_batches=0 ++trainer.num_sanity_val_steps=0 ++trainer.max_epochs=2500 ++trainer.min_epochs=2500 ++trainer.check_val_every_n_epoch=250 ++model.scheduler_interval=epoch ++model.scheduler.max_steps=2500 ++model.scheduler.warmup_steps=125 ++model.log_per_layer_grad_norms=true ++model.enable_grad_norm=false ++norm_stats.norm_mode=minmax $DL launch_params.gpus_per_node=3 ++trainer.strategy=ddp_find_unused_parameters_true ++logger.wandb.project=pushshapes-indomain-c4 ++logger.wandb.id=indomain_c4_baseline7_$cell ++logger.wandb.name=${cell}_200m_v5 ++logger.wandb.group=indomain_c4_baseline7 ++logger.wandb.resume=allow name=indomain_c4_200m_v5 description=$cell $SMOKE_OV


### PR DESCRIPTION
Model configs encdec/encdec2/b1/b3/b4 (+dino) with per-emb EncoderDecoder bottoms
around cossim chunkers, ratio w=1.0 always-on; indomain_c4 experiment grid
(tx/hpt/hnet cells incl. retired width-sweep s3-s9 for the record); configurable
prev_end_combine depth + residual_mixer_kwargs; end_to_end_output_dim polymorphism
(tapering chunker at chain root); per-leaf grad-norm logging; env-gated
torch.compile; hnet_ed launcher + sbatch, self-healing goal daemon v2,
active-param counter.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CjuZ3zwWaCeQQigxiNuzGw