### PR TITLE
feat(sql): add rig_name to episodes + collect it in aria/eva uploaders

### DIFF
--- a/egomimic/scripts/data_upload/abstract_upload.py
+++ b/egomimic/scripts/data_upload/abstract_upload.py
@@ -10,7 +10,7 @@ from egomimic.utils.aws.aws_sql import TableRow
 
 
 class Uploader:
-    def __init__(self, embodiment, datatype, collect_files):
+    def __init__(self, embodiment, datatype, collect_files, defaults=None):
         """Initialize upload template with S3 configuration and metadata settings."""
 
         self.embodiment = embodiment
@@ -20,6 +20,9 @@ class Uploader:
         self.s3_base_prefix = f"raw_v2/{embodiment}/"
 
         self.collect_files = collect_files
+        # Per-uploader metadata defaults, e.g. {"rig_name": "aria_gen1"}.
+        # Offered as the bracketed default at the prompt; Enter accepts it.
+        self.defaults = defaults or {}
         self.local_dir = None
         self.directory_prompted = False
 
@@ -99,7 +102,9 @@ class Uploader:
                 }
 
                 for key in self.metadata_keys:
-                    value = self._collect_metadata_value(key)
+                    value = self._collect_metadata_value(
+                        key, self.defaults.get(key, "")
+                    )
                     self.batch_metadata[key] = value
 
                 print(
@@ -271,7 +276,9 @@ class Uploader:
                 )
 
             for key in self.metadata_keys:
-                previous_value = self.previous_inputs.get(key, "")
+                previous_value = self.previous_inputs.get(
+                    key, ""
+                ) or self.defaults.get(key, "")
 
                 value = self._collect_metadata_value(key, previous_value)
                 submitted_metadata[key] = value

--- a/egomimic/scripts/data_upload/aria_uploader.py
+++ b/egomimic/scripts/data_upload/aria_uploader.py
@@ -28,6 +28,7 @@ def aria_uploader():
         embodiment="aria",  # Embodiment name
         datatype=".vrs",  # Main data file extension
         collect_files=collect_files,
+        defaults={"rig_name": "aria_gen1"},
     )
 
     return uploader

--- a/egomimic/scripts/data_upload/eva_uploader.py
+++ b/egomimic/scripts/data_upload/eva_uploader.py
@@ -17,7 +17,12 @@ def eva_uploader():
 
         return hdf5_files
 
-    uploader = Uploader(embodiment="eva", datatype=".hdf5", collect_files=collect_files)
+    uploader = Uploader(
+        embodiment="eva",
+        datatype=".hdf5",
+        collect_files=collect_files,
+        defaults={"rig_name": "eva"},
+    )
 
     return uploader
 

--- a/egomimic/utils/aws/add_raw_data_to_table.py
+++ b/egomimic/utils/aws/add_raw_data_to_table.py
@@ -136,8 +136,7 @@ def _add_raw_episode_to_table(
             task_description=metadata.get("task_description", ""),
             scene=metadata["scene"],
             objects=metadata["objects"],
-            processed_path="",
-            mp4_path="",
+            rig_name=metadata.get("rig_name", ""),
         )
 
         add_episode(engine, episode)

--- a/egomimic/utils/aws/aws_sql.py
+++ b/egomimic/utils/aws/aws_sql.py
@@ -32,6 +32,7 @@ class TableRow:
     lab: str
     task: str
     embodiment: str
+    rig_name: str = ""  # physical capture rig (e.g. aria_gen1, eva, mecka)
     num_frames: int = -1  # Updateable
     task_description: str = ""
     scene: str = ""


### PR DESCRIPTION
Adds the rig_name column to TableRow so the capture rig is recorded per
episode alongside lab/embodiment (column already added to app.episodes).

- aws_sql: TableRow.rig_name (defaults to ""). Because the uploaders derive
  their prompt list from TableRow.__dataclass_fields__, both aria and eva now
  ask for rig_name automatically.
- abstract_upload: new defaults= arg, offered as the bracketed prompt default
  in both batch and per-file modes (Enter accepts it).
- aria_uploader defaults to aria_gen1, eva_uploader to eva.
- add_raw_data_to_table: pass rig_name through from the metadata json, and
  drop the stale processed_path/mp4_path kwargs — those columns were renamed
  to zarr_* and removed from TableRow, so this call raised TypeError and was
  silently breaking s3-writer-node ingestion on every sync.