### PR TITLE
feat(overfit): EGOVERSE_EPISODES_TABLE override + microagi single-episode data config

### DIFF
--- a/egomimic/hydra_configs/data/microagi.yaml
+++ b/egomimic/hydra_configs/data/microagi.yaml
@@ -1,0 +1,37 @@
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+# Single-microagi-episode overfit. The resolver reads the episode table via
+# episode_table_to_df; set EGOVERSE_EPISODES_TABLE=staging_microagi to source the
+# episode from the staging table (built by stage_processed_folder.py) WITHOUT
+# merging into app.episodes. Same format/keymap as mecka (human_bimanual,
+# images.front_1, cartesian ee_pose), so hpt_bc_flow_mecka trains it unchanged.
+train_datasets:
+  human_bimanual:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
+      folder_path: ${paths.dataset_dir}
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Human.get_keymap
+        keymap_mode: cartesian
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Human.get_transform_list
+        mode: cartesian
+        stride: 1
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: row['episode_hash'] == '2025-05-08-02-34-47-172880'"
+    mode: total
+
+valid_datasets:
+  human_bimanual: ${train_datasets.human_bimanual}
+
+train_dataloader_params:
+  human_bimanual:
+    batch_size: 32
+    num_workers: 10
+valid_dataloader_params:
+  human_bimanual:
+    batch_size: 32
+    num_workers: 10

--- a/egomimic/utils/aws/aws_sql.py
+++ b/egomimic/utils/aws/aws_sql.py
@@ -92,9 +92,17 @@ def create_default_engine():
     return engine
 
 
+def _episodes_table_name():
+    """The app-schema table the episode helpers read/write. Defaults to
+    ``episodes``; override with EGOVERSE_EPISODES_TABLE to point the dataset
+    resolver at a staging table (e.g. ``staging_microagi``) without merging into
+    the production table — used for validating a staged folder before merge."""
+    return os.environ.get("EGOVERSE_EPISODES_TABLE", "episodes")
+
+
 def _episodes_table(engine):
     md = MetaData()
-    return Table("episodes", md, autoload_with=engine, schema="app")
+    return Table(_episodes_table_name(), md, autoload_with=engine, schema="app")
 
 
 def add_episode(engine, episode) -> bool:
@@ -183,11 +191,11 @@ def delete_all_episodes(engine):
 
 
 def episode_table_to_df(engine):
-    """
-    Prints all rows in the 'episodes' table in a nicely formatted table.
-    """
+    """Return all rows of the episode table (see ``EGOVERSE_EPISODES_TABLE``)."""
     metadata = MetaData()
-    episodes_tbl = Table("episodes", metadata, autoload_with=engine, schema="app")
+    episodes_tbl = Table(
+        _episodes_table_name(), metadata, autoload_with=engine, schema="app"
+    )
 
     import pandas as pd
 


### PR DESCRIPTION
episode_table_to_df / _episodes_table read the app-schema table from
EGOVERSE_EPISODES_TABLE (default 'episodes'), so the dataset resolver can source
episodes from a staging table (e.g. staging_microagi) without merging into
app.episodes. microagi.yaml overfits one microagi episode (same format/keymap as
mecka) via that staging read — used to validate a staged folder end-to-end.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>