### PR TITLE
state ownership refactor: per-class narrow/merge_ row semantics (StateRowMixin)

### DIFF
--- a/egomimic/models/hnet/blocks.py
+++ b/egomimic/models/hnet/blocks.py
@@ -19,7 +19,7 @@ Tensor shape conventions (match upstream):
 """
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any, Dict, Optional, Union
 
 import torch
@@ -55,8 +55,189 @@ def has_mamba() -> bool:
     return _HAS_MAMBA
 
 
+# --------------------------------------------------------------------------- #
+# Row-ownership machinery for inference-state dataclasses.
+#
+# Every state dataclass that crosses the stage tree's per-batch slice/scatter
+# boundary (``stages._slice_state`` / ``stages._scatter_state``) owns its own
+# row semantics via ``StateRowMixin``:
+#
+#   narrow(idx)      -> deep, row-sliced copy (rows where the (B,) bool mask
+#                       ``idx`` is True), recursing into nested states.
+#   merge_(sub, idx) -> writes ``sub``'s rows back into ``self`` IN PLACE.
+#
+# Both methods iterate ``dataclasses.fields`` and dispatch generically
+# (tensor / nested state / dict / list / None), so a newly added field is
+# either handled or fails LOUDLY (TypeError) — never silently skipped.
+# ``merge_`` additionally MATERIALIZES tensor fields that are still None on
+# the persistent side (lazily-created carries like ChunkerStageState.prev_x
+# used to be dropped by the old ``if both non-None`` scatter guards), and
+# always ends with a cheap invariant check that nothing carried by the
+# sub-state got lost.
+# --------------------------------------------------------------------------- #
+
+
+def _narrow_value(v: Any, idx: torch.Tensor, owner: str, name: str) -> Any:
+    """Row-slice one field value; tensors are batched on dim 0 by default."""
+    if v is None:
+        return None
+    if isinstance(v, torch.Tensor):
+        return v[idx].clone()
+    if isinstance(v, dict):
+        return {
+            k: _narrow_value(x, idx, owner, f"{name}[{k!r}]") for k, x in v.items()
+        }
+    if isinstance(v, (list, tuple)):
+        vals = [_narrow_value(x, idx, owner, f"{name}[{i}]") for i, x in enumerate(v)]
+        return tuple(vals) if isinstance(v, tuple) else vals
+    narrow = getattr(v, "narrow", None)
+    if callable(narrow):
+        return narrow(idx)
+    raise TypeError(
+        f"{owner}.{name}: cannot row-slice value of type {type(v).__name__}; "
+        f"give it a narrow/merge_ pair (StateRowMixin) or handle it explicitly."
+    )
+
+
+def _merge_value(
+    mine: Any, theirs: Any, idx: torch.Tensor, owner: str, name: str
+) -> Any:
+    """Write ``theirs``'s rows into ``mine`` in place. Returns the (possibly
+    newly materialized) persistent-side value; callers must store it back if
+    it differs from ``mine``."""
+    if theirs is None:
+        # Sub-state carries nothing for this field -> leave the persistent
+        # side untouched (matches the old ``if ... is None: return`` guards).
+        return mine
+    if mine is None:
+        if isinstance(theirs, torch.Tensor):
+            # Materialize-on-merge: the sub-state lazily created this tensor
+            # (e.g. prev_x on a state allocated by an old code path). Allocate
+            # the full-batch buffer and write the active rows so the carry is
+            # NOT dropped.
+            mine = torch.zeros(
+                idx.shape[0],
+                *theirs.shape[1:],
+                dtype=theirs.dtype,
+                device=theirs.device,
+            )
+            mine[idx] = theirs
+            return mine
+        raise AssertionError(
+            f"{owner}.{name}: persistent state is None but the sliced sub-state "
+            f"carries a {type(theirs).__name__}; nested states must be "
+            f"allocated up front (allocate_inference_cache/_allocate)."
+        )
+    if isinstance(mine, torch.Tensor):
+        mine[idx] = theirs.to(mine.dtype)
+        return mine
+    if isinstance(mine, dict):
+        for k in mine:
+            sub_v = theirs.get(k) if isinstance(theirs, dict) else theirs
+            merged = _merge_value(mine[k], sub_v, idx, owner, f"{name}[{k!r}]")
+            if merged is not mine[k]:
+                mine[k] = merged
+        return mine
+    if isinstance(mine, tuple):
+        raise TypeError(
+            f"{owner}.{name}: tuple fields cannot be merged in place; use a list."
+        )
+    if isinstance(mine, list):
+        for i, (c, d) in enumerate(zip(mine, theirs)):
+            merged = _merge_value(c, d, idx, owner, f"{name}[{i}]")
+            if merged is not c:
+                mine[i] = merged
+        return mine
+    merge = getattr(mine, "merge_", None)
+    if callable(merge):
+        merge(theirs, idx)
+        return mine
+    raise TypeError(
+        f"{owner}.{name}: cannot merge value of type {type(mine).__name__}; "
+        f"give it a narrow/merge_ pair (StateRowMixin) or handle it explicitly."
+    )
+
+
+class StateRowMixin:
+    """``narrow``/``merge_`` over ``dataclasses.fields`` for state dataclasses.
+
+    Per-class hooks (plain class attributes, NOT dataclass fields):
+      * ``_DIM1_FIELDS``: names of fields whose batch dim is 1, not 0 (GRU
+        hiddens shaped (num_layers, B, H)): sliced ``v[:, idx]`` and merged
+        ``v[:, idx] = sub``.
+      * ``_META_FIELDS``: non-batched metadata; copied through ``_narrow_meta``
+        on narrow and left untouched by merge_.
+    """
+
+    _DIM1_FIELDS: tuple = ()
+    _META_FIELDS: tuple = ()
+
+    def _narrow_meta(self, name: str, value: Any, idx: torch.Tensor) -> Any:
+        return value
+
+    def narrow(self, idx: torch.Tensor):
+        cls_name = type(self).__name__
+        all_fields = fields(self)
+        handled = set()
+        kwargs = {}
+        for f in all_fields:
+            v = getattr(self, f.name)
+            if f.name in self._META_FIELDS:
+                kwargs[f.name] = self._narrow_meta(f.name, v, idx)
+            elif f.name in self._DIM1_FIELDS:
+                kwargs[f.name] = None if v is None else v[:, idx].clone()
+            else:
+                kwargs[f.name] = _narrow_value(v, idx, cls_name, f.name)
+            handled.add(f.name)
+        missing = {f.name for f in all_fields} - handled
+        assert not missing, f"{cls_name}.narrow: unhandled fields {sorted(missing)}"
+        return type(self)(**kwargs)
+
+    def merge_(self, sub, idx: torch.Tensor) -> None:
+        cls_name = type(self).__name__
+        all_fields = fields(self)
+        handled = set()
+        for f in all_fields:
+            mine = getattr(self, f.name)
+            theirs = getattr(sub, f.name)
+            if f.name in self._META_FIELDS:
+                handled.add(f.name)  # metadata: merge is a no-op by contract
+                continue
+            if f.name in self._DIM1_FIELDS:
+                if theirs is not None:
+                    if mine is None:
+                        # Materialize-on-merge, dim-1 batched analogue.
+                        mine = torch.zeros(
+                            theirs.shape[0],
+                            idx.shape[0],
+                            *theirs.shape[2:],
+                            dtype=theirs.dtype,
+                            device=theirs.device,
+                        )
+                        setattr(self, f.name, mine)
+                    mine[:, idx] = theirs.to(mine.dtype)
+                handled.add(f.name)
+                continue
+            merged = _merge_value(mine, theirs, idx, cls_name, f.name)
+            if merged is not mine:
+                setattr(self, f.name, merged)
+            handled.add(f.name)
+        missing = {f.name for f in all_fields} - handled
+        assert not missing, f"{cls_name}.merge_: unhandled fields {sorted(missing)}"
+        # Post-merge invariant (always on, cheap attribute checks): nothing the
+        # sub-state carries may remain missing on the persistent side — a None
+        # here means a write-back was silently dropped (the prev_x bug class).
+        for f in all_fields:
+            if getattr(sub, f.name) is not None:
+                assert getattr(self, f.name) is not None, (
+                    f"{cls_name}.merge_: field {f.name!r} is non-None on the "
+                    f"sliced sub-state but None on the persistent state; the "
+                    f"write-back was dropped."
+                )
+
+
 @dataclass
-class KVCache:
+class KVCache(StateRowMixin):
     """Per-attention-layer K/V cache with per-batch-element fill counters."""
 
     k: torch.Tensor  # (B, num_heads, max_seqlen, head_dim)
@@ -70,7 +251,7 @@ class KVCache:
 
 
 @dataclass
-class MambaCache:
+class MambaCache(StateRowMixin):
     """Per-SSM-layer state for Mamba2 step inference."""
 
     conv_state: torch.Tensor  # (B, conv_dim, d_conv - 1)
@@ -85,12 +266,22 @@ LayerCache = Union[KVCache, MambaCache]
 
 
 @dataclass
-class IsotropicInferenceParams:
+class IsotropicInferenceParams(StateRowMixin):
     """One per-layer cache (KV or Mamba) per layer index."""
 
     layer_caches: Dict[int, Any] = field(default_factory=dict)
     max_seqlen: int = 0
     batch_size: int = 0
+
+    # max_seqlen is copied through narrow; batch_size is recomputed to the
+    # sliced row count (matches the old stages._slice_iso_params). merge_
+    # leaves both untouched (matches the old _scatter_iso_params).
+    _META_FIELDS = ("max_seqlen", "batch_size")
+
+    def _narrow_meta(self, name: str, value: Any, idx: torch.Tensor) -> Any:
+        if name == "batch_size":
+            return int(idx.sum().item())
+        return value
 
 
 class RMSNorm(nn.Module):

--- a/egomimic/models/hnet/register_interface.py
+++ b/egomimic/models/hnet/register_interface.py
@@ -34,7 +34,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from egomimic.models.hnet.blocks import MultiHeadAttention, RMSNorm
+from egomimic.models.hnet.blocks import MultiHeadAttention, RMSNorm, StateRowMixin
 
 
 def _fourier_phase(phase: torch.Tensor, n_freqs: int = 4) -> torch.Tensor:
@@ -266,7 +266,7 @@ class RegisterInterface(nn.Module):
 
 
 @dataclass
-class RegisterTrunkState:
+class RegisterTrunkState(StateRowMixin):
     """Per-layer KV caches for the register AR step.
 
     Two caches per layer:

