### PR TITLE
feat(sql): add created_at / updated_at timestamps to app.episodes

### DIFF
--- a/egomimic/scripts/data_upload/abstract_upload.py
+++ b/egomimic/scripts/data_upload/abstract_upload.py
@@ -45,6 +45,9 @@ class Uploader:
                 "eval_score",
                 "eval_success",
                 "is_deleted",
+                # DB-managed timestamps — never prompted for / entered by operators.
+                "created_at",
+                "updated_at",
             ]
         ]
 

--- a/egomimic/utils/aws/aws_sql.py
+++ b/egomimic/utils/aws/aws_sql.py
@@ -44,6 +44,18 @@ class TableRow:
     is_eval: bool = False
     eval_score: float = -1
     eval_success: bool = True
+    # DB-managed timestamps (server-side): created_at is set once on INSERT via a
+    # column DEFAULT now(); updated_at is bumped on every UPDATE by a BEFORE UPDATE
+    # trigger (app.set_updated_at). They are READ-ONLY here — populated when a row
+    # is loaded (episode_hash_to_table_row), but add_episode/update_episode drop
+    # them so the database always owns their values. Do NOT set them by hand.
+    created_at: datetime | None = None  # Time Created (read-only)
+    updated_at: datetime | None = None  # Last Modified (read-only)
+
+
+# Timestamp columns the database maintains itself; the write paths must never
+# send them (created_at is immutable after insert, updated_at is trigger-managed).
+_DB_MANAGED_COLUMNS = ("created_at", "updated_at")
 
 
 def create_default_engine():
