### PR TITLE
fix(hpt): preserve non-registered batch keys through process_batch_for_training

### DIFF
--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -995,9 +995,10 @@ class HPT(Algo):
             embodiment_id = get_embodiment_id(embodiment_name)
             processed_batch[embodiment_id] = {}
             for key, value in _batch.items():
-                key_name = self.norm_stats.zarr_key_to_keyname(key, embodiment_id)
-                if key is not None:
-                    processed_batch[embodiment_id][key_name] = value
+                key_name = (
+                    self.norm_stats.zarr_key_to_keyname(key, embodiment_id) or key
+                )
+                processed_batch[embodiment_id][key_name] = value
 
             ac_key = self.ac_keys[embodiment_id]
             if len(processed_batch[embodiment_id][ac_key].shape) != 3:


### PR DESCRIPTION
zarr_key_to_keyname returns None for any batch key that isn't a registered action/proprio zarr key (intrinsics, episode_hash, image keys). The old 'if key is not None' guard checked the wrong variable — 'key' is a string from _batch.items() and never None, so the branch always fired and wrote every unregistered key under a single None dict slot. Later writes clobbered earlier ones, and 'intrinsics' was silently dropped.

Downstream _intrinsics_from_batch(batch, i) then returned None, so Human.viz / Eva.viz fell back to the hardcoded class INTRINSICS constant. For episodes whose per-episode K disagrees with the aria default (mecka fx=fy≈251, cy≈184 vs ARIA cy=240), this projected the GT trajectory ~55px vertically offset — the visible wrist-vs-palm misalignment reported against arc_tests mecka fold_clothes val-videos.

Fix: fall back to the original key when zarr_key_to_keyname is None so unregistered keys survive the rekey. Also fixes downstream access to episode_hash and per-episode image side-channel keys.