### PR TITLE
feat(annotations): converters emit role-keyed annotation JSONs (task/subtask)

### DIFF
--- a/egomimic/scripts/language_process/augment_prompt.txt
+++ b/egomimic/scripts/language_process/augment_prompt.txt
@@ -29,6 +29,7 @@ Rules:
 - Keep each variant grammatical, concise (under 25 words), and natural.
 - Every string must be a valid standalone instruction a robot could follow.
 - Variants that drop information must still fully describe the core action and object.
+- NEVER drop or generalize the object's descriptors. Keep its color, material, size, and every modifier exactly as in the original (e.g. keep "the blue stuffed animal" as "the blue stuffed animal"; never shorten it to "the stuffed animal" or drop "blue"). Only arm, placement/orientation, and grabbing-method information may be omitted — per the variant types above; the object's identity and descriptors are never omittable.
 - Do not include the original instruction in the output; the caller will add it back.
 - Return only the JSON array, e.g. ["variant one", "variant two"].
 - Ensure there are exactly 12 variants total, each from the types listed above. Only 3 variants should include full information. 

--- a/egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py
+++ b/egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py
@@ -6,6 +6,12 @@ Counterpart to scale_to_bucket_annotation_parallel.py. Each Ray task:
 
 Episodes that already have ``annotation_key`` in their Zarr are skipped (unless --overwrite).
 
+Role-keyed scheme: run once per role (--annotation-key annotations_task, then
+annotations_subtask) against the SAME bucket state — the per-key skip is
+independent, so mixing runs after a bucket regeneration can pair a task array
+with a subtask array from different converter runs; pass --overwrite on both
+after regenerating.
+
 Example usage:
 python egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py \
 --dataset-config-path egomimic/hydra_configs/data/eva_pi_lang.yaml \

--- a/egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py
+++ b/egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py
@@ -71,6 +71,9 @@ def process_episode(
     obj = s3.get_object(Bucket=bucket, Key=key)
     payload = json.loads(obj["Body"].read().decode("utf-8"))
 
+    # Plain span entries — the annotation ROLE lives in the key NAME
+    # (annotations_task / annotations_subtask / ...), selected per run via
+    # --annotation-key; entries carry no level field.
     annotations = [
         (entry["text"], int(entry["start_idx"]), int(entry["end_idx"]))
         for entry in payload
@@ -116,6 +119,13 @@ if __name__ == "__main__":
         default=1,
         help="CPUs reserved per Ray task (default: 1)",
     )
+    parser.add_argument(
+        "--dataset-dir",
+        type=str,
+        default=None,
+        help="Resolve the config's ${paths.dataset_dir} (resolver folder_path). "
+        "Required when the dataset config inherits folder_path: ${paths.dataset_dir}.",
+    )
     args = parser.parse_args()
 
     bucket, prefix = parse_s3_uri(args.bucket)
@@ -130,6 +140,22 @@ if __name__ == "__main__":
     rel_path = os.path.relpath(abs_cfg_path, HYDRA_CONFIG_DIR)
     config_name = os.path.splitext(rel_path)[0]
     dataset_cfg = load_config(config_name)
+
+    # load_config composes only the `data` group, so ${paths.dataset_dir} (the
+    # resolver folder_path inherited from cotrain_pi_base) has no node to resolve
+    # against. Overwrite each train resolver's folder_path with --dataset-dir so
+    # the real resolver runs unmodified (valid resolvers interpolate from train).
+    if args.dataset_dir is not None:
+        from omegaconf import OmegaConf
+
+        OmegaConf.set_struct(dataset_cfg, False)
+        for _name in list((dataset_cfg.get("train_datasets") or {}).keys()):
+            _ds = dataset_cfg.train_datasets[_name]
+            if _ds is None:
+                continue
+            _res = _ds.get("resolver")
+            if _res is not None and "folder_path" in _res:
+                _res.folder_path = args.dataset_dir
 
     train_datasets = {}
     for dataset_name in dataset_cfg.train_datasets:

--- a/egomimic/scripts/language_process/bucket_to_zarr_parallel.sbatch
+++ b/egomimic/scripts/language_process/bucket_to_zarr_parallel.sbatch
@@ -13,7 +13,18 @@ source ~/.bashrc
 source .venv/bin/activate && export PATH="/storage/project/r-dxu345-0/paphiwetsa3/install/bin:$PATH"
 
 # --num-cpus-per-task defaults to 1, meaning 12 episodes process at the same time.
+# Role-keyed scheme: scale_to_bucket uploads {hash}_annotations_task.json (+
+# _annotations_subtask.json where emitted); inject each role under its own
+# zarr key. Run BOTH from the same bucket state so an episode's two roles
+# always come from one converter run.
 python egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py \
     --dataset-config-path egomimic/hydra_configs/data/eva_pi_lang.yaml \
     --bucket s3://rldb/processed_annotations \
+    --annotation-key annotations_task \
+    --overwrite
+
+python egomimic/scripts/language_process/bucket_to_zarr_annotation_parallel.py \
+    --dataset-config-path egomimic/hydra_configs/data/eva_pi_lang.yaml \
+    --bucket s3://rldb/processed_annotations \
+    --annotation-key annotations_subtask \
     --overwrite

--- a/egomimic/scripts/language_process/converter.py
+++ b/egomimic/scripts/language_process/converter.py
@@ -4,6 +4,17 @@ from abc import abstractmethod
 
 from openai import OpenAI
 
+# Annotation ROLE is encoded in the zarr KEY NAME (one array per role) —
+# entries are plain ``(text, start_idx, end_idx)`` with no level field. The
+# PI subtask-prediction pipeline conditions on ``annotations_task`` and
+# predicts ``annotations_subtask``; see
+# ``egomimic/rldb/annotation_processing.py``. The task key is populated for
+# BOTH pick_place and sort episodes (the instruction / the sort goal); the
+# subtask key only where a decomposition exists (sort), or as an identical
+# copy of the task instruction when ``subtask_copy`` is set (eva regime).
+KEY_TASK = "annotations_task"
+KEY_SUBTASK = "annotations_subtask"
+
 
 def micro_seconds_to_frames(micro_seconds: int, fps: int) -> int:
     return micro_seconds / 1000000 * fps
@@ -13,14 +24,16 @@ class ScaleToZarrAnnotationConverter:
     def __init__(self, scale_annotation_dir: str):
         self.scale_annotation_dir = scale_annotation_dir
 
-    def convert(self, tid: str) -> dict:
+    def convert(self, tid: str) -> dict[str, list]:
+        """Returns ``{annotation_key_name: [(text, start_idx, end_idx), ...]}``
+        — one entry list per role-named zarr key."""
         scale_annotation_path = os.path.join(self.scale_annotation_dir, f"{tid}.json")
         with open(scale_annotation_path, "r") as f:
             annotation_dict = json.load(f)
         return self.scale_to_str_format(annotation_dict)
 
     @abstractmethod
-    def scale_to_str_format(self, annotation_dict: dict) -> dict:
+    def scale_to_str_format(self, annotation_dict: dict) -> dict[str, list]:
         pass
 
 
@@ -40,6 +53,7 @@ class PickPlaceLLMConverter(LLMConverter):
         scale_annotation_dir: str,
         prompt_filepath: str,
         augment_prompt_filepath: str | None = None,
+        subtask_copy: bool = False,
     ):
         super().__init__(scale_annotation_dir, prompt_filepath)
         if augment_prompt_filepath is not None:
@@ -47,39 +61,61 @@ class PickPlaceLLMConverter(LLMConverter):
                 self.augment_prompt_template = f.read()
         else:
             self.augment_prompt_template = None
+        # When True, the task instructions are ALSO written verbatim under the
+        # subtask key (eva regime: identical task prompt and subtask target).
+        self.subtask_copy = subtask_copy
 
-    def scale_to_str_format(self, annotation_dict: dict) -> dict:
-        annotations = annotation_dict["annotations"]
-        zarr_annotations_list = []
-        for annotation in annotations:
+    def scale_to_str_format(self, annotation_dict: dict) -> dict[str, list]:
+        # Pick-and-place instructions ARE the task-level conditioning for
+        # non-sort episodes — written under the task key (no read-time
+        # fallback; a missing task never borrows the subtask text).
+        task_entries = []
+        for prompt_dict, start_idx, end_idx in self._iter_pick_place_clips(
+            annotation_dict
+        ):
+            base_instruction = self.scale_annotation_to_str(prompt_dict)
+            instructions = self.augment_instruction(base_instruction, prompt_dict)
+            for instruction in instructions:
+                task_entries.append((instruction, start_idx, end_idx))
+        keyed = {KEY_TASK: task_entries}
+        if self.subtask_copy:
+            keyed[KEY_SUBTASK] = list(task_entries)
+        return keyed
+
+    def _iter_pick_place_clips(self, annotation_dict: dict):
+        """Yield ``(prompt_dict, start_idx, end_idx)`` for every valid
+        pick-and-place clip.
+
+        Encapsulates the shared parsing/filtering — derive the arm from the
+        actuator label, convert the clip's microsecond span to frames, drop
+        clips flagged as a mistake and "Adjust" (or action-less) clips — so
+        subclasses such as :class:`SortConverter` reuse the exact same
+        low-level extraction instead of re-deriving it.
+        """
+        for annotation in annotation_dict["annotations"]:
             if "label" not in annotation:
                 continue
             arm = annotation["label"].split(" ")[0].lower()
-            clips = annotation["clips"]
-            for clip in clips:
+            for clip in annotation["clips"]:
+                if "attributes" not in clip:
+                    # High-level tracks (e.g. the sort "Sorting" track) carry a
+                    # bare text clip with no action attributes — not a
+                    # pick-and-place motion, so skip it here.
+                    continue
                 timestamp = micro_seconds_to_frames(clip["timestamp"], self.fps)
                 duration = micro_seconds_to_frames(clip["duration"], self.fps)
-                attributes = clip["attributes"]
-                text = clip["text"]
                 attr_dict = {}
-                for attribute in attributes:
+                for attribute in clip["attributes"]:
                     attr_dict[attribute["name"]] = attribute["values"][0]
-                if attr_dict["Mistake"] == "Yes":
+                if attr_dict.get("Mistake") == "Yes":
                     continue
                 if "Action" not in attr_dict or attr_dict["Action"] == "Adjust":
                     continue
                 prompt_dict = attr_dict.copy()
-                prompt_dict.pop("Mistake")
-                prompt_dict["description"] = text
+                prompt_dict.pop("Mistake", None)
+                prompt_dict["description"] = clip["text"]
                 prompt_dict["arm"] = arm
-
-                base_instruction = self.scale_annotation_to_str(prompt_dict)
-                instructions = self.augment_instruction(base_instruction, prompt_dict)
-                start_idx = timestamp
-                end_idx = timestamp + duration
-                for instruction in instructions:
-                    zarr_annotations_list.append((instruction, start_idx, end_idx))
-        return zarr_annotations_list
+                yield prompt_dict, timestamp, timestamp + duration
 
     def scale_annotation_to_str(self, scale_annotation_dict: dict) -> str:
         model_prompt = self.prompt_template + "\n" + json.dumps(scale_annotation_dict)