--- a/egomimic/models/hnet/routing.py
+++ b/egomimic/models/hnet/routing.py
@@ -21,6 +21,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from egomimic.models.hnet.blocks import StateRowMixin
+
 # Optional Mamba2 selective-scan kernel for the DeChunkLayer EMA.
 try:
     from einops import rearrange, repeat  # type: ignore
@@ -49,13 +51,13 @@ class RoutingModuleOutput:
 
 
 @dataclass
-class RoutingModuleState:
+class RoutingModuleState(StateRowMixin):
     has_seen_tokens: torch.Tensor  # (B,) bool
     last_hidden_state: torch.Tensor  # (B, D)
 
 
 @dataclass
-class DeChunkState:
+class DeChunkState(StateRowMixin):
     last_value: torch.Tensor  # (B, D)
 
 

--- a/egomimic/models/hnet/scan_interface.py
+++ b/egomimic/models/hnet/scan_interface.py
@@ -43,6 +43,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from .blocks import StateRowMixin
 from .routing import DeChunkLayer, RoutingModuleOutput, get_seq_idx
 
 try:  # RMSNorm for the gated decoder-end normalization (paper "network norm").
@@ -98,7 +99,7 @@ def _causal_phase_scalar(offset: torch.Tensor) -> torch.Tensor:
 
 
 @dataclass
-class ScanRouterState:
+class ScanRouterState(StateRowMixin):
     """AR state for ``ScanRouter``. ``has_seen_tokens`` forces a boundary on
     the first step of each episode (subseq start), mirroring the packed
     forward's ``boundary_prob[cu_seqlens[:-1]] = 1.0``. ``gru_h`` is the GRU
@@ -107,6 +108,8 @@ class ScanRouterState:
     Mamba path it stashes the previous step's mixer output (the GRU path reads
     it directly from ``gru_h``)."""
 
+    _DIM1_FIELDS = ("gru_h",)
+
     has_seen_tokens: torch.Tensor  # (B,) bool
     gru_h: Optional[torch.Tensor] = None  # (1, B, d_state) GRU carry
     mamba_cache: Optional["object"] = None  # MambaCache on the CUDA path
@@ -114,7 +117,7 @@ class ScanRouterState:
 
 
 @dataclass
-class ChunkScanEncoderState:
+class ChunkScanEncoderState(StateRowMixin):
     """AR state for ``ChunkScanEncoder``. Per-chunk GRU carry + running offset
     + a FIXED-capacity buffer of this chunk's per-token GRU outputs (needed to
     extract the m sub-latents at chunk completion, when the full chunk length
@@ -123,13 +126,15 @@ class ChunkScanEncoderState:
     length the AR path can summarize exactly; a chunk longer than ``cap``
     triggers an assert (raise ``max_chunk_len`` in the config / allocate)."""
 
+    _DIM1_FIELDS = ("gru_h",)
+
     gru_h: torch.Tensor  # (1, B, H) per-chunk GRU carry
     offset: torch.Tensor  # (B,) running position within the current chunk
     buf: torch.Tensor  # (B, cap, H) per-token outputs of the current chunk
 
 
 @dataclass
