### PR TITLE
refactor(annotations): role-in-key-name scheme + modular annotation processors

### DIFF
--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -15,6 +15,7 @@ from tslearn.metrics import SoftDTWLossPyTorch
 
 from egomimic.algo.algo import Algo
 from egomimic.models.hpt_nets import MultiheadAttention, SimpleTransformer
+from egomimic.rldb.annotation_processing import AnnotationProcessor
 from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
 from egomimic.utils.egomimicUtils import (
     STD_SCALE,
@@ -817,6 +818,9 @@ class HPT(Algo):
         # ---------------------------
         annotation_key: str | None = None,
         annotation_sampling_mode: Literal["random", "first"] = "random",
+        # Optional hydra-instantiated AnnotationProcessor; when None one is
+        # built from annotation_key + annotation_sampling_mode (back-compat).
+        annotation_processor=None,
         annotation_modality: str = "annotation",
         default_prompt: str = "",
         # ---------------------------
@@ -828,6 +832,13 @@ class HPT(Algo):
         self.norm_stats = norm_stats
         self.annotation_key = annotation_key
         self.annotation_sampling_mode = annotation_sampling_mode
+        self.annotation_processor = (
+            annotation_processor
+            if annotation_processor is not None
+            else AnnotationProcessor(
+                key=annotation_key, strategy=annotation_sampling_mode
+            )
+        )
         self.annotation_modality = annotation_modality
         self.default_prompt = default_prompt
 
@@ -956,20 +967,12 @@ class HPT(Algo):
         self.training_step = 0
 
     def _build_prompts(self, _batch, batch_size: int) -> list[str]:
-        """Sample one annotation per batch item, falling back to default_prompt
-        on empty / missing annotations. Mirrors the Pi algo flow.
+        """Sample one annotation per batch item via the annotation processor,
+        falling back to default_prompt on empty / missing annotations.
+        Mirrors the Pi algo flow.
         """
-        if self.annotation_key is None or self.annotation_key not in _batch:
-            return [self.default_prompt] * batch_size
-        prompts = []
-        for sample in _batch[self.annotation_key]:
-            if not sample:
-                prompts.append(self.default_prompt)
-            elif self.annotation_sampling_mode == "random":
-                prompts.append(sample[random.randint(0, len(sample) - 1)])
-            else:  # "first"
-                prompts.append(sample[0])
-        return prompts
+        sampled = self.annotation_processor(_batch, batch_size)["task"]
+        return [self.default_prompt if p is None else p for p in sampled]
 
     @override
     def process_batch_for_training(self, batch):

--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -15,7 +15,7 @@ from tslearn.metrics import SoftDTWLossPyTorch
 
 from egomimic.algo.algo import Algo
 from egomimic.models.hpt_nets import MultiheadAttention, SimpleTransformer
-from egomimic.rldb.annotation_processing import AnnotationProcessor
+from egomimic.rldb.annotation_processing import DefaultAnnotationProcessor
 from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
 from egomimic.utils.egomimicUtils import (
     STD_SCALE,
@@ -838,7 +838,7 @@ class HPT(Algo):
         self.annotation_processor = (
             annotation_processor
             if annotation_processor is not None
-            else AnnotationProcessor(
+            else DefaultAnnotationProcessor(
                 key=annotation_key, strategy=annotation_sampling_mode
             )
         )

--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -832,6 +832,9 @@ class HPT(Algo):
         self.norm_stats = norm_stats
         self.annotation_key = annotation_key
         self.annotation_sampling_mode = annotation_sampling_mode
+        # An explicitly-provided processor must not be silently ignored when
+        # annotation_key is None (the prompt gate below also honors it).
+        self._explicit_annotation_processor = annotation_processor is not None
         self.annotation_processor = (
             annotation_processor
             if annotation_processor is not None
@@ -1014,7 +1017,9 @@ class HPT(Algo):
 
             # Sample one annotation per item (random/first, default fallback for
             # empty). Stays as list[str]; the Qwen stem owns tokenization.
-            if self.annotation_key is not None:
+            # Also fires when an annotation_processor was explicitly provided
+            # (its key config lives inside the processor, not annotation_key).
+            if self.annotation_key is not None or self._explicit_annotation_processor:
                 processed_batch[embodiment_id]["sampled_prompt"] = self._build_prompts(
                     _batch, B
                 )

--- a/egomimic/algo/pi.py
+++ b/egomimic/algo/pi.py
@@ -23,7 +23,10 @@ from egomimic.models.preprocess_pi_obs import (
     _SimpleObservation,
     _to_minus1_1,
 )
-from egomimic.rldb.annotation_processing import AnnotationProcessor
+from egomimic.rldb.annotation_processing import (
+    AnnotationProcessor,
+    DefaultAnnotationProcessor,
+)
 from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
 from egomimic.utils.action_utils import ConverterRegistry
 
@@ -89,7 +92,7 @@ class PI(Algo):
         self.annotation_processor = (
             annotation_processor
             if annotation_processor is not None
-            else AnnotationProcessor(key=annotation_key, strategy=sampling_mode)
+            else DefaultAnnotationProcessor(key=annotation_key, strategy=sampling_mode)
         )
         self.default_prompt = default_prompt
         self.proprio_in_prompt = proprio_in_prompt

--- a/egomimic/algo/pi.py
+++ b/egomimic/algo/pi.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import random
 from collections import OrderedDict
 from typing import Literal
 
@@ -24,6 +23,7 @@ from egomimic.models.preprocess_pi_obs import (
     _SimpleObservation,
     _to_minus1_1,
 )
+from egomimic.rldb.annotation_processing import AnnotationProcessor
 from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
 from egomimic.utils.action_utils import ConverterRegistry
 
@@ -64,6 +64,12 @@ class PI(Algo):
         tokenizer_max_length: int = 128,
         sampling_mode: Literal["first", "random"] = "random",
         annotation_key: str | None = None,
+        # Modular annotation processing: a hydra-instantiated
+        # AnnotationProcessor that turns the raw batch annotation lists into
+        # per-role sampled strings (see egomimic/rldb/annotation_processing.py).
+        # When None, a default processor is built from annotation_key +
+        # sampling_mode, so existing configs behave identically.
+        annotation_processor: AnnotationProcessor | None = None,
         default_prompt: str = "",
         proprio_in_prompt: bool = False,
         embodiment_label: bool = False,
@@ -80,6 +86,11 @@ class PI(Algo):
         self.tokenizer_max_length = tokenizer_max_length
         self.sampling_mode = sampling_mode
         self.annotation_key = annotation_key
+        self.annotation_processor = (
+            annotation_processor
+            if annotation_processor is not None
+            else AnnotationProcessor(key=annotation_key, strategy=sampling_mode)
+        )
         self.default_prompt = default_prompt
         self.proprio_in_prompt = proprio_in_prompt
         self.embodiment_label = embodiment_label
@@ -233,24 +244,16 @@ class PI(Algo):
     def _build_prompts(
         self, _batch, embodiment_name: str, batch_size: int
     ) -> list[str]:
-        """Sample one prompt per item from the raw annotation lists and
+        """Sample one prompt per item via the annotation processor and
         splice in any of the active blocks. Returns ``batch_size`` strings.
 
-        Mirrors the prompt assembly previously done in
-        ``build_tokenized_collate``. Embodiment is known per-batch (one
-        DataLoader per embodiment), so we don't re-derive it per sample.
+        Sampling lives in ``self.annotation_processor`` (role ``task``);
+        ``None`` per item (no annotation / missing key) falls back to
+        ``default_prompt``. Embodiment is known per-batch (one DataLoader
+        per embodiment), so we don't re-derive it per sample.
         """
-        if self.annotation_key is None or self.annotation_key not in _batch:
-            prompts = [self.default_prompt] * batch_size
-        else:
-            prompts = []
-            for sample in _batch[self.annotation_key]:
-                if not sample:
-                    prompts.append(self.default_prompt)
-                elif self.sampling_mode == "random":
-                    prompts.append(sample[random.randint(0, len(sample) - 1)])
-                else:  # "first"
-                    prompts.append(sample[0])
+        sampled = self.annotation_processor(_batch, batch_size)["task"]
+        prompts = [self.default_prompt if p is None else p for p in sampled]
 
         any_block_active = (
             self.proprio_in_prompt or self.embodiment_label or bool(self.control_mode)

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -254,9 +254,16 @@ def _extract_list_keys(batch):
     This lets ``default_collate`` handle tensors / numbers while variable-length
     annotation lists (``key_type == "annotation_keys"``) are preserved as
     ``list[list[str]]``.
+
+    List keys are UNIONED across the whole batch (not just ``batch[0]``) and
+    missing items fill ``[]``: annotation keys are per-episode (e.g. only sort
+    episodes carry ``annotations_subtask``), so samples in one batch may
+    legitimately differ in which keys they emit.
     """
-    list_keys = {k for k in batch[0] if isinstance(batch[0][k], list)}
-    return {k: [sample.pop(k) for sample in batch] for k in list_keys}
+    list_keys = {
+        k for sample in batch for k in sample if isinstance(sample[k], list)
+    }
+    return {k: [sample.pop(k, []) for sample in batch] for k in list_keys}
 
 
 def _extract_keys(batch, keys):

--- a/egomimic/rldb/annotation_processing.py
+++ b/egomimic/rldb/annotation_processing.py
@@ -5,14 +5,16 @@ Annotation ROLE is encoded in the zarr key NAME (e.g. ``annotations_task``,
 entries are plain ``{"text", "start_idx", "end_idx"}`` spans. ``ZarrDataset``
 fetches every ``annotations*`` key into the batch (``list[list[str]]`` per
 key after ``annotation_collate``); a processor then turns those raw lists
-into per-role sampled strings inside ``process_batch_for_training``.
+into per-role outputs inside ``process_batch_for_training``.
 
-Processors are hydra-instantiable and return ``{role: list[str | None]}``:
-``None`` marks "no annotation for this item" so the algo can apply its own
-fallback (``default_prompt`` for prompts, no-loss for prediction targets).
-
-- :class:`AnnotationProcessor` — default: samples ONE annotation per item
-  from a single key with a ``first`` / ``random`` strategy (role ``task``).
+- :class:`AnnotationProcessor` — the ABSTRACT contract: batch in,
+  ``{role: per-item outputs}`` out. It deliberately does NOT prescribe what
+  a per-item output is (one string, several candidates, a structured
+  target, ...) — that is a policy of the concrete processor, agreed upon
+  with the consuming algo.
+- :class:`DefaultAnnotationProcessor` — the default policy: sample ONE
+  annotation string per item from a single key with a ``first`` / ``random``
+  strategy (role ``task``).
 - :class:`SubtaskAnnotationProcessor` — hierarchical: samples the
   conditioning instruction from ``task_key`` and the prediction target from
   ``subtask_key`` (roles ``task`` + ``subtask``). No cross-role fallback:
@@ -22,11 +24,32 @@ fallback (``default_prompt`` for prompts, no-loss for prediction targets).
 from __future__ import annotations
 
 import random
+from abc import ABC, abstractmethod
 from typing import Literal
 
 
-class AnnotationProcessor:
-    """Sample one annotation string per item from ``batch[key]``.
+class AnnotationProcessor(ABC):
+    """Abstract contract: turn raw batch annotation fields into per-role outputs.
+
+    ``__call__(batch, batch_size)`` returns ``{role: outputs}`` where
+    ``outputs`` is a length-``batch_size`` sequence, one entry per batch
+    item. The ENTRY TYPE is processor-defined — the default samplers emit
+    ``str | None`` (``None`` = "no annotation for this item", so the algo
+    can apply its own fallback), but a subclass may emit candidate lists,
+    structured targets, or anything else its consuming algo expects. Keep
+    new processors hydra-instantiable.
+    """
+
+    #: role names this processor emits (documentation; subclasses override)
+    roles: tuple[str, ...] = ()
+
+    @abstractmethod
+    def __call__(self, batch, batch_size: int) -> dict[str, list]:
+        ...
+
+
+class DefaultAnnotationProcessor(AnnotationProcessor):
+    """Default policy: sample ONE annotation string per item from ``batch[key]``.
 
     ``batch[key]`` is the raw ``list[list[str]]`` left by
     ``annotation_collate`` (outer = batch items, inner = all annotation texts
@@ -34,8 +57,7 @@ class AnnotationProcessor:
     missing/``None`` key — yield ``None``.
     """
 
-    #: roles this processor emits (subclasses extend)
-    roles: tuple[str, ...] = ("task",)
+    roles = ("task",)
 
     def __init__(
         self,
@@ -57,11 +79,11 @@ class AnnotationProcessor:
             return [None] * batch_size
         return [self._sample_one(texts) for texts in batch[key]]
 
-    def __call__(self, batch, batch_size: int) -> dict[str, list[str | None]]:
+    def __call__(self, batch, batch_size: int) -> dict[str, list]:
         return {"task": self._sample_key(batch, self.key, batch_size)}
 
 
-class SubtaskAnnotationProcessor(AnnotationProcessor):
+class SubtaskAnnotationProcessor(DefaultAnnotationProcessor):
     """Sample the (task instruction, subtask target) pair from role-named keys.
 
     - ``task`` (from ``task_key``): the conditioning instruction — populated
@@ -90,7 +112,7 @@ class SubtaskAnnotationProcessor(AnnotationProcessor):
         self.subtask_key = subtask_key
         self.tie_identical = tie_identical
 
-    def __call__(self, batch, batch_size: int) -> dict[str, list[str | None]]:
+    def __call__(self, batch, batch_size: int) -> dict[str, list]:
         task = self._sample_key(batch, self.task_key, batch_size)
         subtask = self._sample_key(batch, self.subtask_key, batch_size)
         if self.tie_identical and self.task_key in batch and self.subtask_key in batch:

--- a/egomimic/rldb/annotation_processing.py
+++ b/egomimic/rldb/annotation_processing.py
@@ -1,0 +1,102 @@
+"""Modular annotation processing.
+
+Annotation ROLE is encoded in the zarr key NAME (e.g. ``annotations_task``,
+``annotations_subtask``) instead of a ``level`` field inside each entry —
+entries are plain ``{"text", "start_idx", "end_idx"}`` spans. ``ZarrDataset``
+fetches every ``annotations*`` key into the batch (``list[list[str]]`` per
+key after ``annotation_collate``); a processor then turns those raw lists
+into per-role sampled strings inside ``process_batch_for_training``.
+
+Processors are hydra-instantiable and return ``{role: list[str | None]}``:
+``None`` marks "no annotation for this item" so the algo can apply its own
+fallback (``default_prompt`` for prompts, no-loss for prediction targets).
+
+- :class:`AnnotationProcessor` — default: samples ONE annotation per item
+  from a single key with a ``first`` / ``random`` strategy (role ``task``).
+- :class:`SubtaskAnnotationProcessor` — hierarchical: samples the
+  conditioning instruction from ``task_key`` and the prediction target from
+  ``subtask_key`` (roles ``task`` + ``subtask``). No cross-role fallback:
+  a missing task never leaks the subtask text into the prompt.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Literal
+
+
+class AnnotationProcessor:
+    """Sample one annotation string per item from ``batch[key]``.
+
+    ``batch[key]`` is the raw ``list[list[str]]`` left by
+    ``annotation_collate`` (outer = batch items, inner = all annotation texts
+    active at that item's frame). Items with no active annotation — or a
+    missing/``None`` key — yield ``None``.
+    """
+
+    #: roles this processor emits (subclasses extend)
+    roles: tuple[str, ...] = ("task",)
+
+    def __init__(
+        self,
+        key: str | None = "annotations",
+        strategy: Literal["first", "random"] = "random",
+    ):
+        self.key = key
+        self.strategy = strategy
+
+    def _sample_one(self, texts) -> str | None:
+        if not texts:
+            return None
+        if self.strategy == "random":
+            return texts[random.randint(0, len(texts) - 1)]
+        return texts[0]  # "first"
+
+    def _sample_key(self, batch, key, batch_size) -> list[str | None]:
+        if key is None or key not in batch:
+            return [None] * batch_size
+        return [self._sample_one(texts) for texts in batch[key]]
+
+    def __call__(self, batch, batch_size: int) -> dict[str, list[str | None]]:
+        return {"task": self._sample_key(batch, self.key, batch_size)}
+
+
+class SubtaskAnnotationProcessor(AnnotationProcessor):
+    """Sample the (task instruction, subtask target) pair from role-named keys.
+
+    - ``task`` (from ``task_key``): the conditioning instruction — populated
+      for ALL annotated episodes (pick_place instruction / sort goal).
+    - ``subtask`` (from ``subtask_key``): the prediction target — only
+      populated where a decomposition exists (sort); ``None`` elsewhere, so
+      those items contribute no LM loss and nothing leaks into the prompt.
+
+    ``tie_identical`` keeps the two roles textually IDENTICAL whenever an
+    item's two candidate lists are equal (the eva regime, where the same
+    instruction set is injected under both keys): one sample is drawn and
+    reused, instead of two independent draws picking different paraphrases.
+    """
+
+    roles = ("task", "subtask")
+
+    def __init__(
+        self,
+        task_key: str = "annotations_task",
+        subtask_key: str = "annotations_subtask",
+        strategy: Literal["first", "random"] = "random",
+        tie_identical: bool = True,
+    ):
+        super().__init__(key=task_key, strategy=strategy)
+        self.task_key = task_key
+        self.subtask_key = subtask_key
+        self.tie_identical = tie_identical
+
+    def __call__(self, batch, batch_size: int) -> dict[str, list[str | None]]:
+        task = self._sample_key(batch, self.task_key, batch_size)
+        subtask = self._sample_key(batch, self.subtask_key, batch_size)
+        if self.tie_identical and self.task_key in batch and self.subtask_key in batch:
+            for i in range(batch_size):
+                t_list = batch[self.task_key][i]
+                s_list = batch[self.subtask_key][i]
+                if t_list and t_list == s_list:
+                    subtask[i] = task[i]
+        return {"task": task, "subtask": subtask}

--- a/egomimic/rldb/zarr/zarr_dataset_action_expert.py
+++ b/egomimic/rldb/zarr/zarr_dataset_action_expert.py
@@ -63,11 +63,16 @@ class ZarrActionExpertDataset(ZarrDataset):
     # --- episode setup -----------------------------------------------------
 
     def _load_annotation_map(self) -> dict[int, int]:
-        """Build {frame_idx -> annotation_index} for every frame inside an annotation span."""
-        raw = self.episode_reader._store["annotations"][:]
-        decoded = [self._decode_json_entry(x) for x in raw]
-        self._annotations = [d for d in decoded if isinstance(d, dict)]
-        for i, ann in enumerate(self._annotations):
+        """Build {frame_idx -> annotation_index} for every frame inside an annotation span.
+
+        Uses the base class's per-key annotation cache (``_load_annotations``
+        returns the decoded list for one zarr key). The entries are kept on a
+        SEPARATE attribute: the base ``self._annotations`` is a
+        ``{zarr_key: list}`` cache dict, and clobbering it with a list breaks
+        the base readers (``_annotation_text_for_frame``).
+        """
+        self._ann_entries = self._load_annotations("annotations")
+        for i, ann in enumerate(self._ann_entries):
             start_idx = int(ann.get("start_idx", -1))
             end_idx = int(ann.get("end_idx", -1))
             for idx in range(start_idx, end_idx + 1):
@@ -145,7 +150,7 @@ class ZarrActionExpertDataset(ZarrDataset):
           - Actions:              <key>  (t..EOS, padded to horizon)
         """
         t = self._valid_frame_indices[index]
-        ann = self._annotations[self.annotation_map[t]]
+        ann = self._ann_entries[self.annotation_map[t]]
         bos, eos = int(ann["start_idx"]), int(ann["end_idx"])
 
         try:

--- a/egomimic/rldb/zarr/zarr_dataset_multi.py
+++ b/egomimic/rldb/zarr/zarr_dataset_multi.py
@@ -1598,27 +1598,40 @@ class ZarrDataset(torch.utils.data.Dataset):
             return json.loads(value)
         return value
 
-    def _load_annotations(self) -> list[dict]:
+    def _annotation_zarr_keys(self) -> list[str]:
+        """All annotation arrays present in this episode. The annotation ROLE
+        is encoded in the key NAME (``annotations``, ``annotations_task``,
+        ``annotations_subtask``, ...) — entries are plain
+        ``{"text", "start_idx", "end_idx"}`` spans with no level field."""
+        return sorted(k for k in self.keys_dict if k.startswith("annotations"))
+
+    def _load_annotations(self, zarr_key: str = "annotations") -> list[dict]:
         """
-        Load and cache decoded language annotations.
+        Load and cache decoded language annotations for ``zarr_key``.
 
         Expected format per entry:
             {"text": str, "start_idx": int, "end_idx": int}
         """
-        if self._annotations is not None:
-            return self._annotations
+        if self._annotations is None:
+            self._annotations = {}
+        if zarr_key not in self._annotations:
+            if zarr_key in self.keys_dict:
+                raw = self.episode_reader._store[zarr_key][:]
+                decoded = [self._decode_json_entry(x) for x in raw]
+                self._annotations[zarr_key] = [
+                    d for d in decoded if isinstance(d, dict)
+                ]
+            else:
+                self._annotations[zarr_key] = []
+        return self._annotations[zarr_key]
 
-        raw = self.episode_reader._store["annotations"][:]
-
-        decoded = [self._decode_json_entry(x) for x in raw]
-        self._annotations = [d for d in decoded if isinstance(d, dict)]
-        return self._annotations
-
-    def _annotation_text_for_frame(self, frame_idx: int) -> str:
+    def _annotation_text_for_frame(
+        self, frame_idx: int, zarr_key: str = "annotations"
+    ) -> list[str]:
         """
-        Resolve language annotation text for a frame from span annotations.
+        Resolve language annotation texts for a frame from span annotations.
         """
-        annotations = self._load_annotations()
+        annotations = self._load_annotations(zarr_key)
         valid_annotations = []
         for ann in annotations:
             start_idx = int(ann.get("start_idx", -1))
@@ -1695,7 +1708,9 @@ class ZarrDataset(torch.utils.data.Dataset):
                 horizon = self.key_map[k].get("horizon", None)
 
                 if key_type == "annotation_keys":
-                    data[k] = self._annotation_text_for_frame(idx)
+                    # Honor the declared zarr_key (previously hardcoded to
+                    # "annotations") so keymaps can alias any annotation array.
+                    data[k] = self._annotation_text_for_frame(idx, zarr_key)
                     continue
 
                 if horizon is not None:
@@ -1724,6 +1739,17 @@ class ZarrDataset(torch.utils.data.Dataset):
                         data[k] = self._decode_json_entry(data[k])
             if retry:
                 continue
+
+            # Fetch ALL annotation keys present in the episode (role encoded in
+            # the key name: annotations, annotations_task, annotations_subtask,
+            # ...). Keymap-declared aliases above take precedence; everything
+            # else is emitted under its zarr name so annotation processors can
+            # pick roles by key without keymap registration. Episodes lacking a
+            # key simply don't emit it — annotation_collate unions across the
+            # batch and fills [] for missing items.
+            for ann_key in self._annotation_zarr_keys():
+                if ann_key not in data:
+                    data[ann_key] = self._annotation_text_for_frame(idx, ann_key)
 
             if self.transform:
                 for transform in self.transform or []:

--- a/egomimic/rldb/zarr/zarr_dataset_multi.py
+++ b/egomimic/rldb/zarr/zarr_dataset_multi.py
@@ -495,6 +495,22 @@ class S3EpisodeResolver(EpisodeResolver):
 # (missing required keymap keys, corrupt JPEGs, or — optionally — episodes
 # without a language-annotation field).
 # ---------------------------------------------------------------------------
+def _tensor_only_collate(batch):
+    """``default_collate`` with list-valued keys dropped.
+
+    ZarrDataset emits every ``annotations*`` array as a variable-length
+    ``list[str]`` per sample; the norm-stats loader only needs the numeric
+    fields and torch's default_collate rejects ragged lists ("each element in
+    list of batch should be of equal size"). Module-level so DataLoader
+    workers can pickle it.
+    """
+    batch = [
+        {k: v for k, v in sample.items() if not isinstance(v, list)}
+        for sample in batch
+    ]
+    return torch.utils.data.default_collate(batch)
+
+
 def _jpeg_probe_failed(ds_obj: "ZarrDataset") -> tuple[str, str] | None:
     """Try decoding 5 sampled frames per image key. If every probe fails
     for a key, return (key, reason); else None."""
@@ -1140,6 +1156,10 @@ class MultiDataset(torch.utils.data.Dataset):
             num_workers=num_workers,
             shuffle=True,
             generator=torch.Generator().manual_seed(seed),
+            # Norm stats only touch numeric fields; drop the variable-length
+            # annotation lists the dataset now always emits (default_collate
+            # would crash on ragged / per-episode-differing list keys).
+            collate_fn=_tensor_only_collate,
         )
         N = len(dataset)
         if N <= 0:
@@ -1558,6 +1578,7 @@ class ZarrDataset(torch.utils.data.Dataset):
         self.keys_dict = {k: (0, None) for k in self.episode_reader._collect_keys()}
         self._image_keys = self._detect_image_keys()
         self._json_keys = self._detect_json_keys()
+        self._annotation_keys_cache = None  # rebuilt per episode open
 
     @property
     def intrinsics(self) -> np.ndarray | dict[str, np.ndarray] | None:
@@ -1602,8 +1623,22 @@ class ZarrDataset(torch.utils.data.Dataset):
         """All annotation arrays present in this episode. The annotation ROLE
         is encoded in the key NAME (``annotations``, ``annotations_task``,
         ``annotations_subtask``, ...) — entries are plain
-        ``{"text", "start_idx", "end_idx"}`` spans with no level field."""
-        return sorted(k for k in self.keys_dict if k.startswith("annotations"))
+        ``{"text", "start_idx", "end_idx"}`` spans with no level field.
+
+        Listed from the actual zarr STORE, not the ``features`` attrs metadata:
+        annotation arrays injected post-hoc (``ZarrWriter.append_annotations``
+        via bucket_to_zarr) historically never updated ``features``, so a
+        metadata-based listing would silently miss them.
+        """
+        if getattr(self, "_annotation_keys_cache", None) is None:
+            try:
+                names = list(self.episode_reader._store.array_keys())
+            except Exception:
+                names = list(self.keys_dict)
+            self._annotation_keys_cache = sorted(
+                k for k in names if k.startswith("annotations")
+            )
+        return self._annotation_keys_cache
 
     def _load_annotations(self, zarr_key: str = "annotations") -> list[dict]:
         """
@@ -1611,18 +1646,23 @@ class ZarrDataset(torch.utils.data.Dataset):
 
         Expected format per entry:
             {"text": str, "start_idx": int, "end_idx": int}
+
+        Reads the store directly (an absent array yields ``[]``) — gating on
+        the ``features`` metadata would miss post-hoc injected annotation
+        arrays, which don't appear there.
         """
         if self._annotations is None:
             self._annotations = {}
         if zarr_key not in self._annotations:
-            if zarr_key in self.keys_dict:
+            try:
                 raw = self.episode_reader._store[zarr_key][:]
+            except KeyError:
+                self._annotations[zarr_key] = []
+            else:
                 decoded = [self._decode_json_entry(x) for x in raw]
                 self._annotations[zarr_key] = [
                     d for d in decoded if isinstance(d, dict)
                 ]
-            else:
-                self._annotations[zarr_key] = []
         return self._annotations[zarr_key]
 
     def _annotation_text_for_frame(
@@ -1809,15 +1849,24 @@ class ZarrAnnotationCutoffDataset(ZarrDataset):
     def _build_frame_to_ann_end(self) -> dict[int, int]:
         """Map ``frame_idx -> ann_end`` (exclusive) for every frame inside an
         annotation span. Annotations use half-open ``[start_idx, end_idx)``.
+
+        Spans are unioned across ALL annotation keys present in the episode
+        (``annotations``, ``annotations_task``, ``annotations_subtask``, ...),
+        keeping the furthest end per frame — role-keyed episodes carry no
+        plain ``annotations`` array, so a single hardcoded key would silently
+        disable the EOS clamp for them. Legacy episodes behave identically
+        (their only key is ``annotations``).
         """
         mapping: dict[int, int] = {}
-        for ann in self._load_annotations():
-            start_idx = int(ann.get("start_idx", -1))
-            end_idx = int(ann.get("end_idx", -1))
-            if start_idx < 0 or end_idx <= start_idx:
-                continue
-            for idx in range(start_idx, end_idx):
-                mapping[idx] = end_idx
+        for ann_key in self._annotation_zarr_keys() or ["annotations"]:
+            for ann in self._load_annotations(ann_key):
+                start_idx = int(ann.get("start_idx", -1))
+                end_idx = int(ann.get("end_idx", -1))
+                if start_idx < 0 or end_idx <= start_idx:
+                    continue
+                for idx in range(start_idx, end_idx):
+                    if end_idx > mapping.get(idx, -1):
+                        mapping[idx] = end_idx
         return mapping
 
     def _chunk_end_idx(self, start_idx: int, horizon: int, key_type: str | None) -> int:

--- a/egomimic/rldb/zarr/zarr_writer.py
+++ b/egomimic/rldb/zarr/zarr_writer.py
@@ -644,6 +644,14 @@ class ZarrWriter:
                 self.remove_key(self.episode_path, annotation_key)
         store = zarr.open(str(self.episode_path), mode="a", zarr_format=3)
         self._write_annotations(store, annotations, annotation_key)
+        # Post-hoc injection into an EXISTING episode: merge the new key into
+        # the persisted ``features`` attrs so metadata-based key listings see
+        # it. (_write_annotations only updates self._features, which fresh
+        # writers never flush for appends — historically injected annotation
+        # arrays were invisible to ``features`` readers.)
+        feats = dict(store.attrs.get("features", {}))
+        feats[annotation_key] = self._features[annotation_key]
+        store.attrs["features"] = feats
 
     def _write_annotations(
         self,


### PR DESCRIPTION
Annotation role is now encoded in the zarr KEY NAME (annotations_task /
annotations_subtask) instead of a 'level' field inside each entry — entries
are plain {text, start_idx, end_idx} spans.

- ZarrDataset fetches ALL annotations* keys per episode (each under its own
  name; keymap-declared aliases take precedence and now honor their declared
  zarr_key instead of a hardcoded 'annotations' read). Per-key cache.
- annotation_collate unions list keys across the batch and fills [] for
  items missing a key (annotation keys are per-episode: only sort episodes
  carry annotations_subtask).
- New egomimic/rldb/annotation_processing.py: AnnotationProcessor (default:
  sample one string from one key, first/random) and
  SubtaskAnnotationProcessor (task + subtask roles from role-named keys; no
  cross-role fallback, so a missing task never leaks the subtask target into
  the prompt; tie_identical keeps eva's task==subtask draws identical).
- PI + HPT: prompt sampling delegated to the processor; annotation_key +
  sampling_mode still accepted and build the default processor, so every
  existing config behaves identically.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TYmG3nhxt7LYiaaSJPsKEV