@@ -95,16 +131,26 @@ class PickPlaceLLMConverter(LLMConverter):
         plus, when an augmentation prompt is configured, LLM-generated
         synonyms and variants that omit arm and place-orientation info.
         """
-        if self.augment_prompt_template is None:
+        return self._augment_with_template(
+            base_instruction, scale_annotation_dict, self.augment_prompt_template
+        )
+
+    def _augment_with_template(
+        self, base_instruction: str, metadata: dict, template: str | None
+    ) -> list[str]:
+        """Shared augmentation: ask the LLM for a JSON array of variants and
+        return ``[base_instruction, *unique_variants]``. Returns just
+        ``[base_instruction]`` when no augmentation template is configured."""
+        if template is None:
             return [base_instruction]
 
         model_prompt = (
-            self.augment_prompt_template
+            template
             + "\n"
             + json.dumps(
                 {
                     "instruction": base_instruction,
-                    "metadata": scale_annotation_dict,
+                    "metadata": metadata,
                 }
             )
         )
@@ -124,6 +170,240 @@ class PickPlaceLLMConverter(LLMConverter):
                 deduped.append(v)
                 seen.add(v)
         return deduped
+
+
+class SortConverter(PickPlaceLLMConverter):
+    """Convert Scale annotations for *sort* tasks into Zarr annotation tuples.
+
+    A sort episode's Scale annotation has separate label tracks:
+
+      * ``Left Gripper`` / ``Right Gripper`` — the *low-level* pick-and-place
+        clips (with Action/Mistake/… attributes), handled exactly like
+        :class:`PickPlaceLLMConverter`.
+      * ``Sorting`` — the *high-level* sort goals, written by the annotators as
+        plain ``text`` clips (no attributes), each spanning the window of the
+        sort sub-goal it describes (e.g. "Sort the corn and the croissant on
+        the white plate").
+      * ``Both Grippers`` — return-to-home transitions (empty ``text``). Kept
+        as low-level clips too, mirroring :class:`PickPlaceLLMConverter` (which
+        annotates "Return to home" from the Action even with empty text); each
+        pairs with the nearest sort goal since they fall between sort windows.
+
+    High-level instructions are therefore *read* from the ``Sorting`` track
+    rather than generated. Each low-level pick-and-place clip is paired with the
+    sort instruction active during it (max temporal overlap); both sides are
+    augmented and truncated to a common count so that **every low-level span
+    carries an equal number of high-level sort and low-level pick-and-place
+    instructions** — i.e. the two granularities are balanced at all times
+    (frames with no pick-and-place clip trivially carry 0 == 0).
+
+    If an annotation has no ``Sorting`` track and ``sort_prompt_filepath`` is
+    configured, the converter falls back to LLM-generating a single high-level
+    instruction from the pick-and-place steps.
+    """
+
+    #: Annotation labels (case-insensitive prefix) that hold the high-level
+    #: sort-goal text track.
+    SORT_LABEL_PREFIX = "sort"
+
+    def __init__(
+        self,
+        scale_annotation_dir: str,
+        prompt_filepath: str,
+        sort_prompt_filepath: str | None = None,
+        augment_prompt_filepath: str | None = None,
+        sort_augment_prompt_filepath: str | None = None,
+    ):
+        super().__init__(
+            scale_annotation_dir,
+            prompt_filepath,
+            augment_prompt_filepath=augment_prompt_filepath,
+        )
+        # Optional LLM-generation prompt — only used as a fallback when the
+        # annotation has no human-written "Sorting" track.
+        self.sort_prompt_template = self._read_template(sort_prompt_filepath)
+        # Augmentation prompt for the high-level sort instructions.
+        self.sort_augment_prompt_template = self._read_template(
+            sort_augment_prompt_filepath
+        )
+
+    @staticmethod
+    def _read_template(path: str | None) -> str | None:
+        if path is None:
+            return None
+        with open(path, "r") as f:
+            return f.read()
+
+    def scale_to_str_format(self, annotation_dict: dict) -> dict[str, list]:
+        # Subtask level: every gripper pick-and-place clip, exactly like
+        # PickPlaceLLMConverter (only Mistake/Adjust clips are filtered, inside
+        # _iter_pick_place_clips). This keeps "Return to home" transition clips,
+        # which pick_place also annotates — the LLM phrases them from the Action
+        # even though their text is empty.
+        low_clips = list(self._iter_pick_place_clips(annotation_dict))
+        if not low_clips:
+            return {}
+
+        # Task level: read the human-written "Sorting" track. Fall back to LLM
+        # generation only when no such track exists.
+        sort_intervals = self._iter_sort_clips(annotation_dict)
+        fallback_pool: list[str] | None = None
+        if not sort_intervals:
+            if self.sort_prompt_template is None:
+                return {}
+            context = self.build_sort_context(low_clips)
+            fallback_pool = self._nonblank(
+                self.augment_sort_instruction(
+                    self.sort_annotation_to_str(context), context
+                )
+            )
+            if not fallback_pool:
+                return {}
+
+        # Augment each distinct sort instruction at most once.
+        aug_cache: dict[str, list[str]] = {}
+
+        def high_pool_for(text: str) -> list[str]:
+            if text not in aug_cache:
+                aug_cache[text] = self._nonblank(
+                    self.augment_sort_instruction(text, {"task": "sort"})
+                )
+            return aug_cache[text]
+
+        task_entries = []
+        subtask_entries = []
+        for i, (prompt_dict, start_idx, end_idx) in enumerate(low_clips):
+            if sort_intervals:
+                high_text = self._sort_text_for_span(start_idx, end_idx, sort_intervals)
+                high_pool = high_pool_for(high_text) if high_text else []
+            else:
+                high_pool = fallback_pool
+
+            low_base = self.scale_annotation_to_str(prompt_dict)
+            low_pool = self._nonblank(self.augment_instruction(low_base, prompt_dict))
+            if not low_pool or not high_pool:
+                continue
+
+            # Rotate the high-level pool so successive spans pair with different
+            # phrasings, then truncate both sides to equal length so the span
+            # carries the same count of each granularity.
+            offset = i % len(high_pool)
+            high_rotated = high_pool[offset:] + high_pool[:offset]
+            low_balanced, high_balanced = self.balance_instructions(
+                low_pool, high_rotated
+            )
+            # Role in the KEY NAME: the sort goal conditions the model
+            # (task key), the pick-and-place phrasing is the prediction
+            # target (subtask key). Same span on both sides so a frame's two
+            # candidate lists stay pairable.
+            for instruction in low_balanced:
+                subtask_entries.append((instruction, start_idx, end_idx))
+            for instruction in high_balanced:
+                task_entries.append((instruction, start_idx, end_idx))
+        if not task_entries and not subtask_entries:
+            return {}
+        return {KEY_TASK: task_entries, KEY_SUBTASK: subtask_entries}
+
+    def _iter_sort_clips(self, annotation_dict: dict) -> list[tuple[str, float, float]]:
+        """Return ``(text, start_idx, end_idx)`` for the high-level "Sorting"
+        track — annotations whose label starts with "sort", whose clips carry
+        the sort goal as ``text`` (and have no action attributes)."""
+        intervals: list[tuple[str, float, float]] = []
+        for annotation in annotation_dict["annotations"]:
+            label = annotation.get("label", "") or ""
+            if not label.strip().lower().startswith(self.SORT_LABEL_PREFIX):
+                continue
+            for clip in annotation["clips"]:
+                text = (clip.get("text") or "").strip()
+                if not text:
+                    continue
+                start_idx = micro_seconds_to_frames(clip["timestamp"], self.fps)
+                end_idx = start_idx + micro_seconds_to_frames(
+                    clip["duration"], self.fps
+                )
+                intervals.append((text, start_idx, end_idx))
+        return intervals
+
+    @staticmethod
+    def _sort_text_for_span(
+        start_idx: float,
+        end_idx: float,
+        sort_intervals: list[tuple[str, float, float]],
+    ) -> str | None:
+        """Return the sort instruction active during the clip span
+        ``[start_idx, end_idx]``: the one with the most temporal overlap, or —
+        for a clip that falls in a gap between sort goals (e.g. a return-to-home
+        transition) — the temporally nearest one. ``None`` only when there are
+        no sort intervals at all."""
+        best_text, best_overlap = None, 0.0
+        for text, s, e in sort_intervals:
+            overlap = max(0.0, min(end_idx, e) - max(start_idx, s))
+            if overlap > best_overlap:
+                best_overlap, best_text = overlap, text
+        if best_text is not None:
+            return best_text
+        # No overlap: fall back to the temporally nearest sort instruction.
+        nearest_text, nearest_dist = None, None
+        for text, s, e in sort_intervals:
+            dist = max(s - end_idx, start_idx - e, 0.0)
+            if nearest_dist is None or dist < nearest_dist:
+                nearest_dist, nearest_text = dist, text
+        return nearest_text
+
+    @staticmethod
+    def _nonblank(instructions: list[str]) -> list[str]:
+        """Drop ``None``/blank instructions so an empty LLM response never
+        becomes an empty-text annotation (keeps per-span counts meaningful)."""
+        return [s for s in instructions if s and s.strip()]
+
+    def build_sort_context(self, clips: list) -> dict:
+        """Summarize the episode's pick-and-place sub-actions into a grounded
+        context for the LLM-generation *fallback* (used only when there is no
+        human-written "Sorting" track).
+
+        The arm/hand is intentionally omitted: a high-level sort goal is
+        arm-agnostic and both sort prompts forbid mentioning a hand.
+
+        Args:
+            clips: ``(prompt_dict, start_idx, end_idx)`` tuples, in episode order.
+        """
+        steps = []
+        for prompt_dict, _, _ in clips:
+            steps.append(
+                {
+                    "Action": prompt_dict.get("Action"),
+                    "description": prompt_dict.get("description"),
+                }
+            )
+        return {
+            "task": "sort",
+            "steps": steps,
+        }
+
+    def sort_annotation_to_str(self, sort_context: dict) -> str:
+        """Generate one high-level sort instruction from the episode context
+        (fallback path; requires ``sort_prompt_filepath``)."""
+        model_prompt = self.sort_prompt_template + "\n" + json.dumps(sort_context)
+        response = self.client.responses.create(model=self.model, input=model_prompt)
+        return response.output_text
+
+    def augment_sort_instruction(
+        self, base_instruction: str, sort_context: dict
+    ) -> list[str]:
+        """High-level analogue of :meth:`augment_instruction` using the sort
+        augmentation prompt. Always includes ``base_instruction`` first."""
+        return self._augment_with_template(
+            base_instruction, sort_context, self.sort_augment_prompt_template
+        )
+
+    @staticmethod
+    def balance_instructions(
+        low_list: list[str], high_list: list[str]
+    ) -> tuple[list[str], list[str]]:
+        """Truncate both lists to a common length so a span carries an equal
+        number of low-level and high-level instructions."""
+        k = min(len(low_list), len(high_list))
+        return low_list[:k], high_list[:k]
 
 
 class HardCodedConverter(ScaleToZarrAnnotationConverter):

--- a/egomimic/scripts/language_process/converter.py
+++ b/egomimic/scripts/language_process/converter.py
@@ -20,7 +20,7 @@ def micro_seconds_to_frames(micro_seconds: int, fps: int) -> int:
     return micro_seconds / 1000000 * fps
 
 
-class ScaleToZarrAnnotationConverter:
+class ScaleAnnotationConverter:
     def __init__(self, scale_annotation_dir: str):
         self.scale_annotation_dir = scale_annotation_dir
 
@@ -37,7 +37,7 @@ class ScaleToZarrAnnotationConverter:
         pass
 
 
-class LLMConverter(ScaleToZarrAnnotationConverter):
+class LLMConverter(ScaleAnnotationConverter):
     def __init__(self, scale_annotation_dir: str, prompt_filepath: str):
         super().__init__(scale_annotation_dir)
         self.client = OpenAI()
@@ -406,6 +406,6 @@ class SortConverter(PickPlaceLLMConverter):
         return low_list[:k], high_list[:k]
 
 
-class HardCodedConverter(ScaleToZarrAnnotationConverter):
+class HardCodedConverter(ScaleAnnotationConverter):
     def scale_to_str_format(self, annotation: dict) -> dict:
         pass

--- a/egomimic/scripts/language_process/correct_annotation_keys.py
+++ b/egomimic/scripts/language_process/correct_annotation_keys.py
@@ -1,0 +1,235 @@
+"""Migrate existing level-tagged annotation JSONs on S3 to the role-keyed scheme.
+
+Reads every ``{prefix}/{hash}_annotations.json`` (the old single-key files
+whose entries carry a ``level`` field — or no level at all for the pre-sort
+pick_place era), splits them into the new role-named files WITHOUT re-running
+any LLM generation, uploads those, and (with ``--delete-old``) removes the old
+object:
+
+    {hash}_annotations_task.json      <- level == "high" entries (sort goals),
+                                         or ALL entries when the episode has
+                                         no high entries (pick_place: the
+                                         instruction IS the task conditioning)
+    {hash}_annotations_subtask.json   <- level != "high" entries for sort
+                                         episodes; for eva pick_place episodes
+                                         an identical copy of the task list
+                                         (subtask_copy regime); absent for
+                                         aria/human pick_place
+
+Entries are rewritten as plain ``{text, start_idx, end_idx}`` — the ``level``
+field is dropped (role lives in the key name; see converter.py).
+
+Eva-vs-human is resolved by looking up each episode hash's ``embodiment`` in
+the SQL registry (``eva_*`` -> subtask copy). Use ``--assume-embodiment`` to
+skip SQL (e.g. a bucket known to be single-embodiment).
+
+Safety: ``--dry-run`` prints the per-episode plan without writing; start with
+``--episode-hash`` / ``--limit`` on a small sample. Old files are only deleted
+with ``--delete-old``, and only after BOTH new uploads for that episode
+succeed.
+
+Usage:
+    python correct_annotation_keys.py --bucket s3://rldb/scale_annotations \
+        [--episode-hash H | --limit N] [--dry-run] [--delete-old] \
+        [--assume-embodiment eva|human]
+"""
+
+import argparse
+import json
+
+OLD_SUFFIX = "_annotations.json"
+TASK_SUFFIX = "_annotations_task.json"
+SUBTASK_SUFFIX = "_annotations_subtask.json"
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    if uri.startswith("s3://"):
+        uri = uri[len("s3://") :]
+    parts = uri.split("/", 1)
+    return parts[0], (parts[1].rstrip("/") if len(parts) > 1 else "")
+
+
+def list_old_annotation_objects(s3, bucket: str, prefix: str) -> list[str]:
+    """All object keys under ``prefix`` ending in exactly ``_annotations.json``
+    (the old single-key files; the new ``_annotations_task/_subtask`` files
+    don't match)."""
+    keys = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            k = obj["Key"]
+            if k.endswith(OLD_SUFFIX) and not (
+                k.endswith(TASK_SUFFIX) or k.endswith(SUBTASK_SUFFIX)
+            ):
+                keys.append(k)
+    return sorted(keys)
+
+
+def episode_hash_of(key: str) -> str:
+    return key.rsplit("/", 1)[-1][: -len(OLD_SUFFIX)]
+
+
+def fetch_embodiments(hashes: list[str]) -> dict[str, str]:
+    """{episode_hash: embodiment} from the SQL registry."""
+    from sqlalchemy import text
+
+    from egomimic.utils.aws.aws_data_utils import load_env
+    from egomimic.utils.aws.aws_sql import create_default_engine
+
+    load_env()
+    eng = create_default_engine()
+    out: dict[str, str] = {}
+    with eng.connect() as c:
+        for row in c.execute(
+            text(
+                "SELECT episode_hash, embodiment FROM app.episodes "
+                "WHERE episode_hash = ANY(:h)"
+            ),
+            {"h": hashes},
+        ):
+            out[row[0]] = row[1] or ""
+    return out
+
+
+def split_payload(payload: list[dict], subtask_copy: bool) -> dict[str, list[dict]]:
+    """Old level-tagged entries -> {new_key_suffixless_name: plain entries}.
+
+    Episodes WITH high entries are sort episodes: high -> task, rest ->
+    subtask. Episodes without are pick_place: everything -> task, plus an
+    identical subtask copy when ``subtask_copy`` (eva regime).
+    """
+
+    def plain(e: dict) -> dict:
+        return {
+            "text": e["text"],
+            "start_idx": int(e["start_idx"]),
+            "end_idx": int(e["end_idx"]),
+        }
+
+    highs = [plain(e) for e in payload if e.get("level") == "high"]
+    rest = [plain(e) for e in payload if e.get("level") != "high"]
+    if highs:  # sort episode
+        return {"annotations_task": highs, "annotations_subtask": rest}
+    keyed = {"annotations_task": rest}
+    if subtask_copy:
+        keyed["annotations_subtask"] = [dict(e) for e in rest]
+    return keyed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bucket",
+        type=str,
+        required=True,
+        help="Bucket as 's3://bucket/optional/prefix' (or 'bucket/prefix').",
+    )
+    parser.add_argument("--episode-hash", type=str, default=None)
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Process at most N episodes."
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--delete-old",
+        action="store_true",
+        help="Delete the old {hash}_annotations.json AFTER the new uploads "
+        "succeed. Off by default.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Rewrite the new key files even when they already exist.",
+    )
+    parser.add_argument(
+        "--assume-embodiment",
+        choices=["eva", "human"],
+        default=None,
+        help="Skip the SQL embodiment lookup and treat every episode as this "
+        "embodiment (eva -> subtask copy).",
+    )
+    args = parser.parse_args()
+
+    from egomimic.utils.aws.aws_data_utils import get_boto3_s3_client
+
+    s3 = get_boto3_s3_client()
+    bucket, prefix = parse_s3_uri(args.bucket)
+
+    old_keys = list_old_annotation_objects(s3, bucket, prefix)
+    if args.episode_hash is not None:
+        old_keys = [k for k in old_keys if episode_hash_of(k) == args.episode_hash]
+    if args.limit is not None:
+        old_keys = old_keys[: args.limit]
+    print(f"[INFO] {len(old_keys)} old *_annotations.json objects to migrate")
+    if not old_keys:
+        return
+
+    hashes = [episode_hash_of(k) for k in old_keys]
+    if args.assume_embodiment is not None:
+        embodiments = {h: args.assume_embodiment for h in hashes}
+    else:
+        embodiments = fetch_embodiments(hashes)
+        missing = [h for h in hashes if h not in embodiments]
+        if missing:
+            print(
+                f"[WARN] {len(missing)} hashes not in SQL registry — treated "
+                f"as human (no subtask copy): {missing[:5]}{'...' if len(missing) > 5 else ''}"
+            )
+
+    n_sort = n_pp = n_eva = n_skipped = n_deleted = 0
+    for key in old_keys:
+        ep = episode_hash_of(key)
+        emb = embodiments.get(ep, "human")
+        subtask_copy = emb.startswith("eva")
+
+        payload = json.loads(
+            s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
+        )
+        keyed = split_payload(payload, subtask_copy)
+        is_sort = any(e.get("level") == "high" for e in payload)
+        n_sort += is_sort
+        n_pp += not is_sort
+        n_eva += subtask_copy
+
+        base = key[: -len(OLD_SUFFIX)]
+        new_keys = {f"{base}_{name}.json": entries for name, entries in keyed.items()}
+
+        if not args.overwrite and not args.dry_run:
+            existing = []
+            for nk in new_keys:
+                try:
+                    s3.head_object(Bucket=bucket, Key=nk)
+                    existing.append(nk)
+                except s3.exceptions.ClientError:
+                    pass
+            if len(existing) == len(new_keys):
+                print(f"[SKIP] {ep} -> new keys already exist")
+                n_skipped += 1
+                continue
+
+        counts = {nk.rsplit("_", 1)[-1][:-5]: len(v) for nk, v in new_keys.items()}
+        tag = "sort" if is_sort else ("pp+evacopy" if subtask_copy else "pp")
+        if args.dry_run:
+            print(f"[DRY] {ep} ({tag}, emb={emb}) -> {counts}")
+            continue
+
+        for nk, entries in new_keys.items():
+            s3.put_object(
+                Bucket=bucket,
+                Key=nk,
+                Body=json.dumps(entries, ensure_ascii=False).encode("utf-8"),
+                ContentType="application/json",
+            )
+        if args.delete_old:
+            s3.delete_object(Bucket=bucket, Key=key)
+            n_deleted += 1
+        print(f"[OK] {ep} ({tag}, emb={emb}) -> {counts}"
+              + (" [old deleted]" if args.delete_old else ""))
+
+    print(
+        f"\n[DONE] {len(old_keys)} episodes: {n_sort} sort, {n_pp} pick_place "
+        f"({n_eva} eva subtask-copies), {n_skipped} skipped, {n_deleted} old deleted"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/egomimic/scripts/language_process/correct_annotation_keys.py
+++ b/egomimic/scripts/language_process/correct_annotation_keys.py
@@ -55,7 +55,11 @@ def list_old_annotation_objects(s3, bucket: str, prefix: str) -> list[str]:
     don't match)."""
     keys = []
     paginator = s3.get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+    # Exact-directory scoping: S3 prefixes are STRING prefixes, so a bare
+    # "scale_annotations" would also sweep sibling sets like
+    # "scale_annotations_sort/". Run once per annotation set instead.
+    list_prefix = prefix + "/" if prefix else ""
+    for page in paginator.paginate(Bucket=bucket, Prefix=list_prefix):
         for obj in page.get("Contents", []):
             k = obj["Key"]
             if k.endswith(OLD_SUFFIX) and not (
@@ -188,7 +192,9 @@ def main() -> None:
         is_sort = any(e.get("level") == "high" for e in payload)
         n_sort += is_sort
         n_pp += not is_sort
-        n_eva += subtask_copy
+        # subtask_copy only APPLIES to non-sort episodes (sort has real
+        # high/low structure regardless of embodiment).
+        n_eva += (not is_sort) and subtask_copy
 
         base = key[: -len(OLD_SUFFIX)]
         new_keys = {f"{base}_{name}.json": entries for name, entries in keyed.items()}
@@ -202,14 +208,14 @@ def main() -> None:
                 except s3.exceptions.ClientError:
                     pass
             if len(existing) == len(new_keys):
-                print(f"[SKIP] {ep} -> new keys already exist")
+                print(f"[SKIP] {key} -> new keys already exist")
                 n_skipped += 1
                 continue
 
         counts = {nk.rsplit("_", 1)[-1][:-5]: len(v) for nk, v in new_keys.items()}
         tag = "sort" if is_sort else ("pp+evacopy" if subtask_copy else "pp")
         if args.dry_run:
-            print(f"[DRY] {ep} ({tag}, emb={emb}) -> {counts}")
+            print(f"[DRY] {key} ({tag}, emb={emb}) -> {counts}")
             continue
 
         for nk, entries in new_keys.items():
@@ -222,7 +228,7 @@ def main() -> None:
         if args.delete_old:
             s3.delete_object(Bucket=bucket, Key=key)
             n_deleted += 1
-        print(f"[OK] {ep} ({tag}, emb={emb}) -> {counts}"
+        print(f"[OK] {key} ({tag}, emb={emb}) -> {counts}"
               + (" [old deleted]" if args.delete_old else ""))
 
     print(

--- a/egomimic/scripts/language_process/scale_to_bucket_annotation_parallel.py
+++ b/egomimic/scripts/language_process/scale_to_bucket_annotation_parallel.py
@@ -4,8 +4,12 @@ Ray-parallel: download Scale annotations, run conversion, upload result JSON to 
 Each episode is processed as an independent Ray task:
   download Scale annotation -> convert via LLM/hardcoded -> upload JSON to bucket.
 
-The uploaded object key is: {prefix}/{episode_hash}_{annotation_key}.json
-Episodes whose object already exists in the bucket are skipped (unless --overwrite).
+Uploads ONE JSON PER ROLE KEY: {prefix}/{episode_hash}_annotations_task.json
+(+ _annotations_subtask.json where the converter emits it) — entries are plain
+{text, start_idx, end_idx}; the role lives in the key name (see converter.py).
+An episode is skipped only when EVERY role key it would produce already exists
+(unless --overwrite); a partial upload is regenerated whole so the roles never
+come from different converter runs.
 
 Example usage:
 python egomimic/scripts/language_process/scale_to_bucket_annotation_parallel.py \
@@ -129,6 +133,26 @@ def process_episode(
     from egomimic.utils.aws.aws_data_utils import get_boto3_s3_client
 
     s3 = get_boto3_s3_client()
+
+    # Early skip BEFORE the (expensive) download + LLM conversion: the role
+    # keys each mode emits are known up front for the LLM converters, so an
+    # idempotent re-run costs one head_object per key instead of the full
+    # base-instruction + augmentation generation. `hardcoded` keys are
+    # converter-determined, so it falls through to the post-convert check.
+    if not overwrite:
+        expected = None
+        if conversion_mode == "pick_place_llm":
+            expected = ["annotations_task"] + (
+                ["annotations_subtask"] if subtask_copy else []
+            )
+        elif conversion_mode == "sort_llm":
+            expected = ["annotations_task", "annotations_subtask"]
+        if expected and all(
+            s3_object_exists(s3, bucket, object_key(prefix, episode_hash, k))
+            for k in expected
+        ):
+            print(f"[SKIP] {episode_hash} -> all of {expected} already exist")
+            return episode_hash
 
     client = ScaleClient(scale_api_key)
     download_scale_annotation(client, tid, scale_annotation_dir)

--- a/egomimic/scripts/language_process/scale_to_bucket_annotation_parallel.py
+++ b/egomimic/scripts/language_process/scale_to_bucket_annotation_parallel.py
@@ -72,10 +72,14 @@ def _make_converter(
     annotation_dir: str,
     prompt_filepath: str,
     augment_prompt_filepath: str | None = None,
+    sort_prompt_filepath: str | None = None,
+    sort_augment_prompt_filepath: str | None = None,
+    subtask_copy: bool = False,
 ):
     from egomimic.scripts.language_process.converter import (
         HardCodedConverter,
         PickPlaceLLMConverter,
+        SortConverter,
     )
 
     if conversion_mode == "pick_place_llm":
@@ -83,6 +87,18 @@ def _make_converter(
             annotation_dir,
             prompt_filepath,
             augment_prompt_filepath=augment_prompt_filepath,
+            # eva regime: identical task instruction and subtask target.
+            subtask_copy=subtask_copy,
+        )
+    elif conversion_mode == "sort_llm":
+        # Task-level sort text is read from the annotation's "Sorting" track;
+        # sort_prompt_filepath is only an optional LLM-generation fallback.
+        return SortConverter(
+            annotation_dir,
+            prompt_filepath,
+            sort_prompt_filepath,
+            augment_prompt_filepath=augment_prompt_filepath,
+            sort_augment_prompt_filepath=sort_augment_prompt_filepath,
         )
     elif conversion_mode == "hardcoded":
         return HardCodedConverter(annotation_dir)
@@ -99,19 +115,20 @@ def process_episode(
     prompt_filepath: str,
     bucket: str,
     prefix: str,
-    annotation_key: str = "annotations",
     overwrite: bool = False,
     augment_prompt_filepath: str | None = None,
+    sort_prompt_filepath: str | None = None,
+    sort_augment_prompt_filepath: str | None = None,
+    subtask_copy: bool = False,
 ) -> str:
-    """Self-contained Ray task: download, convert, and upload one episode's annotations."""
+    """Self-contained Ray task: download, convert, and upload one episode's
+    annotations — ONE JSON PER ROLE KEY (``{hash}_annotations_task.json``,
+    ``{hash}_annotations_subtask.json``, ...), entries are plain
+    ``{text, start_idx, end_idx}`` (role lives in the key name, no level field).
+    """
     from egomimic.utils.aws.aws_data_utils import get_boto3_s3_client
 
     s3 = get_boto3_s3_client()
-    key = object_key(prefix, episode_hash, annotation_key)
-
-    if not overwrite and s3_object_exists(s3, bucket, key):
-        print(f"[SKIP] {episode_hash} -> s3://{bucket}/{key} already exists")
-        return episode_hash
 
     client = ScaleClient(scale_api_key)
     download_scale_annotation(client, tid, scale_annotation_dir)
@@ -121,16 +138,39 @@ def process_episode(
         scale_annotation_dir,
         prompt_filepath,
         augment_prompt_filepath=augment_prompt_filepath,
+        sort_prompt_filepath=sort_prompt_filepath,
+        sort_augment_prompt_filepath=sort_augment_prompt_filepath,
+        subtask_copy=subtask_copy,
     )
-    annotations = converter.convert(tid)
+    keyed = converter.convert(tid)
+    if not keyed:
+        print(f"[EMPTY] {episode_hash} -> converter produced no annotations")
+        return episode_hash
 
-    payload = [
-        {"text": text, "start_idx": int(start_idx), "end_idx": int(end_idx)}
-        for text, start_idx, end_idx in annotations
-    ]
-    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
-    print(f"[OK] {episode_hash} -> s3://{bucket}/{key} ({len(payload)} entries)")
+    # Skip only when EVERY role key already exists — a partial upload (e.g.
+    # task present, subtask missing) is regenerated whole so the two roles
+    # never come from different converter runs.
+    keys = {ann_key: object_key(prefix, episode_hash, ann_key) for ann_key in keyed}
+    if not overwrite and all(
+        s3_object_exists(s3, bucket, k) for k in keys.values()
+    ):
+        print(f"[SKIP] {episode_hash} -> all of {sorted(keys)} already exist")
+        return episode_hash
+
+    for ann_key, entries in keyed.items():
+        payload = [
+            {"text": text, "start_idx": int(start_idx), "end_idx": int(end_idx)}
+            for text, start_idx, end_idx in entries
+        ]
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        s3.put_object(
+            Bucket=bucket, Key=keys[ann_key], Body=body,
+            ContentType="application/json",
+        )
+        print(
+            f"[OK] {episode_hash} -> s3://{bucket}/{keys[ann_key]} "
+            f"({len(payload)} entries)"
+        )
     return episode_hash
 
 
@@ -162,14 +202,32 @@ if __name__ == "__main__":
         "--conversion-mode",
         type=str,
         required=True,
-        choices=["pick_place_llm", "hardcoded"],
+        choices=["pick_place_llm", "sort_llm", "hardcoded"],
     )
     parser.add_argument(
         "-s", "--scale-api-key", default=os.environ.get("SCALE_API_KEY", "")
     )
     parser.add_argument("--prompt-filepath", type=str, required=True)
     parser.add_argument("--augment-prompt-filepath", type=str, default=None)
-    parser.add_argument("--annotation-key", type=str, default="annotations")
+    parser.add_argument(
+        "--sort-prompt-filepath",
+        type=str,
+        default=None,
+        help="High-level sort instruction prompt (required for --conversion-mode sort_llm).",
+    )
+    parser.add_argument(
+        "--sort-augment-prompt-filepath",
+        type=str,
+        default=None,
+        help="High-level sort augmentation prompt (optional, used by sort_llm).",
+    )
+    parser.add_argument(
+        "--subtask-copy",
+        action="store_true",
+        help="pick_place_llm only: ALSO write the task instructions verbatim "
+        "under annotations_subtask (eva regime — identical task prompt and "
+        "subtask target).",
+    )
     parser.add_argument(
         "--bucket",
         type=str,
@@ -198,6 +256,15 @@ if __name__ == "__main__":
         default=1,
         help="CPUs reserved per Ray task (default: 1)",
     )
+    parser.add_argument(
+        "--dataset-dir",
+        type=str,
+        default=None,
+        help="Resolve the config's ${paths.dataset_dir} (resolver folder_path). "
+        "Required when the dataset config inherits folder_path: ${paths.dataset_dir} "
+        "(e.g. the cotrain-derived sort configs) since load_config composes only the "
+        "data group and has no paths node.",
+    )
     args = parser.parse_args()
 
     bucket, prefix = parse_s3_uri(args.bucket)
@@ -221,6 +288,22 @@ if __name__ == "__main__":
     rel_path = os.path.relpath(abs_cfg_path, HYDRA_CONFIG_DIR)
     config_name = os.path.splitext(rel_path)[0]
     dataset_cfg = load_config(config_name)
+
+    # load_config composes only the `data` group, so ${paths.dataset_dir} (the
+    # resolver folder_path inherited from cotrain_pi_base) has no node to resolve
+    # against. Overwrite each train resolver's folder_path with --dataset-dir so
+    # the real resolver runs unmodified (valid resolvers interpolate from train).
+    if args.dataset_dir is not None:
+        from omegaconf import OmegaConf
+
+        OmegaConf.set_struct(dataset_cfg, False)
+        for _name in list((dataset_cfg.get("train_datasets") or {}).keys()):
+            _ds = dataset_cfg.train_datasets[_name]
+            if _ds is None:
+                continue
+            _res = _ds.get("resolver")
+            if _res is not None and "folder_path" in _res:
+                _res.folder_path = args.dataset_dir
 
     train_datasets = {}
     train_hashes = set()
@@ -281,9 +364,11 @@ if __name__ == "__main__":
             prompt_filepath=args.prompt_filepath,
             bucket=bucket,
             prefix=prefix,
-            annotation_key=args.annotation_key,
             overwrite=args.overwrite,
             augment_prompt_filepath=args.augment_prompt_filepath,
+            sort_prompt_filepath=args.sort_prompt_filepath,
+            sort_augment_prompt_filepath=args.sort_augment_prompt_filepath,
+            subtask_copy=args.subtask_copy,
         )
         pending[ref] = ep_hash
 

--- a/egomimic/scripts/language_process/scale_to_zarr_annotation.py
+++ b/egomimic/scripts/language_process/scale_to_zarr_annotation.py
@@ -120,25 +120,31 @@ if __name__ == "__main__":
             tid = get_episode_hash_to_tid(df, episode_hash)
             if tid is None:
                 continue
-            annotation = converter.convert(tid)
+            keyed = converter.convert(tid)
             writer = ZarrWriter(
                 episode_path=zarr_dataset.episode_path,
                 verbose=True,
             )
-            writer.append_annotations(
-                annotation_key="annotations", annotations=annotation, mode="w"
-            )
+            # Converters emit {annotation_key_name: [(text, start, end), ...]}
+            # — one list per role-named zarr key (see converter.py).
+            for ann_key, annotation in keyed.items():
+                writer.append_annotations(
+                    annotation_key=ann_key, annotations=annotation, mode="w"
+                )
 
     for dataset_name in valid_datasets:
         for episode_hash, zarr_dataset in valid_datasets[dataset_name].datasets.items():
             tid = get_episode_hash_to_tid(df, episode_hash)
             if tid is None:
                 continue
-            annotation = converter.convert(tid)
+            keyed = converter.convert(tid)
             writer = ZarrWriter(
                 episode_path=zarr_dataset.episode_path,
                 verbose=True,
             )
-            writer.append_annotations(
-                annotation_key="annotations", annotations=annotation, mode="w"
-            )
+            # Converters emit {annotation_key_name: [(text, start, end), ...]}
+            # — one list per role-named zarr key (see converter.py).
+            for ann_key, annotation in keyed.items():
+                writer.append_annotations(
+                    annotation_key=ann_key, annotations=annotation, mode="w"
+                )

--- a/egomimic/scripts/language_process/scale_to_zarr_annotation_parallel.py
+++ b/egomimic/scripts/language_process/scale_to_zarr_annotation_parallel.py
@@ -105,11 +105,15 @@ def process_episode(
         prompt_filepath,
         augment_prompt_filepath=augment_prompt_filepath,
     )
-    annotation = converter.convert(tid)
+    keyed = converter.convert(tid)
 
-    writer.append_annotations(
-        annotation_key=annotation_key, annotations=annotation, mode="w"
-    )
+    # Converters emit {annotation_key_name: [(text, start, end), ...]} — one
+    # list per role-named zarr key (see converter.py). Every emitted role is
+    # injected under its own key name.
+    for ann_key, annotation in keyed.items():
+        writer.append_annotations(
+            annotation_key=ann_key, annotations=annotation, mode="w"
+        )
     print(f"[OK] {episode_hash} -> {episode_path}")
     return episode_hash
 

--- a/egomimic/scripts/language_process/sort_augment_prompt.txt
+++ b/egomimic/scripts/language_process/sort_augment_prompt.txt
@@ -1,0 +1,31 @@
+You will be given a JSON object with two fields:
+
+- "instruction": a HIGH-LEVEL natural-language SORTING instruction describing the overall goal of an episode (e.g. "Sort the croissant and the corn on the white plate").
+- "metadata": the context used to produce it (the "task" and the ordered pick-and-place "steps").
+
+Produce a set of language-augmented variants of the high-level sorting instruction for training a language-conditioned robot policy. Your output must be a single JSON array of strings with no surrounding prose, markdown, or code fences.
+
+Goal: every variant must keep the SAME meaning, the SAME objects, and the SAME destinations as the original, but should be a genuinely different phrasing — not a near-identical copy. Aim for moderate variety: the variants stay clearly about the same sort goal, yet differ from one another in wording and structure.
+
+Verb rule:
+- Around 8 of the 12 variants should keep "sort" as the main verb (e.g. "Sort the corn and the croissant onto the white plate.").
+- The remaining ~4 may use a close synonym verb (e.g. "place", "put", "arrange", "organize") or a different sentence structure.
+
+Ways to vary (combine a few per variant, but keep the objects and destinations exactly):
+- Reword connectives and noun phrasing ("the croissant and the corn" -> "both the croissant and the corn" / "the corn together with the croissant").
+- Reorder the listed objects, and swap the destination preposition where natural ("on" / "onto" / "to").
+- Vary the sentence structure on some variants — e.g. a prepositional opener ("Onto the white plate, sort the corn and the croissant.") or "The croissant and the corn should be sorted onto the white plate.".
+
+Rules:
+- Do NOT invent objects, containers, sorting criteria, or counts not in the instruction or metadata; keep exactly the same objects and destinations as the original.
+- NEVER drop or generalize an object's descriptors. Preserve every color, material, size, and modifier that appears in the original (e.g. keep "the blue stuffed animal" as "the blue stuffed animal"; never shorten it to "the stuffed animal" or drop "blue"). Do not add descriptors that are not in the original either.
+- Do NOT abstract away the specifics (no "organize the items into groups"); always name the same concrete objects and destinations.
+- These are HIGH-LEVEL goals: do NOT mention any specific hand or arm, and do NOT describe a single pick-and-place motion or enumerate the steps.
+- Do NOT use "lift" as a synonym for pick, grab, or take.
+- Do NOT use adjectives or adverbs describing the style of execution (e.g. "carefully", "precisely").
+- Keep each variant grammatical, concise (under 25 words), and a valid standalone instruction.
+- Do not include the original instruction in the output; the caller will add it back.
+- Return only the JSON array, e.g. ["Sort the corn and the croissant onto the white plate.", "..."].
+- Ensure there are exactly 12 variants total, and that no two are identical.
+
+Input:

--- a/egomimic/scripts/language_process/sort_prompt.txt
+++ b/egomimic/scripts/language_process/sort_prompt.txt
@@ -1,0 +1,19 @@
+You are generating a single HIGH-LEVEL natural-language instruction for a language-conditioned robot bimanual manipulation policy that is performing a SORTING task. The instruction describes the OVERALL GOAL of the whole episode — not any individual motion. The policy receives one instruction string, so the instruction must be grounded strictly in the metadata provided below. Do not invent or infer any details that are not present.
+
+You will be given a JSON dictionary with:
+- "task": always "sort".
+- "steps": the ordered pick-and-place sub-actions that make up the episode, each with an "Action" (e.g. "Pick up", "Put") and a "description".
+
+Infer what is being sorted, and where/by what criterion it is being sorted, STRICTLY from the steps, then output one high-level sorting instruction.
+
+Output exactly one instruction sentence in the imperative mood (e.g. "Sort the utensils into the correct bins."). Keep it under 25 words. Do not include punctuation other than a period at the end.
+
+General rules:
+- Describe the goal at a high level: what category of objects is being sorted, and the destinations or sorting criterion, when those are evident from the steps.
+- Summarize the episode; do NOT list, enumerate, or count the individual pick-and-place steps.
+- Do NOT mention which hand or arm is used — a high-level sort goal is arm-agnostic.
+- Do NOT invent objects, containers, criteria, or counts that are not supported by the steps. If the destinations or criterion are not clear from the steps, give a general sorting instruction (e.g. "Sort the items into their correct containers.").
+- Do not use "lift" as a synonym for pick, grab, or take.
+- Use concrete, goal-oriented language a robot can be conditioned on.
+
+Dictionary:


### PR DESCRIPTION
Port SortConverter (from aidan/subtask-pi) and rewrite the converter output
contract for the role-in-key-name scheme:

- converters return {annotation_key_name: [(text, start, end), ...]} — one
  list per role key, plain entries, no level field.
- PickPlaceLLMConverter writes the instructions under annotations_task (the
  pick_place instruction IS the task-level conditioning; no read-time
  fallback). subtask_copy=true (eva regime) also writes them verbatim under
  annotations_subtask, so eva's task prompt and subtask target are identical.
- SortConverter writes the span-aligned sort goals under annotations_task
  and the pick-and-place decompositions under annotations_subtask (sort is
  the only source of real subtask targets), balanced per span as before.
- scale_to_bucket uploads ONE JSON PER KEY ({hash}_{key}.json), skipping an
  episode only when every role key exists; --subtask-copy CLI flag added,
  --annotation-key dropped (the converter decides its keys).
- bucket_to_zarr injects plain 3-field entries under --annotation-key
  (unchanged mechanics; level-carrying removed; keeps --dataset-dir).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TYmG3nhxt7LYiaaSJPsKEV