-class SplineUpsamplerState:
+class SplineUpsamplerState(StateRowMixin):
     """AR state for ``SplineUpsampler``. ``prev_inner_sub`` is the most
     recently COMPLETED chunk's inner-processed m sub-latents (B, m, d_inner),
     used as the basis for the current chunk's tokens (shift-by-one). Zero
@@ -726,7 +731,7 @@ class SplineUpsampler(nn.Module):
 
 
 @dataclass
-class MSublatentDeChunkerState:
+class MSublatentDeChunkerState(StateRowMixin):
     """AR state for ``MSublatentDeChunker.step`` (DECHUNK-AR). Mirrors
     ``SplineUpsamplerState`` plus a chunk-rate EMA carry (``ema_prev``)."""
     prev_inner_sub: torch.Tensor  # (B, m, d_inner) POST-EMA sub-latents = W_v basis source (shift-by-one)

--- a/egomimic/models/hnet/stages.py
+++ b/egomimic/models/hnet/stages.py
@@ -37,8 +37,7 @@ import torch.nn as nn
 
 from egomimic.models.hnet.blocks import (
     IsotropicInferenceParams,
-    KVCache,
-    MambaCache,
+    StateRowMixin,
 )
 from egomimic.models.hnet.context import HNetContext
 from egomimic.models.hnet.isotropic_builder import build_isotropic
@@ -47,21 +46,16 @@ from egomimic.models.hnet.routing import (
     DeChunkLayer,
     DeChunkState,
     RoutingModule,
-    RoutingModuleState,
 )
 from egomimic.models.hnet.scan_interface import (
     ChunkScanEncoder,
     ChunkScanEncoderState,
     MSublatentDeChunker,
     ScanRouter,
-    ScanRouterState,
     SplineUpsampler,
     SplineUpsamplerState,
 )
-from egomimic.models.hnet.transformer_router import (
-    PhaseSummaryRouter,
-    PhaseSummaryRouterState,
-)
+from egomimic.models.hnet.transformer_router import PhaseSummaryRouter
 from egomimic.models.hnet.register_interface import (
     RegisterInterface,
     RegisterTrunk,
@@ -69,12 +63,14 @@ from egomimic.models.hnet.register_interface import (
 )
 
 # --------------------------------------------------------------------------- #
-# Inference-state dataclasses (one per stage type).
+# Inference-state dataclasses (one per stage type). Each owns its per-batch
+# row semantics via StateRowMixin: ``narrow(idx)`` (row-sliced deep copy) and
+# ``merge_(sub, idx)`` (in-place write-back). See blocks.StateRowMixin.
 # --------------------------------------------------------------------------- #
 
 
 @dataclass
-class EncoderDecoderStageState:
+class EncoderDecoderStageState(StateRowMixin):
     encoder_state: Optional[IsotropicInferenceParams] = None
     inner_state: Optional[Any] = None
     decoder_state: Optional[IsotropicInferenceParams] = None
@@ -83,9 +79,10 @@ class EncoderDecoderStageState:
 
 
 @dataclass
-class ChunkerStageState:
-    # routing_state is a RoutingModuleState (cossim router) or a
-    # ScanRouterState (scan router); both are sliced/scattered generically.
+class ChunkerStageState(StateRowMixin):
+    # routing_state is a RoutingModuleState (cossim router), a ScanRouterState
+    # (scan router) or a PhaseSummaryRouterState (PSER); all carry their own
+    # narrow/merge_ so they slice/scatter generically.
     routing_state: Optional[Any] = None
     inner_state: Optional[Any] = None
     dechunk_state: Optional[DeChunkState] = None
@@ -93,15 +90,22 @@ class ChunkerStageState:
     scan_enc_state: Optional[ChunkScanEncoderState] = None
     spline_state: Optional[SplineUpsamplerState] = None
     # Register masked-transformer interface state (None unless
-    # chunk_interface == "register").
+    # chunk_interface == "register" or down_interface == "register").
     reg_trunk_state: Optional[RegisterTrunkState] = None
     # grab_prev_end: previous step's input token (B, D) for the first_token
-    # chunker's "first + prev-chunk-end" combine at AR rollout. None until 1st step.
+    # chunker's "first + prev-chunk-end" combine at AR rollout. EAGERLY
+    # allocated by _allocate (zeros) when grab_prev_end is on, so merge_
+    # write-back propagates for chunkers below a slice/scatter boundary.
     prev_x: Optional[torch.Tensor] = None
+    # (B,) bool: True once prev_x holds a REAL previous token for that row.
+    # Rows still False read the learned no_prev embedding instead.
+    prev_x_valid: Optional[torch.Tensor] = None
+    # up_interface == "msublatent" dechunker state (None otherwise).
+    msublatent_state: Optional[Any] = None
 
 
 @dataclass
-class ComputeStageState:
+class ComputeStageState(StateRowMixin):
     main_state: Optional[IsotropicInferenceParams] = None
     inner_state: Optional[Any] = None
 
@@ -140,281 +144,41 @@ def _build_padded_valid_mask(shape, device) -> torch.Tensor:
 
 
 # --------------------------------------------------------------------------- #
-# Per-batch slice/scatter helpers for nested inference state during step().
-# Reused (and slightly simplified) from the previous monolithic HNet.
+# Per-batch slice/scatter during step(): thin wrappers only. Row semantics
+# live on the state dataclasses themselves (StateRowMixin.narrow/merge_), so
+# there is no per-type switchboard here to fall out of sync with the fields.
 # --------------------------------------------------------------------------- #
 
 
-def _slice_iso_params(params: Optional[IsotropicInferenceParams], mask: torch.Tensor):
-    if params is None:
-        return None
-    new = IsotropicInferenceParams(
-        layer_caches={},
-        max_seqlen=params.max_seqlen,
-        batch_size=int(mask.sum().item()),
-    )
-    for k, c in params.layer_caches.items():
-        if isinstance(c, KVCache):
-            new.layer_caches[k] = KVCache(
-                k=c.k[mask].clone(),
-                v=c.v[mask].clone(),
-                offsets=c.offsets[mask].clone(),
-            )
-        elif isinstance(c, MambaCache):
-            new.layer_caches[k] = MambaCache(
-                conv_state=c.conv_state[mask].clone(),
-                ssm_state=c.ssm_state[mask].clone(),
-            )
-        else:
-            raise TypeError(f"Unknown layer cache type: {type(c)}")
-    return new
-
-
-def _scatter_iso_params(
-    params: Optional[IsotropicInferenceParams],
-    sub: Optional[IsotropicInferenceParams],
-    mask: torch.Tensor,
-):
-    if params is None or sub is None:
-        return
-    for k, c in params.layer_caches.items():
-        s = sub.layer_caches[k]
-        if isinstance(c, KVCache):
-            c.k[mask] = s.k.to(c.k.dtype)
-            c.v[mask] = s.v.to(c.v.dtype)
-            c.offsets[mask] = s.offsets
-        elif isinstance(c, MambaCache):
-            c.conv_state[mask] = s.conv_state.to(c.conv_state.dtype)
-            c.ssm_state[mask] = s.ssm_state.to(c.ssm_state.dtype)
-        else:
-            raise TypeError(f"Unknown layer cache type: {type(c)}")
-
-
-def _slice_routing_state(rs: Any, mask: torch.Tensor):
-    """Slice a RoutingModuleState (cossim) or ScanRouterState (scan)."""
-    if rs is None:
-        return None
-    if isinstance(rs, RoutingModuleState):
-        return RoutingModuleState(
-            has_seen_tokens=rs.has_seen_tokens[mask].clone(),
-            last_hidden_state=rs.last_hidden_state[mask].clone(),
-        )
-    if isinstance(rs, ScanRouterState):
-        return ScanRouterState(
-            has_seen_tokens=rs.has_seen_tokens[mask].clone(),
-            gru_h=(rs.gru_h[:, mask].clone() if rs.gru_h is not None else None),
-            mamba_cache=_slice_mamba_cache(rs.mamba_cache, mask),
-            h_prev=(rs.h_prev[mask].clone() if rs.h_prev is not None else None),
-        )
-    if isinstance(rs, PhaseSummaryRouterState):
-        return PhaseSummaryRouterState(
-            has_seen_tokens=rs.has_seen_tokens[mask].clone(),
-            kv=[
-                KVCache(
-                    k=c.k[mask].clone(),
-                    v=c.v[mask].clone(),
-                    offsets=c.offsets[mask].clone(),
-                )
-                for c in rs.kv
-            ],
-            last_cut_pos=rs.last_cut_pos[mask].clone(),
-            t_idx=rs.t_idx[mask].clone(),
-            seg_sum=rs.seg_sum[mask].clone(),
-            seg_count=rs.seg_count[mask].clone(),
-        )
-    raise TypeError(f"Unknown routing state type: {type(rs)}")
-
-
-def _slice_mamba_cache(cache, mask: torch.Tensor):
-    if cache is None:
-        return None
-    # MambaCache: conv_state / ssm_state batched on dim 0.
-    return MambaCache(
-        conv_state=cache.conv_state[mask].clone(),
-        ssm_state=cache.ssm_state[mask].clone(),
-    )
-
-
-def _slice_scan_enc_state(s: Optional[ChunkScanEncoderState], mask: torch.Tensor):
-    if s is None:
-        return None
-    return ChunkScanEncoderState(
-        gru_h=s.gru_h[:, mask].clone(),
-        offset=s.offset[mask].clone(),
-        buf=s.buf[mask].clone(),
-    )
-
-
-def _slice_spline_state(s: Optional[SplineUpsamplerState], mask: torch.Tensor):
-    if s is None:
-        return None
-    return SplineUpsamplerState(
-        prev_inner_sub=s.prev_inner_sub[mask].clone(),
-        have_prev=s.have_prev[mask].clone(),
-        offset=s.offset[mask].clone(),
-    )
-
-
-def _slice_reg_trunk_state(s: Optional[RegisterTrunkState], mask: torch.Tensor):
-    if s is None:
-        return None
-    return RegisterTrunkState(
-        reg_k=[t[mask].clone() for t in s.reg_k],
-        reg_v=[t[mask].clone() for t in s.reg_v],
-        reg_fill=s.reg_fill[mask].clone(),
-        mem_k=[t[mask].clone() for t in s.mem_k],
-        mem_v=[t[mask].clone() for t in s.mem_v],
-        mem_fill=s.mem_fill[mask].clone(),
-        mem_x=s.mem_x[mask].clone(),
-        offset=s.offset[mask].clone(),
-        has_seen=s.has_seen[mask].clone(),
-    )
-
-
-def _scatter_reg_trunk_state(s: Optional[RegisterTrunkState], sub, mask: torch.Tensor):
-    if s is None or sub is None:
-        return
-    for c, d in zip(s.reg_k, sub.reg_k):
-        c[mask] = d.to(c.dtype)
-    for c, d in zip(s.reg_v, sub.reg_v):
-        c[mask] = d.to(c.dtype)
-    s.reg_fill[mask] = sub.reg_fill
-    for c, d in zip(s.mem_k, sub.mem_k):
-        c[mask] = d.to(c.dtype)
-    for c, d in zip(s.mem_v, sub.mem_v):
-        c[mask] = d.to(c.dtype)
-    s.mem_fill[mask] = sub.mem_fill
-    s.mem_x[mask] = sub.mem_x.to(s.mem_x.dtype)
-    s.offset[mask] = sub.offset
-    s.has_seen[mask] = sub.has_seen
-
-
 def _slice_state(state: Any, mask: torch.Tensor):
-    """Generic batch-dim slice for any stage state dataclass."""
+    """Generic batch-dim slice for any stage state (delegates to .narrow)."""
     if state is None:
         return None
-    if isinstance(state, IsotropicInferenceParams):
-        return _slice_iso_params(state, mask)
-    if isinstance(state, EncoderDecoderStageState):
-        return EncoderDecoderStageState(
-            encoder_state=_slice_iso_params(state.encoder_state, mask),
-            inner_state=_slice_state(state.inner_state, mask),
-            decoder_state=_slice_iso_params(state.decoder_state, mask),
-        )
-    if isinstance(state, ChunkerStageState):
-        ds = state.dechunk_state
-        if ds is not None:
-            ds = DeChunkState(last_value=ds.last_value[mask].clone())
-        return ChunkerStageState(
-            routing_state=_slice_routing_state(state.routing_state, mask),
-            inner_state=_slice_state(state.inner_state, mask),
-            dechunk_state=ds,
-            scan_enc_state=_slice_scan_enc_state(state.scan_enc_state, mask),
-            spline_state=_slice_spline_state(state.spline_state, mask),
-            reg_trunk_state=_slice_reg_trunk_state(state.reg_trunk_state, mask),
-            prev_x=(state.prev_x[mask].clone() if state.prev_x is not None else None),
-        )
-    if isinstance(state, ComputeStageState):
-        return ComputeStageState(
-            main_state=_slice_iso_params(state.main_state, mask),
-            inner_state=_slice_state(state.inner_state, mask),
-        )
     if isinstance(state, dict):
         # PerEmbodimentStage holds per-embodiment sub-states in a dict keyed by
         # embodiment_id. Slice each independently — all sub-states share the
         # same batch dim, so the boundary mask applies elementwise. (None subs
         # are handled by the early return above.)
         return {k: _slice_state(v, mask) for k, v in state.items()}
-    raise TypeError(f"Unknown stage state type: {type(state)}")
-
-
-def _scatter_routing_state(rs: Any, sub: Any, mask: torch.Tensor):
-    if rs is None or sub is None:
-        return
-    if isinstance(rs, RoutingModuleState):
-        rs.has_seen_tokens[mask] = sub.has_seen_tokens
-        rs.last_hidden_state[mask] = sub.last_hidden_state.to(
-            rs.last_hidden_state.dtype
-        )
-        return
-    if isinstance(rs, ScanRouterState):
-        rs.has_seen_tokens[mask] = sub.has_seen_tokens
-        if rs.gru_h is not None and sub.gru_h is not None:
-            rs.gru_h[:, mask] = sub.gru_h.to(rs.gru_h.dtype)
-        if rs.h_prev is not None and sub.h_prev is not None:
-            rs.h_prev[mask] = sub.h_prev.to(rs.h_prev.dtype)
-        if rs.mamba_cache is not None and sub.mamba_cache is not None:
-            rs.mamba_cache.conv_state[mask] = sub.mamba_cache.conv_state.to(
-                rs.mamba_cache.conv_state.dtype
-            )
-            rs.mamba_cache.ssm_state[mask] = sub.mamba_cache.ssm_state.to(
-                rs.mamba_cache.ssm_state.dtype
-            )
-        return
-    if isinstance(rs, PhaseSummaryRouterState):
-        rs.has_seen_tokens[mask] = sub.has_seen_tokens
-        for c, s in zip(rs.kv, sub.kv):
-            c.k[mask] = s.k.to(c.k.dtype)
-            c.v[mask] = s.v.to(c.v.dtype)
-            c.offsets[mask] = s.offsets
-        rs.last_cut_pos[mask] = sub.last_cut_pos
-        rs.t_idx[mask] = sub.t_idx
-        rs.seg_sum[mask] = sub.seg_sum.to(rs.seg_sum.dtype)
-        rs.seg_count[mask] = sub.seg_count
-        return
-    raise TypeError(f"Unknown routing state type: {type(rs)}")
-
-
-def _scatter_scan_enc_state(s: Any, sub: Any, mask: torch.Tensor):
-    if s is None or sub is None:
-        return
-    s.gru_h[:, mask] = sub.gru_h.to(s.gru_h.dtype)
-    s.offset[mask] = sub.offset
-    s.buf[mask] = sub.buf.to(s.buf.dtype)
-
-
-def _scatter_spline_state(s: Any, sub: Any, mask: torch.Tensor):
-    if s is None or sub is None:
-        return
-    s.prev_inner_sub[mask] = sub.prev_inner_sub.to(s.prev_inner_sub.dtype)
-    s.have_prev[mask] = sub.have_prev
-    s.offset[mask] = sub.offset
+    narrow = getattr(state, "narrow", None)
+    if not callable(narrow):
+        raise TypeError(f"Unknown stage state type (no .narrow): {type(state)}")
+    return narrow(mask)
 
 
 def _scatter_state(state: Any, sub: Any, mask: torch.Tensor):
+    """In-place row write-back of ``sub`` into ``state`` (delegates to .merge_)."""
     if state is None or sub is None:
-        return
-    if isinstance(state, IsotropicInferenceParams):
-        _scatter_iso_params(state, sub, mask)
-        return
-    if isinstance(state, EncoderDecoderStageState):
-        _scatter_iso_params(state.encoder_state, sub.encoder_state, mask)
-        _scatter_state(state.inner_state, sub.inner_state, mask)
-        _scatter_iso_params(state.decoder_state, sub.decoder_state, mask)
-        return
-    if isinstance(state, ChunkerStageState):
-        _scatter_routing_state(state.routing_state, sub.routing_state, mask)
-        _scatter_state(state.inner_state, sub.inner_state, mask)
-        if state.dechunk_state is not None and sub.dechunk_state is not None:
-            state.dechunk_state.last_value[mask] = sub.dechunk_state.last_value.to(
-                state.dechunk_state.last_value.dtype
-            )
-        _scatter_scan_enc_state(state.scan_enc_state, sub.scan_enc_state, mask)
-        _scatter_spline_state(state.spline_state, sub.spline_state, mask)
-        _scatter_reg_trunk_state(state.reg_trunk_state, sub.reg_trunk_state, mask)
-        if state.prev_x is not None and sub.prev_x is not None:
-            state.prev_x[mask] = sub.prev_x.to(state.prev_x.dtype)
-        return
-    if isinstance(state, ComputeStageState):
-        _scatter_iso_params(state.main_state, sub.main_state, mask)
-        _scatter_state(state.inner_state, sub.inner_state, mask)
         return
     if isinstance(state, dict):
         # PerEmbodimentStage per-embodiment sub-states (mirror of _slice_state).
         for k in state:
             _scatter_state(state[k], sub.get(k) if isinstance(sub, dict) else sub, mask)
         return
-    raise TypeError(f"Unknown stage state type: {type(state)}")
+    merge = getattr(state, "merge_", None)
+    if not callable(merge):
+        raise TypeError(f"Unknown stage state type (no .merge_): {type(state)}")
+    merge(sub, mask)
 
 
 # --------------------------------------------------------------------------- #
@@ -1374,12 +1138,53 @@ class ChunkerStage(_BaseStage):
         inner_in = self.chunk_layer.step(x, bpred.boundary_mask)
         if self.grab_prev_end:
             if inner_in.shape[0] > 0:
-                prev_end = (state.prev_x[bpred.boundary_mask]
-                            if state.prev_x is not None
-                            else self.no_prev.to(inner_in.dtype).expand_as(inner_in))
+                if state.prev_x is None:
+                    # Legacy fallback (state allocated by an old code path,
+                    # before the eager _allocate): no prev-token carry yet ->
+                    # every row uses the learned no_prev token, as before.
+                    prev_end = self.no_prev.to(inner_in.dtype).expand_as(inner_in)
+                else:
+                    # prev_x is stored canonically as (B, D); reshape the
+                    # selected rows to inner_in's layout ((k, D) or (k, 1, D)).
+                    pv = state.prev_x[bpred.boundary_mask].reshape(inner_in.shape)
+                    if state.prev_x_valid is None:
+                        # Legacy fallback: carry without validity bits -> old
+                        # unconditional read.
+                        prev_end = pv
+                    else:
+                        # Per-row validity: rows that have not yet seen a real
+                        # previous token at THIS level read the learned no_prev
+                        # embedding. This (plus eager allocation + in-place
+                        # writes) is what bootstraps prev_x for chunkers BELOW
+                        # a slice/scatter boundary, where the old lazy
+                        # `state.prev_x = x` write-back was silently dropped.
+                        valid = state.prev_x_valid[bpred.boundary_mask].view(
+                            -1, *([1] * (inner_in.dim() - 1))
+                        )
+                        prev_end = torch.where(
+                            valid,
+                            pv.to(inner_in.dtype),
+                            self.no_prev.to(inner_in.dtype).expand_as(pv),
+                        )
                 cat = torch.cat([inner_in, prev_end], dim=-1).float()
                 inner_in = self.prev_end_combine(cat).to(x.dtype)  # concat -> trunk dim
-            state.prev_x = x  # update for next step (every step, boundary or not)
+            # Update the carry for the next step (every step, boundary or not).
+            # Strictly IN PLACE so an outer merge_ write-back propagates to the
+            # persistent state instead of mutating only the sliced copy.
+            x_rows = x.reshape(x.shape[0], -1)  # canonical (B, D)
+            if state.prev_x is None:
+                # Legacy-allocated state: create the carry here; the outer
+                # merge_ materializes the persistent-side buffer (zeros + row
+                # write), so the write-back is no longer dropped.
+                state.prev_x = x_rows.clone()
+            else:
+                state.prev_x.copy_(x_rows)
+            if state.prev_x_valid is None:
+                state.prev_x_valid = torch.ones(
+                    x.shape[0], dtype=torch.bool, device=x.device
+                )
+            else:
+                state.prev_x_valid.fill_(True)
         if inner_in.shape[0] > 0:
             if self.proj_in is not None:
                 inner_in = self.proj_in(inner_in)
@@ -1668,9 +1473,12 @@ class ChunkerStage(_BaseStage):
         dechunk_state = self.dechunk_layer.allocate_inference_cache(
             batch_size, max_seqlen, device, dtype
         )
-        # Register trunk state (only on the fused register interface).
+        # Register trunk state: needed by BOTH register uses — the fused
+        # interface (_step_register) and the down-only register chunker
+        # (_step_register_down reads state.reg_trunk_state but the old
+        # allocation gated on the fused interface only, leaving it None).
         reg_trunk_state = None
-        if self.chunk_interface == "register":
+        if self._register_chunker:
             # cap_mem: longest open chunk == full episode (single-chunk init).
             # cap_reg: at most one chunk per token across the episode, each
             # contributing m registers -> max_seqlen * m (loose but exact bound).
@@ -1681,6 +1489,26 @@ class ChunkerStage(_BaseStage):
                 d_model=self.input_hidden_dim,
                 device=device,
                 dtype=dtype,
+            )
+        # grab_prev_end: EAGERLY allocate the prev-token carry + per-row
+        # validity bits. The old lazy creation (`state.prev_x = x` on first
+        # step) left the PERSISTENT state's prev_x None for chunkers below a
+        # slice/scatter boundary, and the old scatter guard silently dropped
+        # the sub-state's write-back — so the "[first_token ; prev_chunk_end]"
+        # combine fed the learned no_prev embedding on EVERY chunk at rollout.
+        prev_x = None
+        prev_x_valid = None
+        if self.grab_prev_end:
+            prev_x = torch.zeros(
+                batch_size, self.input_hidden_dim, dtype=dtype, device=device
+            )
+            prev_x_valid = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        # msublatent up-interface state (was never allocated before: the
+        # `state.msublatent_state` read in _step_register_down was dormant).
+        msublatent_state = None
+        if self.up_interface == "msublatent":
+            msublatent_state = self.msublatent_up.allocate_inference_cache(
+                batch_size, self.input_hidden_dim, device, dtype
             )
         return ChunkerStageState(
             routing_state=routing_state,
@@ -1693,6 +1521,9 @@ class ChunkerStage(_BaseStage):
             scan_enc_state=scan_enc_state,
             spline_state=spline_state,
             reg_trunk_state=reg_trunk_state,
+            prev_x=prev_x,
+            prev_x_valid=prev_x_valid,
+            msublatent_state=msublatent_state,
         )
 
     def _init_weights(self, initializer_range: float, parent_residuals: int) -> int:

--- a/egomimic/models/hnet/transformer_router.py
+++ b/egomimic/models/hnet/transformer_router.py
@@ -57,7 +57,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .blocks import IsotropicInferenceParams, KVCache, MultiHeadAttention, RMSNorm
+from .blocks import (
+    IsotropicInferenceParams,
+    KVCache,
+    MultiHeadAttention,
+    RMSNorm,
+    StateRowMixin,
+)
 from .routing import RoutingModuleOutput, get_seq_idx
 
 
@@ -98,7 +104,7 @@ def _g_dwell(
 
 
 @dataclass
-class PhaseSummaryRouterState:
+class PhaseSummaryRouterState(StateRowMixin):
     """AR state for ``PhaseSummaryRouter`` (mirror of ``ScanRouterState``).
 
     ``has_seen_tokens`` forces a boundary on the first step of each episode