@@ -105,6 +117,8 @@ def add_episode(engine, episode) -> bool:
     """
     episodes_tbl = _episodes_table(engine)
     row = asdict(episode)
+    for col in _DB_MANAGED_COLUMNS:
+        row.pop(col, None)  # let the DB set created_at (DEFAULT) / updated_at (trigger)
 
     try:
         with engine.begin() as conn:
@@ -127,6 +141,8 @@ def update_episode(engine, episode: TableRow):
 
     # Create a dict out of episode fields
     row = asdict(episode)
+    for col in _DB_MANAGED_COLUMNS:
+        row.pop(col, None)  # created_at is immutable; updated_at is trigger-managed
     episode_hash = row.pop("episode_hash")  # Remove episode_hash from the update values
 
     stmt = (

--- a/egomimic/utils/aws/migrate_add_timestamp_columns.py
+++ b/egomimic/utils/aws/migrate_add_timestamp_columns.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""One-time migration: add created_at / updated_at timestamps to app.episodes.
+
+- created_at TIMESTAMPTZ NOT NULL DEFAULT now()  (Time Created; set once on INSERT)
+- updated_at TIMESTAMPTZ NOT NULL DEFAULT now()  (Last Modified)
+
+`updated_at` is bumped automatically on every UPDATE by a BEFORE UPDATE trigger
+(app.set_updated_at), so no application code needs to set it. For the existing
+rows, `created_at` is backfilled from the episode_hash when it is a recording
+timestamp (``YYYY-MM-DD-HH-MM-SS-ffffff``, interpreted as UTC); UUID/ObjectId
+hashed vendor episodes keep the migration-time default. Idempotent: safe to
+re-run (ADD COLUMN IF NOT EXISTS / CREATE OR REPLACE / DROP TRIGGER IF EXISTS),
+but the created_at backfill re-parses every timestamp-hashed row each run
+(harmless — it writes the same value).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from sqlalchemy import text
+
+from egomimic.utils.aws.aws_sql import create_default_engine
+
+# recording-timestamp episode_hash, e.g. 2026-07-17-02-06-28-000000
+_TS_HASH_REGEX = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{6}$"
+
+
+def main() -> int:
+    engine = create_default_engine()
+    try:
+        # 1) columns + created_at backfill (one transaction; timezone pinned to
+        #    UTC so to_timestamp reads the hash's wall-clock as UTC). The trigger
+        #    does not exist yet, so this UPDATE does not touch updated_at.
+        with engine.begin() as conn:
+            conn.execute(text("SET LOCAL timezone TO 'UTC'"))
+            conn.execute(text(
+                "ALTER TABLE app.episodes ADD COLUMN IF NOT EXISTS "
+                "created_at TIMESTAMPTZ NOT NULL DEFAULT now()"
+            ))
+            conn.execute(text(
+                "ALTER TABLE app.episodes ADD COLUMN IF NOT EXISTS "
+                "updated_at TIMESTAMPTZ NOT NULL DEFAULT now()"
+            ))
+            res = conn.execute(text(
+                "UPDATE app.episodes "
+                "SET created_at = to_timestamp(episode_hash, 'YYYY-MM-DD-HH24-MI-SS-US') "
+                f"WHERE episode_hash ~ '{_TS_HASH_REGEX}'"
+            ))
+            print(f"Added created_at/updated_at; backfilled created_at from "
+                  f"episode_hash for {res.rowcount} timestamp-hashed rows.")
+
+        # 2) updated_at auto-update trigger (separate transaction so a
+        #    permissions issue here doesn't roll back the columns above).
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "CREATE OR REPLACE FUNCTION app.set_updated_at() RETURNS trigger "
+                    "LANGUAGE plpgsql AS $$ BEGIN NEW.updated_at = now(); "
+                    "RETURN NEW; END; $$"
+                ))
+                conn.execute(text(
+                    "DROP TRIGGER IF EXISTS episodes_set_updated_at ON app.episodes"
+                ))
+                conn.execute(text(
+                    "CREATE TRIGGER episodes_set_updated_at BEFORE UPDATE ON "
+                    "app.episodes FOR EACH ROW EXECUTE FUNCTION app.set_updated_at()"
+                ))
+            print("Installed BEFORE UPDATE trigger episodes_set_updated_at.")
+        except Exception as exc:
+            print(f"WARNING: columns added but trigger install failed: {exc}",
+                  file=sys.stderr)
+            print("  updated_at will only reflect inserts until the trigger exists.",
+                  file=sys.stderr)
+
+        # 3) verify
+        with engine.connect() as conn:
+            cols = conn.execute(text(
+                "SELECT column_name, is_nullable, data_type, column_default "
+                "FROM information_schema.columns WHERE table_schema='app' "
+                "AND table_name='episodes' AND column_name IN "
+                "('created_at','updated_at') ORDER BY column_name"
+            )).all()
+            trig = conn.execute(text(
+                "SELECT tgname FROM pg_trigger WHERE tgname='episodes_set_updated_at' "
+                "AND NOT tgisinternal"
+            )).all()
+            sample = conn.execute(text(
+                "SELECT episode_hash, created_at, updated_at FROM app.episodes "
+                f"WHERE episode_hash ~ '{_TS_HASH_REGEX}' ORDER BY episode_hash DESC LIMIT 3"
+            )).all()
+
+        if len(cols) != 2:
+            print(f"ERROR: expected 2 timestamp columns, found {len(cols)}.",
+                  file=sys.stderr)
+            return 1
+        for c in cols:
+            print(f"Verified {c.column_name}: {c.data_type}, "
+                  f"nullable={c.is_nullable}, default={c.column_default}")
+        print(f"Trigger present: {bool(trig)}")
+        print("Sample backfilled rows (hash -> created_at should match):")
+        for s in sample:
+            print(f"  {s.episode_hash}  created_at={s.created_at}  updated_at={s.updated_at}")
+        print("Migration completed successfully.")
+        return 0
+    except Exception as exc:
+        print(f"ERROR: migration failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds Time Created + Last Modified to the episodes table:
- migrate_add_timestamp_columns.py: ADD COLUMN created_at/updated_at
  TIMESTAMPTZ NOT NULL DEFAULT now(); backfill created_at from the recording
  timestamp encoded in episode_hash (UUID/ObjectId vendor hashes keep now());
  BEFORE UPDATE trigger app.set_updated_at bumps updated_at on every update.
- TableRow gains read-only created_at/updated_at; add_episode/update_episode
  drop the DB-managed columns so Postgres always owns them (created_at
  immutable, updated_at trigger-managed).
- abstract_upload.py excludes the two from the operator metadata prompt.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>