### PR TITLE
fix(aria_uploader): metadata.embodiment = robot config, not the 'aria' device

### DIFF
--- a/egomimic/scripts/data_upload/abstract_upload.py
+++ b/egomimic/scripts/data_upload/abstract_upload.py
@@ -10,14 +10,25 @@ from egomimic.utils.aws.aws_sql import TableRow
 
 
 class Uploader:
-    def __init__(self, embodiment, datatype, collect_files):
-        """Initialize upload template with S3 configuration and metadata settings."""
+    def __init__(self, embodiment, datatype, collect_files, device=None):
+        """Initialize upload template with S3 configuration and metadata settings.
+
+        ``embodiment`` is the ROBOT configuration recorded (e.g. ``human_bimanual``)
+        and is written to ``metadata.embodiment`` (→ the SQL ``embodiment`` column).
+        ``device`` is the raw CAPTURE SOURCE (e.g. ``aria``) and only decides the
+        raw-bucket layout (``raw_v2/<device>/``). They are decoupled because aria
+        hardware records human_bimanual / human_left_arm / human_right_arm robots,
+        so the path must stay ``raw_v2/aria/`` while the embodiment varies. When
+        ``device`` is omitted it falls back to ``embodiment`` (unchanged for the
+        eva/eve uploaders, where source and embodiment coincide).
+        """
 
         self.embodiment = embodiment
+        self.device = device or embodiment
         self.datatype = datatype
         self.s3 = get_boto3_s3_client()
         self.bucket_name = "rldb"
-        self.s3_base_prefix = f"raw_v2/{embodiment}/"
+        self.s3_base_prefix = f"raw_v2/{self.device}/"
 
         self.collect_files = collect_files
         self.local_dir = None

--- a/egomimic/scripts/data_upload/aria_uploader.py
+++ b/egomimic/scripts/data_upload/aria_uploader.py
@@ -1,9 +1,14 @@
+import argparse
 import asyncio
 
 from abstract_upload import Uploader
 
+# Robot configurations the aria hardware can record. This is the metadata
+# `embodiment` (→ SQL embodiment column), NOT the capture device ("aria").
+ARIA_EMBODIMENTS = ("human_bimanual", "human_left_arm", "human_right_arm")
 
-def aria_uploader():
+
+def aria_uploader(embodiment="human_bimanual"):
     def collect_files(local_dir):
         """
         Discover VRS files with their corresponding JSON companion files.
@@ -25,16 +30,29 @@ def aria_uploader():
         return file_paths
 
     uploader = Uploader(
-        embodiment="aria",  # Embodiment name
+        embodiment=embodiment,  # robot config recorded → metadata.embodiment
         datatype=".vrs",  # Main data file extension
         collect_files=collect_files,
+        device="aria",  # raw capture source → s3://rldb/raw_v2/aria/
     )
 
     return uploader
 
 
 def main():
-    uploader = aria_uploader()
+    parser = argparse.ArgumentParser(
+        description="Upload raw aria (.vrs) recordings to s3://rldb/raw_v2/aria/."
+    )
+    parser.add_argument(
+        "--embodiment",
+        default="human_bimanual",
+        choices=ARIA_EMBODIMENTS,
+        help="Robot embodiment recorded by the aria hardware; written to "
+        "metadata.embodiment (the raw S3 path stays raw_v2/aria/ regardless). "
+        "Default: human_bimanual.",
+    )
+    args = parser.parse_args()
+    uploader = aria_uploader(embodiment=args.embodiment)
     asyncio.run(uploader.run())
 
 


### PR DESCRIPTION
aria_uploader hardcoded embodiment='aria', so every aria recording landed in
SQL with embodiment='aria' instead of the robot config (human_bimanual/left/
right) the operator intended. Their typed value went to the now-deprecated
robot_name field and was dropped by add_raw_data_to_table (reads
metadata['embodiment']).

Decouple the capture DEVICE (drives the raw_v2/<device>/ bucket layout) from the
EMBODIMENT (metadata -> SQL embodiment column): Uploader gains a 'device' param
that defaults to embodiment (eva/eve unchanged), and aria_uploader passes
device='aria' with embodiment defaulting to human_bimanual (override via
--embodiment for left/right arm). aria raw path stays raw_v2/aria/.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>