--- a/tests_state_roundtrip.py
+++ b/tests_state_roundtrip.py
@@ -1,0 +1,627 @@
+"""
+Pure-torch unit tests for the H-Net state-ownership refactor
+(StateRowMixin.narrow / merge_ on the inference-state dataclasses).
+
+Covers:
+  (a) narrow(mask) reproduces the OLD stages._slice_* semantics (reference
+      implementations inlined below, incl. the dim-1 gru_h cases and the
+      IsotropicInferenceParams batch_size/max_seqlen metadata rules);
+  (b) merge_ round-trip: narrow -> mutate sub -> merge_ -> exactly the masked
+      rows changed, unmasked rows untouched (and narrow returns real copies);
+  (c) the prev_x rollout scenario: eagerly-allocated prev_x/prev_x_valid,
+      sub-level IN-PLACE write, merge_ -> persistent rows updated + valid;
+  (d) materialize-on-merge: persistent prev_x None, sub writes a tensor,
+      merge_ materializes zeros and writes the rows;
+  (e) the always-on post-merge assertion fires on a hand-built violation, and
+      the None-persistent + nested-sub-state case raises loudly.
+
+Run:
+    python3 -m pytest tests_state_roundtrip.py -x -q
+or (no pytest installed):
+    python3 tests_state_roundtrip.py
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from dataclasses import dataclass, fields as dc_fields, is_dataclass
+from typing import Optional
+
+import torch
+
+torch.manual_seed(0)
+
+# --------------------------------------------------------------------------- #
+# Module loading.
+#
+# This working copy contains the full egomimic/models/hnet package (all real
+# modules: config, blocks, routing, scan_interface, register_interface,
+# transformer_router, context, isotropic_builder, residual_mixer, stages) but
+# NO egomimic package __init__ scaffolding, so build the package chain by hand
+# and load each module by file path under its canonical dotted name. External
+# optional deps (flash_attn / mamba_ssm / einops) are try/except'd inside the
+# modules themselves — nothing needs stubbing. These tests exercise ONLY the
+# state dataclasses, never the nn.Modules.
+# --------------------------------------------------------------------------- #
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.join(_HERE, "egomimic")
+
+
+def _ensure_pkg(name):
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        mod.__path__ = []  # package marker
+        sys.modules[name] = mod
+
+
+def _load(name, relpath):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_ROOT, relpath))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+for _pkg in ("egomimic", "egomimic.models", "egomimic.models.hnet"):
+    _ensure_pkg(_pkg)
+
+_load("egomimic.models.hnet.config", "models/hnet/config.py")
+blocks = _load("egomimic.models.hnet.blocks", "models/hnet/blocks.py")
+routing = _load("egomimic.models.hnet.routing", "models/hnet/routing.py")
+scan_interface = _load(
+    "egomimic.models.hnet.scan_interface", "models/hnet/scan_interface.py"
+)
+register_interface = _load(
+    "egomimic.models.hnet.register_interface", "models/hnet/register_interface.py"
+)
+transformer_router = _load(
+    "egomimic.models.hnet.transformer_router", "models/hnet/transformer_router.py"
+)
+_load("egomimic.models.hnet.context", "models/hnet/context.py")
+_load("egomimic.models.hnet.isotropic_builder", "models/hnet/isotropic_builder.py")
+_load("egomimic.models.hnet.residual_mixer", "models/hnet/residual_mixer.py")
+stages = _load("egomimic.models.hnet.stages", "models/hnet/stages.py")
+
+KVCache = blocks.KVCache
+MambaCache = blocks.MambaCache
+IsotropicInferenceParams = blocks.IsotropicInferenceParams
+StateRowMixin = blocks.StateRowMixin
+RoutingModuleState = routing.RoutingModuleState
+DeChunkState = routing.DeChunkState
+ScanRouterState = scan_interface.ScanRouterState
+ChunkScanEncoderState = scan_interface.ChunkScanEncoderState
+SplineUpsamplerState = scan_interface.SplineUpsamplerState
+MSublatentDeChunkerState = scan_interface.MSublatentDeChunkerState
+RegisterTrunkState = register_interface.RegisterTrunkState
+PhaseSummaryRouterState = transformer_router.PhaseSummaryRouterState
+EncoderDecoderStageState = stages.EncoderDecoderStageState
+ChunkerStageState = stages.ChunkerStageState
+ComputeStageState = stages.ComputeStageState
+
+try:
+    import pytest
+
+    _raises = pytest.raises
+except ImportError:  # no-pytest fallback
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _raises(exc):
+        try:
+            yield
+        except exc:
+            return
+        raise AssertionError(f"expected {exc.__name__} to be raised")
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic-state builders. Every field is filled with distinguishable random
+# tensors so a dropped/mixed-up field cannot cancel out.
+# --------------------------------------------------------------------------- #
+
+B, D, M_SUB = 5, 8, 4
+MASK = torch.tensor([True, False, True, True, False])
+K = int(MASK.sum())
+
+
+def _f(*shape):
+    return torch.randn(*shape)
+
+
+def _b(*shape):
+    return torch.rand(*shape) > 0.5
+
+
+def _l(*shape):
+    return torch.randint(0, 97, shape)
+
+
+def make_kv(b=B):
+    return KVCache(k=_f(b, 2, 6, 4), v=_f(b, 2, 6, 4), offsets=_l(b))
+
+
+def make_mamba(b=B):
+    return MambaCache(conv_state=_f(b, 6, 3), ssm_state=_f(b, 2, 4, 4))
+
+
+def make_iso(b=B):
+    return IsotropicInferenceParams(
+        layer_caches={0: make_kv(b), 3: make_mamba(b)}, max_seqlen=64, batch_size=b
+    )
+
+
+def make_routing(b=B):
+    return RoutingModuleState(has_seen_tokens=_b(b), last_hidden_state=_f(b, D))
+
+
+def make_scan_router(b=B):
+    return ScanRouterState(
+        has_seen_tokens=_b(b), gru_h=_f(2, b, 7), mamba_cache=make_mamba(b), h_prev=_f(b, 7)
+    )
+
+
+def make_pser(b=B):
+    return PhaseSummaryRouterState(
+        has_seen_tokens=_b(b),
+        kv=[make_kv(b), make_kv(b)],
+        last_cut_pos=_l(b),
+        t_idx=_l(b),
+        seg_sum=_f(b, D),
+        seg_count=_l(b),
+    )
+
+
+def make_scan_enc(b=B):
+    return ChunkScanEncoderState(gru_h=_f(1, b, 7), offset=_l(b), buf=_f(b, 10, 7))
+
+
+def make_spline(b=B):
+    return SplineUpsamplerState(prev_inner_sub=_f(b, M_SUB, 7), have_prev=_b(b), offset=_l(b))
+
+
+def make_msublatent(b=B):
+    return MSublatentDeChunkerState(
+        prev_inner_sub=_f(b, M_SUB, 7),
+        ema_prev=_f(b, M_SUB * 7),
+        offset=_l(b),
+        have_prev=_b(b),
+    )
+
+
+def make_reg_trunk(b=B):
+    return RegisterTrunkState(
+        reg_k=[_f(b, 12, 4), _f(b, 12, 4)],
+        reg_v=[_f(b, 12, 4), _f(b, 12, 4)],
+        reg_fill=_l(b),
+        mem_k=[_f(b, 6, 4), _f(b, 6, 4)],
+        mem_v=[_f(b, 6, 4), _f(b, 6, 4)],
+        mem_fill=_l(b),
+        mem_x=_f(b, 6, D),
+        offset=_l(b),
+        has_seen=_b(b),
+    )
+
+
+def make_compute(b=B):
+    return ComputeStageState(main_state=make_iso(b), inner_state=None)
+
+
+def make_chunker(b=B, router="scan", with_prev_x=True):
+    routers = {"scan": make_scan_router, "cossim": make_routing, "pser": make_pser}
+    return ChunkerStageState(
+        routing_state=routers[router](b),
+        inner_state=make_compute(b),
+        dechunk_state=DeChunkState(last_value=_f(b, D)),
+        scan_enc_state=make_scan_enc(b),
+        spline_state=make_spline(b),
+        reg_trunk_state=make_reg_trunk(b),
+        prev_x=(_f(b, D) if with_prev_x else None),
+        prev_x_valid=(_b(b) if with_prev_x else None),
+        msublatent_state=make_msublatent(b),
+    )
+
+
+def make_encdec(b=B):
+    return EncoderDecoderStageState(
+        encoder_state=make_iso(b), inner_state=make_chunker(b), decoder_state=make_iso(b)
+    )
+
+
+ALL_BUILDERS = {
+    "KVCache": make_kv,
+    "MambaCache": make_mamba,
+    "IsotropicInferenceParams": make_iso,
+    "RoutingModuleState": make_routing,
+    "ScanRouterState": make_scan_router,
+    "PhaseSummaryRouterState": make_pser,
+    "ChunkScanEncoderState": make_scan_enc,
+    "SplineUpsamplerState": make_spline,
+    "MSublatentDeChunkerState": make_msublatent,
+    "RegisterTrunkState": make_reg_trunk,
+    "ComputeStageState": make_compute,
+    "ChunkerStageState": make_chunker,
+    "EncoderDecoderStageState": make_encdec,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Introspection helpers: flatten any state into {path: tensor}.
+# --------------------------------------------------------------------------- #
+
+
+def flatten(x, prefix=""):
+    out = {}
+    if x is None:
+        return out
+    if isinstance(x, torch.Tensor):
+        out[prefix] = x
+        return out
+    if isinstance(x, dict):
+        for k, v in x.items():
+            out.update(flatten(v, f"{prefix}[{k!r}]"))
+        return out
+    if isinstance(x, (list, tuple)):
+        for i, v in enumerate(x):
+            out.update(flatten(v, f"{prefix}[{i}]"))
+        return out
+    if is_dataclass(x):
+        for f in dc_fields(x):
+            out.update(flatten(getattr(x, f.name), f"{prefix}.{f.name}"))
+        return out
+    if isinstance(x, (int, float, bool, str)):
+        return out  # metadata scalars: compared separately
+    raise TypeError(f"flatten: unexpected type {type(x)} at {prefix!r}")
+
+
+def snapshot(x):
+    return {p: t.clone() for p, t in flatten(x).items()}
+
+
+# The dim-1 exception set, straight from the OLD stages helpers:
+# _slice_scan_enc_state / _slice_routing_state sliced gru_h as [:, mask].
+def _is_dim1(path):
+    return path.endswith(".gru_h")
+
+
+def ref_narrow_flat(state, mask):
+    """OLD-slicing reference on the flattened view: every tensor is sliced on
+    dim 0 with .clone(), EXCEPT GRU hiddens (dim 1)."""
+    return {
+        p: (t[:, mask].clone() if _is_dim1(p) else t[mask].clone())
+        for p, t in flatten(state).items()
+    }
+
+
+# Explicit reference impls (verbatim ports of the OLD stages helpers) for the
+# trickiest classes, so the generic flat rule above is itself cross-checked.
+
+
+def ref_slice_scan_router(rs, mask):
+    return dict(
+        has_seen_tokens=rs.has_seen_tokens[mask].clone(),
+        gru_h=(rs.gru_h[:, mask].clone() if rs.gru_h is not None else None),
+        mamba_conv=(rs.mamba_cache.conv_state[mask].clone()),
+        mamba_ssm=(rs.mamba_cache.ssm_state[mask].clone()),
+        h_prev=(rs.h_prev[mask].clone() if rs.h_prev is not None else None),
+    )
+
+
+def ref_slice_scan_enc(s, mask):
+    return dict(
+        gru_h=s.gru_h[:, mask].clone(),
+        offset=s.offset[mask].clone(),
+        buf=s.buf[mask].clone(),
+    )
+
+
+def ref_slice_iso(params, mask):
+    out = {}
+    for k, c in params.layer_caches.items():
+        if isinstance(c, KVCache):
+            out[k] = (c.k[mask].clone(), c.v[mask].clone(), c.offsets[mask].clone())
+        else:
+            out[k] = (c.conv_state[mask].clone(), c.ssm_state[mask].clone())
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# (a) narrow == old slicing semantics
+# --------------------------------------------------------------------------- #
+
+
+def test_narrow_matches_old_slicing_all_classes():
+    for name, build in ALL_BUILDERS.items():
+        st = build()
+        sub = st.narrow(MASK)
+        got = flatten(sub)
+        want = ref_narrow_flat(st, MASK)
+        assert got.keys() == want.keys(), (
+            f"{name}: narrow dropped/added fields: "
+            f"{set(got) ^ set(want)}"
+        )
+        for p in want:
+            assert torch.equal(got[p], want[p]), f"{name}: mismatch at {p}"
+            assert got[p].dtype == want[p].dtype, f"{name}: dtype changed at {p}"
+
+
+def test_narrow_scan_router_explicit_reference():
+    rs = make_scan_router()
+    sub = rs.narrow(MASK)
+    ref = ref_slice_scan_router(rs, MASK)
+    assert torch.equal(sub.has_seen_tokens, ref["has_seen_tokens"])
+    assert torch.equal(sub.gru_h, ref["gru_h"])  # (num_layers, K, H): dim-1 slice
+    assert sub.gru_h.shape == (2, K, 7)
+    assert torch.equal(sub.mamba_cache.conv_state, ref["mamba_conv"])
+    assert torch.equal(sub.mamba_cache.ssm_state, ref["mamba_ssm"])
+    assert torch.equal(sub.h_prev, ref["h_prev"])
+    # Optional fields None on both sides stay None.
+    rs2 = ScanRouterState(has_seen_tokens=_b(B), gru_h=None, mamba_cache=None, h_prev=None)
+    sub2 = rs2.narrow(MASK)
+    assert sub2.gru_h is None and sub2.mamba_cache is None and sub2.h_prev is None
+
+
+def test_narrow_scan_encoder_explicit_reference():
+    s = make_scan_enc()
+    sub = s.narrow(MASK)
+    ref = ref_slice_scan_enc(s, MASK)
+    assert torch.equal(sub.gru_h, ref["gru_h"]) and sub.gru_h.shape == (1, K, 7)
+    assert torch.equal(sub.offset, ref["offset"])
+    assert torch.equal(sub.buf, ref["buf"])
+
+
+def test_narrow_iso_params_metadata():
+    iso = make_iso()
+    sub = iso.narrow(MASK)
+    # OLD _slice_iso_params: max_seqlen copied, batch_size = mask.sum().
+    assert sub.max_seqlen == iso.max_seqlen == 64
+    assert sub.batch_size == K
+    assert set(sub.layer_caches) == set(iso.layer_caches)
+    ref = ref_slice_iso(iso, MASK)
+    assert torch.equal(sub.layer_caches[0].k, ref[0][0])
+    assert torch.equal(sub.layer_caches[0].v, ref[0][1])
+    assert torch.equal(sub.layer_caches[0].offsets, ref[0][2])
+    assert torch.equal(sub.layer_caches[3].conv_state, ref[3][0])
+    assert torch.equal(sub.layer_caches[3].ssm_state, ref[3][1])
+
+
+def test_narrow_is_deep_copy():
+    for name, build in ALL_BUILDERS.items():
+        st = build()
+        before = snapshot(st)
+        sub = st.narrow(MASK)
+        for t in flatten(sub).values():  # mutate every sub leaf
+            if t.dtype == torch.bool:
+                t.logical_not_()
+            elif t.is_floating_point():
+                t.add_(1.0)
+            else:
+                t.add_(1)
+        after = flatten(st)
+        for p in before:
+            assert torch.equal(after[p], before[p]), (
+                f"{name}: narrow aliased persistent tensor at {p}"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# (b) merge_ round-trip
+# --------------------------------------------------------------------------- #
+
+
+def _mutate_all(state):
+    for t in flatten(state).values():
+        if t.dtype == torch.bool:
+            t.logical_not_()
+        elif t.is_floating_point():
+            t.add_(1.0)
+        else:
+            t.add_(1)
+
+
+def test_merge_roundtrip_all_classes():
+    for name, build in ALL_BUILDERS.items():
+        st = build()
+        before = snapshot(st)
+        sub = st.narrow(MASK)
+        _mutate_all(sub)
+        st.merge_(sub, MASK)
+        after = flatten(st)
+        sub_flat = flatten(sub)
+        for p in before:
+            if _is_dim1(p):
+                assert torch.equal(after[p][:, MASK], sub_flat[p]), f"{name} {p}: masked cols not written"
+                assert torch.equal(after[p][:, ~MASK], before[p][:, ~MASK]), f"{name} {p}: unmasked cols changed"
+            else:
+                assert torch.equal(after[p][MASK], sub_flat[p]), f"{name} {p}: masked rows not written"
+                assert torch.equal(after[p][~MASK], before[p][~MASK]), f"{name} {p}: unmasked rows changed"
+            assert after[p].dtype == before[p].dtype, f"{name} {p}: dtype changed by merge_"
+        # metadata untouched by merge_ (old _scatter_iso_params behavior)
+        if name == "IsotropicInferenceParams":
+            assert st.max_seqlen == 64 and st.batch_size == B
+
+
+def test_merge_is_in_place():
+    st = make_chunker()
+    ids_before = {p: id(t) for p, t in flatten(st).items()}
+    sub = st.narrow(MASK)
+    _mutate_all(sub)
+    st.merge_(sub, MASK)
+    ids_after = {p: id(t) for p, t in flatten(st).items()}
+    assert ids_before == ids_after, "merge_ replaced persistent tensors instead of writing in place"
+
+
+def test_wrapper_dict_state_roundtrip():
+    # PerEmbodimentStage-style dict state through the thin wrappers.
+    state = {"human": make_compute(), "robot": make_compute()}
+    before = snapshot(state)
+    sub = stages._slice_state(state, MASK)
+    assert set(sub) == {"human", "robot"}
+    _mutate_all(sub)
+    stages._scatter_state(state, sub, MASK)
+    after = flatten(state)
+    sub_flat = flatten(sub)
+    for p in before:
+        assert torch.equal(after[p][MASK], sub_flat[p])
+        assert torch.equal(after[p][~MASK], before[p][~MASK])
+    # None passthrough
+    assert stages._slice_state(None, MASK) is None
+    stages._scatter_state(None, None, MASK)  # no-op, no raise
+    # Unknown types still fail loudly.
+    with _raises(TypeError):
+        stages._slice_state(object(), MASK)
+    with _raises(TypeError):
+        stages._scatter_state(object(), object(), MASK)
+
+
+# --------------------------------------------------------------------------- #
+# (c) the prev_x scenario (the bug this refactor fixes)
+# --------------------------------------------------------------------------- #
+
+
+def test_prev_x_eager_roundtrip():
+    st = make_chunker(with_prev_x=True)
+    # Eager-allocation state as _allocate now builds it: zeros + all-invalid.
+    st.prev_x = torch.zeros(B, D)
+    st.prev_x_valid = torch.zeros(B, dtype=torch.bool)
+
+    sub = st.narrow(MASK)
+    assert torch.equal(sub.prev_x, torch.zeros(K, D))
+    assert not sub.prev_x_valid.any()
+
+    # What _step_first_token now does at the sub level: strictly IN PLACE.
+    x = torch.randn(K, D)
+    sub.prev_x.copy_(x)
+    sub.prev_x_valid.fill_(True)
+
+    st.merge_(sub, MASK)
+    assert st.prev_x_valid[MASK].all(), "write-back of prev_x_valid dropped"
+    assert not st.prev_x_valid[~MASK].any()
+    assert torch.equal(st.prev_x[MASK], x), "write-back of prev_x dropped"
+    assert torch.equal(st.prev_x[~MASK], torch.zeros(B - K, D))
+
+    # Second rollout round: the sub now sees the bootstrapped carry.
+    sub2 = st.narrow(MASK)
+    assert sub2.prev_x_valid.all()
+    assert torch.equal(sub2.prev_x, x)
+
+
+def test_prev_x_read_semantics_torch_where():
+    # Mirrors the _step_first_token read: invalid rows take no_prev.
+    prev_x = torch.randn(K, D)
+    valid = torch.tensor([True, False, True]).view(-1, 1)
+    no_prev = torch.randn(D)
+    got = torch.where(valid, prev_x, no_prev.expand_as(prev_x))
+    assert torch.equal(got[0], prev_x[0])
+    assert torch.equal(got[1], no_prev)
+    assert torch.equal(got[2], prev_x[2])
+
+
+# --------------------------------------------------------------------------- #
+# (d) materialize-on-merge (legacy states with prev_x=None)
+# --------------------------------------------------------------------------- #
+
+
+def test_prev_x_materialize_on_merge():
+    st = make_chunker(with_prev_x=False)
+    assert st.prev_x is None and st.prev_x_valid is None
+    sub = st.narrow(MASK)
+    assert sub.prev_x is None  # None-on-both-sides passthrough
+
+    # Legacy sub-level write path (state.prev_x was None): fresh tensors.
+    x = torch.randn(K, D)
+    sub.prev_x = x.clone()
+    sub.prev_x_valid = torch.ones(K, dtype=torch.bool)
+
+    st.merge_(sub, MASK)  # old code silently DROPPED this write-back
+    assert st.prev_x is not None and st.prev_x.shape == (B, D)
+    assert st.prev_x.dtype == x.dtype
+    assert torch.equal(st.prev_x[MASK], x)
+    assert torch.equal(st.prev_x[~MASK], torch.zeros(B - K, D))
+    assert st.prev_x_valid is not None and st.prev_x_valid.dtype == torch.bool
+    assert st.prev_x_valid[MASK].all() and not st.prev_x_valid[~MASK].any()
+
+
+def test_materialize_dim1_field():
+    # dim-1 analogue: gru_h lazily created on the sub side.
+    rs = ScanRouterState(has_seen_tokens=_b(B), gru_h=None, mamba_cache=None, h_prev=None)
+    sub = rs.narrow(MASK)
+    sub.gru_h = torch.randn(2, K, 7)
+    rs.merge_(sub, MASK)
+    assert rs.gru_h is not None and rs.gru_h.shape == (2, B, 7)
+    assert torch.equal(rs.gru_h[:, MASK], sub.gru_h)
+    assert torch.equal(rs.gru_h[:, ~MASK], torch.zeros(2, B - K, 7))
+
+
+def test_none_persistent_nested_state_raises():
+    # None persistent + nested sub-state must fail loudly (naming the field),
+    # not silently drop (old behavior) nor materialize garbage.
+    rs = ScanRouterState(has_seen_tokens=_b(B), gru_h=None, mamba_cache=None, h_prev=None)
+    sub = rs.narrow(MASK)
+    sub.mamba_cache = make_mamba(K)
+    with _raises(AssertionError):
+        rs.merge_(sub, MASK)
+    try:
+        rs2 = ScanRouterState(has_seen_tokens=_b(B), gru_h=None, mamba_cache=None, h_prev=None)
+        sub2 = rs2.narrow(MASK)
+        sub2.mamba_cache = make_mamba(K)
+        rs2.merge_(sub2, MASK)
+    except AssertionError as e:
+        assert "mamba_cache" in str(e)
+
+
+# --------------------------------------------------------------------------- #
+# (e) post-merge assertion fires on a hand-built violation
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _MetaHole(StateRowMixin):
+    """merge_ skips _META_FIELDS by contract, so a sub-only meta value is a
+    hand-built violation the post-merge invariant must catch."""
+
+    _META_FIELDS = ("meta",)
+
+    a: Optional[torch.Tensor] = None
+    meta: Optional[int] = None
+
+
+def test_post_merge_assertion_fires():
+    st = _MetaHole(a=torch.randn(B, 3), meta=None)
+    sub = st.narrow(MASK)
+    sub.meta = 7  # non-None on sub, None (and untouched) on persistent
+    with _raises(AssertionError):
+        st.merge_(sub, MASK)
+
+
+def test_unknown_field_type_fails_loudly():
+    @dataclass
+    class _Odd(StateRowMixin):
+        weird: object = None
+
+    st = _Odd(weird=object())
+    with _raises(TypeError):
+        st.narrow(MASK)
+
+
+# --------------------------------------------------------------------------- #
+# no-pytest fallback runner
+# --------------------------------------------------------------------------- #
+
+if __name__ == "__main__":
+    import traceback
+
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    total = len(fns)
+    print(f"{total - failed}/{total} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Every stage-state dataclass owns its row slice/write-back (generic
dataclasses.fields walk; materialize-on-merge; always-on post-merge
invariant; loud failures on unhandled fields). The ~270-line central
_slice_*/_scatter_* switchboard in stages.py becomes thin delegation.

Fixes (audit-confirmed): grab_prev_end prev_x silently dropped at every
slice/scatter boundary -> nested chunkers rolled out with no_prev on EVERY
chunk (eval-only train/inference mismatch). Now eager prev_x/prev_x_valid,
in-place carry updates, per-row validity read. Also: msublatent_state
allocated, reg_trunk_state gate widened to down_interface=register.

Training path untouched. tests_state_roundtrip.py: 15/15.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CjuZ3zwWaCeQQigxiNuzGw