### PR TITLE
feat(rldb): h264 video-backed images + role-in-key annotations + span selection

### DIFF
--- a/egomimic/rldb/annotation_processing.py
+++ b/egomimic/rldb/annotation_processing.py
@@ -1,0 +1,124 @@
+"""Modular annotation processing.
+
+Annotation ROLE is encoded in the zarr key NAME (e.g. ``annotations_task``,
+``annotations_subtask``) instead of a ``level`` field inside each entry —
+entries are plain ``{"text", "start_idx", "end_idx"}`` spans. ``ZarrDataset``
+fetches every ``annotations*`` key into the batch (``list[list[str]]`` per
+key after ``annotation_collate``); a processor then turns those raw lists
+into per-role outputs inside ``process_batch_for_training``.
+
+- :class:`AnnotationProcessor` — the ABSTRACT contract: batch in,
+  ``{role: per-item outputs}`` out. It deliberately does NOT prescribe what
+  a per-item output is (one string, several candidates, a structured
+  target, ...) — that is a policy of the concrete processor, agreed upon
+  with the consuming algo.
+- :class:`DefaultAnnotationProcessor` — the default policy: sample ONE
+  annotation string per item from a single key with a ``first`` / ``random``
+  strategy (role ``task``).
+- :class:`SubtaskAnnotationProcessor` — hierarchical: samples the
+  conditioning instruction from ``task_key`` and the prediction target from
+  ``subtask_key`` (roles ``task`` + ``subtask``). No cross-role fallback:
+  a missing task never leaks the subtask text into the prompt.
+"""
+
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from typing import Literal
+
+
+class AnnotationProcessor(ABC):
+    """Abstract contract: turn raw batch annotation fields into per-role outputs.
+
+    ``__call__(batch, batch_size)`` returns ``{role: outputs}`` where
+    ``outputs`` is a length-``batch_size`` sequence, one entry per batch
+    item. The ENTRY TYPE is processor-defined — the default samplers emit
+    ``str | None`` (``None`` = "no annotation for this item", so the algo
+    can apply its own fallback), but a subclass may emit candidate lists,
+    structured targets, or anything else its consuming algo expects. Keep
+    new processors hydra-instantiable.
+    """
+
+    #: role names this processor emits (documentation; subclasses override)
+    roles: tuple[str, ...] = ()
+
+    @abstractmethod
+    def __call__(self, batch, batch_size: int) -> dict[str, list]:
+        ...
+
+
+class DefaultAnnotationProcessor(AnnotationProcessor):
+    """Default policy: sample ONE annotation string per item from ``batch[key]``.
+
+    ``batch[key]`` is the raw ``list[list[str]]`` left by
+    ``annotation_collate`` (outer = batch items, inner = all annotation texts
+    active at that item's frame). Items with no active annotation — or a
+    missing/``None`` key — yield ``None``.
+    """
+
+    roles = ("task",)
+
+    def __init__(
+        self,
+        key: str | None = "annotations",
+        strategy: Literal["first", "random"] = "random",
+    ):
+        self.key = key
+        self.strategy = strategy
+
+    def _sample_one(self, texts) -> str | None:
+        if not texts:
+            return None
+        if self.strategy == "random":
+            return texts[random.randint(0, len(texts) - 1)]
+        return texts[0]  # "first"
+
+    def _sample_key(self, batch, key, batch_size) -> list[str | None]:
+        if key is None or key not in batch:
+            return [None] * batch_size
+        return [self._sample_one(texts) for texts in batch[key]]
+
+    def __call__(self, batch, batch_size: int) -> dict[str, list]:
+        return {"task": self._sample_key(batch, self.key, batch_size)}
+
+
+class SubtaskAnnotationProcessor(DefaultAnnotationProcessor):
+    """Sample the (task instruction, subtask target) pair from role-named keys.
+
+    - ``task`` (from ``task_key``): the conditioning instruction — populated
+      for ALL annotated episodes (pick_place instruction / sort goal).
+    - ``subtask`` (from ``subtask_key``): the prediction target — only
+      populated where a decomposition exists (sort); ``None`` elsewhere, so
+      those items contribute no LM loss and nothing leaks into the prompt.
+
+    ``tie_identical`` keeps the two roles textually IDENTICAL whenever an
+    item's two candidate lists are equal (the eva regime, where the same
+    instruction set is injected under both keys): one sample is drawn and
+    reused, instead of two independent draws picking different paraphrases.
+    """
+
+    roles = ("task", "subtask")
+
+    def __init__(
+        self,
+        task_key: str = "annotations_task",
+        subtask_key: str = "annotations_subtask",
+        strategy: Literal["first", "random"] = "random",
+        tie_identical: bool = True,
+    ):
+        super().__init__(key=task_key, strategy=strategy)
+        self.task_key = task_key
+        self.subtask_key = subtask_key
+        self.tie_identical = tie_identical
+
+    def __call__(self, batch, batch_size: int) -> dict[str, list]:
+        task = self._sample_key(batch, self.task_key, batch_size)
+        subtask = self._sample_key(batch, self.subtask_key, batch_size)
+        if self.tie_identical and self.task_key in batch and self.subtask_key in batch:
+            for i in range(batch_size):
+                t_list = batch[self.task_key][i]
+                s_list = batch[self.subtask_key][i]
+                if t_list and t_list == s_list:
+                    subtask[i] = task[i]
+        return {"task": task, "subtask": subtask}

--- a/egomimic/rldb/embodiment/embodiment.py
+++ b/egomimic/rldb/embodiment/embodiment.py
@@ -16,34 +16,29 @@ from egomimic.utils.viz_utils import (
 
 
 class EMBODIMENT(Enum):
-    # All human demonstration data is one embodiment (HUMAN_*); the robot Eva is
-    # the only non-human embodiment. There is NO vendor/source notion at the
-    # embodiment level — the data source is recorded only in the SQL `lab` field.
-    HUMAN_RIGHT_ARM = 1
-    HUMAN_LEFT_ARM = 2
-    HUMAN_BIMANUAL = 3
-    EVA_RIGHT_ARM = 4
-    EVA_LEFT_ARM = 5
-    EVA_BIMANUAL = 6
+    EVE_RIGHT_ARM = 0
+    EVE_LEFT_ARM = 1
+    EVE_BIMANUAL = 2
+    ARIA_RIGHT_ARM = 3
+    ARIA_LEFT_ARM = 4
+    ARIA_BIMANUAL = 5
+    EVA_RIGHT_ARM = 6
+    EVA_LEFT_ARM = 7
+    EVA_BIMANUAL = 8
+    MECKA_BIMANUAL = 9
+    MECKA_RIGHT_ARM = 10
+    MECKA_LEFT_ARM = 11
+    SCALE_BIMANUAL = 12
+    SCALE_RIGHT_ARM = 13
+    SCALE_LEFT_ARM = 14
+    PUSHSHAPES_SIM = 15
+    PUSHSHAPES_SIM_STICK = 16
+    PUSHSHAPES_SIM_SMALL_CIRCLE = 17
+    HUMAN_BIMANUAL = 18
+    PUSHSHAPES_SIM_U_SOCKET = 19
 
 
 EMBODIMENT_ID_TO_KEY = {member.value: member.name for member in EMBODIMENT}
-
-
-def _intrinsics_from_batch(batch, i: int):
-    """Return per-sample intrinsics from batch, or None if missing/NaN sentinel."""
-    K = batch.get("intrinsics") if isinstance(batch, dict) else None
-    if K is None:
-        return None
-    K_i = K[i]
-    if isinstance(K_i, torch.Tensor):
-        if torch.isnan(K_i).any():
-            return None
-        return K_i.detach().cpu().numpy()
-    K_i = np.asarray(K_i)
-    if np.isnan(K_i).any():
-        return None
-    return K_i
 
 
 def get_embodiment(index):
@@ -51,14 +46,14 @@ def get_embodiment(index):
 
 
 def get_embodiment_id(embodiment_name):
-    return EMBODIMENT[embodiment_name.upper()].value
+    embodiment_name = embodiment_name.upper()
+    return EMBODIMENT[embodiment_name].value
 
 
 class Embodiment(ABC):
     """Base embodiment class. An embodiment is responsible for defining the transform pipeline that converts between the raw data in the dataset and the canonical representation used by the model."""
 
-    INTRINSICS = None
-    EXTRINSICS = None
+    VIZ_INTRINSICS_KEY = "base"
     VIZ_IMAGE_KEY = "observations.images.front_img_1"
 
     @staticmethod
@@ -80,6 +75,7 @@ class Embodiment(ABC):
         if transform_list is not None:
             batch = cls.apply_transform(batch, transform_list)
         image_key = image_key or cls.VIZ_IMAGE_KEY
+        intrinsics_key = cls.VIZ_INTRINSICS_KEY
         mode = (mode or "traj").lower()
         B = batch[image_key].shape[0]
         image = _to_numpy(batch[image_key][0])
@@ -94,7 +90,7 @@ class Embodiment(ABC):
             image=image,
             viz_data=viz_data,
             mode=mode,
-            intrinsics=_intrinsics_from_batch(batch, 0),
+            intrinsics_key=intrinsics_key,
             **kwargs,
         )
 
@@ -104,22 +100,22 @@ class Embodiment(ABC):
         image,
         viz_data,
         mode=Literal["traj", "traj+rotation", "axes", "annotations"],
-        intrinsics=None,
+        intrinsics_key=None,
         **kwargs,
     ):
-        K = intrinsics if intrinsics is not None else cls.INTRINSICS
+        intrinsics_key = intrinsics_key or cls.VIZ_INTRINSICS_KEY
         if mode == "traj":
             return _viz_traj(
                 image=image,
                 actions=viz_data,
-                intrinsics=K,
+                intrinsics_key=intrinsics_key,
                 **kwargs,
             )
         if mode == "traj+rotation":
             vis = _viz_traj(
                 image=image,
                 actions=viz_data,
-                intrinsics=K,
+                intrinsics_key=intrinsics_key,
                 **kwargs,
             )
             return _viz_rotation_txt(
@@ -131,7 +127,7 @@ class Embodiment(ABC):
             return _viz_axes(
                 image=image,
                 actions=viz_data,
-                intrinsics=K,
+                intrinsics_key=intrinsics_key,
                 **kwargs,
             )
         if mode == "annotations":
@@ -197,14 +193,11 @@ class Embodiment(ABC):
             image = images[i]
             action = actions[i]
             pred_action = pred_actions[i]
-            K_i = _intrinsics_from_batch(batch, i)
             ims = cls.viz(
-                image, action, mode=mode, color="Greens", alpha=gt_alpha,
-                intrinsics=K_i, **kwargs
+                image, action, mode=mode, color="Greens", alpha=gt_alpha, **kwargs
             )
             ims = cls.viz(
-                ims, pred_action, mode=mode, color="Reds", alpha=pred_alpha,
-                intrinsics=K_i, **kwargs
+                ims, pred_action, mode=mode, color="Reds", alpha=pred_alpha, **kwargs
             )
             if annotation_key is not None:
                 ims = cls.viz(ims, [annotations[i]], mode="annotations", **kwargs)

--- a/egomimic/rldb/embodiment/fold_span_transforms.py
+++ b/egomimic/rldb/embodiment/fold_span_transforms.py
@@ -1,0 +1,255 @@
+"""Span-safe (per-frame, variable-length) keymaps + transforms for the fold
+cross-embodiment cotrain SMOKE.
+
+WHY THIS EXISTS: the canonical ``Eva.get_transform_list('cartesian')`` /
+``Aria.get_transform_list('keypoints_headframe_ypr')`` pipelines build a
+FIXED-horizon windowed action chunk per obs-frame (``InterpolatePose
+chunk_length=100`` / ``Reshape (30,21,3)``). Those assume the WINDOWED padded
+MultiDataset reader. The span-as-episode packed reader
+(``ZarrAnnotationSpanPackedDataset``) reads a whole variable-length span at
+native per-frame resolution, so the fixed reshape/interp blows up
+(``cannot reshape array of size ... into (30,21,3)``).
+
+These minimal transforms instead produce PER-FRAME actions + proprio over the
+whole span by concatenating the raw per-frame arrays (frame conventions are the
+raw quaternion / head-frame-relative-nothing forms — good enough to verify the
+ARCH runs + loss descends, which is the smoke's only goal):
+
+  eva  : actions_cartesian (14) = [left.cmd_ee_pose(7), right.cmd_ee_pose(7)]
+         observations.state.ee_pose (14) = [left.obs_ee_pose(7), right.obs_ee_pose(7)]
+  human: actions_keypoints (132) = [left wrist_xyz(3), left kp(63),
+                                     right wrist_xyz(3), right kp(63)]
+         observations.keypoints (132) = same as the action (teacher-forced)
+         (was 138 with wrist ypr; dropped -- see HeadFrameWristPos)
+         obs_head_pose (7) = raw head pose
+"""
+
+import os
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+from egomimic.rldb.zarr.action_chunk_transforms import (
+    ConcatKeys,
+    NumpyToTensor,
+    Transform,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Span-safe PER-FRAME head-frame conversion (fold2 FIX 2).
+#
+# The canonical Aria.get_transform_list("keypoints_headframe_ypr") brings
+# keypoints + wrist into the head's local frame (relative to obs_head_pose),
+# but does it via ActionChunkCoordinateFrameTransform, which uses ONE head pose
+# for a whole windowed chunk, wrapped in InterpolatePose/Reshape((30,21,3)) that
+# assume a FIXED window length -> breaks on variable-length span reads.
+#
+# The head-frame math is inherently per-frame: frame t's points are expressed
+# in frame t's head frame. These ops do EXACTLY that, vectorised over the whole
+# span AND robust to the single-frame (D,) reads that the WINDOWED ZarrDataset
+# probe (norm_stats.populate_from_datasets) issues. obs_head_pose / wrist_pose
+# are xyz + quat(wxyz) (matches _xyzwxyz_to_matrix in the canonical pipeline).
+# --------------------------------------------------------------------------- #
+def _wxyz_to_matrix(q):
+    """(N,4) wxyz quats -> (N,3,3) rotation matrices (scipy wants xyzw)."""
+    xyzw = np.concatenate([q[:, 1:4], q[:, 0:1]], axis=-1)
+    return R.from_quat(xyzw).as_matrix()
+
+
+class HeadFrameKeypoints(Transform):
+    """Per-frame head-frame conversion of a flat keypoint array.
+
+    ``kp`` (T, n_kp*3) [or (n_kp*3,) single frame] -> same shape, each frame's
+    keypoints expressed in that frame's head frame:
+        kp_head[t,i] = R_head[t]^T @ (kp_world[t,i] - t_head[t])
+    """
+
+    def __init__(self, head_key: str, kp_key: str, out_key: str, n_kp: int = 21):
+        self.head_key = head_key
+        self.kp_key = kp_key
+        self.out_key = out_key
+        self.n_kp = int(n_kp)
+
+    def transform(self, batch: dict) -> dict:
+        head = np.asarray(batch[self.head_key], dtype=np.float64)
+        kp = np.asarray(batch[self.kp_key], dtype=np.float64)
+        single = head.ndim == 1
+        if single:
+            head, kp = head[None, :], kp[None, :]
+        T = head.shape[0]
+        t_head = head[:, :3]
+        R_head = _wxyz_to_matrix(head[:, 3:7])             # (T,3,3)
+        pts = kp.reshape(T, self.n_kp, 3)
+        rel = pts - t_head[:, None, :]                     # (T,n,3)
+        kp_head = np.einsum("tij,tnj->tni", np.transpose(R_head, (0, 2, 1)), rel)
+        out = kp_head.reshape(T, self.n_kp * 3)
+        batch[self.out_key] = out[0] if single else out
+        return batch
+
+
+class HeadFrameWristYPR(Transform):
+    """Per-frame head-frame wrist pose -> xyz + ypr (ZYX euler).
+
+    ``wrist`` (T,7) [or (7,)] xyz+quat(wxyz) -> (T,6) [or (6,)] xyz+ypr, each
+    frame in that frame's head frame:
+        R_wh = R_head^T @ R_wrist ;  t_wh = R_head^T @ (t_wrist - t_head)
+    """
+
+    def __init__(self, head_key: str, wrist_key: str, out_key: str):
+        self.head_key = head_key
+        self.wrist_key = wrist_key
+        self.out_key = out_key
+
+    def transform(self, batch: dict) -> dict:
+        head = np.asarray(batch[self.head_key], dtype=np.float64)
+        wr = np.asarray(batch[self.wrist_key], dtype=np.float64)
+        single = head.ndim == 1
+        if single:
+            head, wr = head[None, :], wr[None, :]
+        t_head = head[:, :3]
+        R_head = _wxyz_to_matrix(head[:, 3:7])             # (T,3,3)
+        t_wr = wr[:, :3]
+        R_wr = _wxyz_to_matrix(wr[:, 3:7])                 # (T,3,3)
+        R_headT = np.transpose(R_head, (0, 2, 1))
+        t_wh = np.einsum("tij,tj->ti", R_headT, t_wr - t_head)      # (T,3)
+        R_wh = np.einsum("tij,tjk->tik", R_headT, R_wr)            # (T,3,3)
+        ypr = R.from_matrix(R_wh).as_euler("ZYX", degrees=False)   # (T,3)
+        out = np.concatenate([t_wh, ypr], axis=-1)                 # (T,6)
+        batch[self.out_key] = out[0] if single else out
+        return batch
+
+
+class HeadFrameWristPos(Transform):
+    """Head-frame wrist POSITION only -- xyz, no orientation (option B).
+
+    ``wrist`` (T,7) [or (7,)] xyz+quat(wxyz) -> (T,3) [or (3,)]:
+        t_wh = R_head^T @ (t_wrist - t_head)
+
+    Deliberately drops the ZYX-euler orientation that HeadFrameWristYPR emits:
+    those 3 dims/wrist are discontinuous (wrap at +-pi, gimbal lock at pitch
+    +-pi/2) and a diffusion model cannot represent the branch cut, which showed
+    up as ~80%% of the human action error concentrated in 12 of 138 dims.
+    Orientation remains recoverable from the 21 head-frame keypoints.
+    """
+
+    def __init__(self, head_key: str, wrist_key: str, out_key: str):
+        self.head_key = head_key
+        self.wrist_key = wrist_key
+        self.out_key = out_key
+
+    def transform(self, batch: dict) -> dict:
+        head = np.asarray(batch[self.head_key], dtype=np.float64)
+        wr = np.asarray(batch[self.wrist_key], dtype=np.float64)
+        single = head.ndim == 1
+        if single:
+            head, wr = head[None, :], wr[None, :]
+        t_head = head[:, :3]
+        R_head = _wxyz_to_matrix(head[:, 3:7])
+        R_headT = np.transpose(R_head, (0, 2, 1))
+        t_wh = np.einsum("tij,tj->ti", R_headT, wr[:, :3] - t_head)   # (T,3)
+        batch[self.out_key] = t_wh[0] if single else t_wh
+        return batch
+
+
+# --------------------------------------------------------------------------- #
+# eva_bimanual
+# --------------------------------------------------------------------------- #
+def _drop_camera_keys(km):
+    """norm_mode: drop image/annotation keys so the norm-stats dataset reads only
+    the numeric (proprio/action) arrays (mirrors Embodiment.get_keymap)."""
+    return {
+        k: v
+        for k, v in km.items()
+        if v.get("key_type") not in ("camera_keys", "annotation_keys")
+    }
+
+
+def eva_span_keymap(norm_mode: bool = False, annotation_key=None):
+    """Minimal keymap: front image + per-arm ee pose (proprio) + per-arm cmd
+    ee pose (action). Deliberately omits wrist images + grippers to keep the
+    span read light. ``norm_mode`` (set by trainHydra when building the
+    norm-stats dataset) drops the image key."""
+    km = {
+        "front_img_1": {"key_type": "camera_keys", "zarr_key": "images.front_1"},
+        "left.cmd_ee_pose": {"key_type": "action_keys", "zarr_key": "left.cmd_ee_pose"},
+        "right.cmd_ee_pose": {"key_type": "action_keys", "zarr_key": "right.cmd_ee_pose"},
+        "left.obs_ee_pose": {"key_type": "proprio_keys", "zarr_key": "left.obs_ee_pose"},
+        "right.obs_ee_pose": {"key_type": "proprio_keys", "zarr_key": "right.obs_ee_pose"},
+    }
+    return _drop_camera_keys(km) if norm_mode else km
+
+
+def eva_span_transforms():
+    return [
+        ConcatKeys(
+            key_list=["left.cmd_ee_pose", "right.cmd_ee_pose"],
+            new_key_name="actions_cartesian",
+            delete_old_keys=True,
+        ),
+        ConcatKeys(
+            key_list=["left.obs_ee_pose", "right.obs_ee_pose"],
+            new_key_name="state_ee_pose",
+            delete_old_keys=True,
+        ),
+        NumpyToTensor(keys=["actions_cartesian", "state_ee_pose"]),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# human_bimanual
+# --------------------------------------------------------------------------- #
+def human_span_keymap(norm_mode: bool = False, annotation_key=None):
+    km = {
+        "front_img_1": {"key_type": "camera_keys", "zarr_key": "images.front_1"},
+        "left.obs_keypoints": {"key_type": "proprio_keys", "zarr_key": "left.obs_keypoints"},
+        "right.obs_keypoints": {"key_type": "proprio_keys", "zarr_key": "right.obs_keypoints"},
+        "left.obs_wrist_pose": {"key_type": "proprio_keys", "zarr_key": "left.obs_wrist_pose"},
+        "right.obs_wrist_pose": {"key_type": "proprio_keys", "zarr_key": "right.obs_wrist_pose"},
+        "obs_head_pose": {"key_type": "proprio_keys", "zarr_key": "obs_head_pose"},
+    }
+    return _drop_camera_keys(km) if norm_mode else km
+
+
+_WRIST_MODE = os.environ.get("RH_WRIST_MODE", "pos").lower()
+#: "ypr" -> 138 (legacy, wrist xyz+ypr) | "pos" -> 132 (wrist xyz) |
+#: "none" -> 126 (KEYPOINTS ONLY, no wrist pose)
+_WRIST = (HeadFrameWristYPR if _WRIST_MODE == "ypr"
+          else (None if _WRIST_MODE == "none" else HeadFrameWristPos))
+
+
+def human_span_transforms():
+    # SPAN-SAFE HEAD-FRAME (fold2 FIX 2): keypoints + wrist expressed in each
+    # frame's head frame (relative to obs_head_pose), matching the canonical
+    # Aria "keypoints_headframe_ypr" representation but computed PER-FRAME so it
+    # works on variable-length span reads AND the single-frame windowed probe.
+    #   action_keypoints (132) = [Lwrist_xyz(3), Lkp_hf(63), Rwrist_xyz(3), Rkp_hf(63)]
+    # (order matches _build_aria_keypoints_bimanual_transform_list). The action
+    # is the teacher-forced per-frame head-frame state (obs == action here).
+    # RH_WRIST_MODE: ypr -> 138 (legacy wrist xyz+ypr) | pos -> 132 (wrist xyz)
+    # | none -> 126 (KEYPOINTS ONLY). 138 is needed to load pre-2026-07-30
+    # checkpoints, whose norm stats and per-emb codecs are keyed to it.
+    _wrist_ops = ([] if _WRIST is None else [
+        _WRIST("obs_head_pose", "left.obs_wrist_pose", "L_wrist_hf"),
+        _WRIST("obs_head_pose", "right.obs_wrist_pose", "R_wrist_hf"),
+    ])
+    _keys = (["L_kp_hf", "R_kp_hf"] if _WRIST is None
+             else ["L_wrist_hf", "L_kp_hf", "R_wrist_hf", "R_kp_hf"])
+    return [
+        *_wrist_ops,
+        HeadFrameKeypoints("obs_head_pose", "left.obs_keypoints", "L_kp_hf"),
+        HeadFrameKeypoints("obs_head_pose", "right.obs_keypoints", "R_kp_hf"),
+        # action target (132): head-frame wrist-xyz + head-frame keypoints per hand.
+        ConcatKeys(
+            key_list=_keys,
+            new_key_name="actions_keypoints",
+            delete_old_keys=False,
+        ),
+        # proprio obs (132): same head-frame layout; consumes the components.
+        ConcatKeys(
+            key_list=_keys,
+            new_key_name="state_keypoints",
+            delete_old_keys=True,
+        ),
+        NumpyToTensor(keys=["actions_keypoints", "state_keypoints", "obs_head_pose"]),
+    ]

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Literal
 
-import numpy as np
-
 from egomimic.rldb.embodiment.embodiment import Embodiment
 from egomimic.rldb.zarr.action_chunk_transforms import (
     ActionChunkCoordinateFrameTransform,
@@ -12,7 +10,6 @@ from egomimic.rldb.zarr.action_chunk_transforms import (
     ConcatKeys,
     DeleteKeys,
     InterpolatePose,
-    PadGripperZeros,
     PoseCoordinateFrameTransform,
     QuaternionPoseToYPR,
     Reshape,
@@ -22,140 +19,24 @@ from egomimic.rldb.zarr.action_chunk_transforms import (
 )
 from egomimic.utils.viz_utils import (
     ColorPalette,
-    _viz_gaze,
     _viz_keypoints,
 )
 
 
-ARIA_INTRINSICS = np.array(
-    [
-        [133.25430222 * 2, 0.0, 320, 0],
-        [0.0, 133.25430222 * 2, 240, 0],
-        [0.0, 0.0, 1.0, 0],
-    ]
-)
-
-ARIA_INTRINSICS_HALF = np.array(
-    [
-        [133.25430222, 0.0, 320 / 2, 0],
-        [0.0, 133.25430222, 240 / 2, 0],
-        [0.0, 0.0, 1.0, 0],
-    ]
-)
-
-SCALE_INTRINSICS = np.array(
-    [[214.134, 0.0, 324.593, 0], [0.0, 256.968, 260.146, 0], [0.0, 0.0, 1.0, 0]]
-)
-
-_w0, _h0 = float(1920), float(1080)
-_fx0, _fy0 = float(752.4707352849115), float(753.0015979987369)
-_cx0, _cy0 = float(961.8249427694457), float(553.245895705989)
-_sx = 640 / _w0
-_sy = 360 / _h0
-_fx, _fy = _fx0 * _sx, _fy0 * _sy
-_cx, _cy = _cx0 * _sx, _cy0 * _sy
-
-MECKA_INTRINSICS = np.array(
-    [[_fx, 0.0, _cx, 0], [0.0, _fy, _cy, 0], [0.0, 0.0, 1.0, 0]], dtype=np.float64
-)
-
-LIGHTWHEEL_INTRINSICS = np.array(
-    [
-        [786.6216072, 0.0, 960.0, 0],
-        [0.0, 786.6216072, 728.0, 0],
-        [0.0, 0.0, 1.0, 0],
-    ]
-)
-
-ARIA_T_RGB_CPF = np.array(
-    [
-        [-0.99989084, 0.01251132, -0.00786028, 0.05686918],
-        [-0.01132842, -0.99067146, -0.13580032, 0.00922798],
-        [-0.009486, -0.13569645, 0.99070505, -0.01147902],
-        [0.0, 0.0, 0.0, 1.0],
-    ]
-)
-
-
-# Aria's raw 21-keypoint layout (0-4 fingertips, 5 palm root) — NOT MANO. Used
-# only for the opt-in raw-Aria-keypoint viz; the canonical keypoints are MANO.
-ARIA_FINGER_EDGES = [
-    (5, 6), (6, 7), (7, 0),                # thumb
-    (5, 8), (8, 9), (9, 10), (10, 1),      # index
-    (5, 11), (11, 12), (12, 13), (13, 2),  # middle
-    (5, 14), (14, 15), (15, 16), (16, 3),  # ring
-    (5, 17), (17, 18), (18, 19), (19, 4),  # pinky
-]
-ARIA_FINGER_EDGE_RANGES = [
-    ("thumb", 0, 3), ("index", 3, 7), ("middle", 7, 11), ("ring", 11, 15), ("pinky", 15, 19),
-]
-
-
 class Human(Embodiment):
-    """Single data-driven human embodiment shared by every vendor's human data.
-
-    Per-vendor structural differences are explicit classmethod arguments supplied
-    by the data config, because get_keymap / get_transform_list resolve at hydra
-    config time (before any episode is read):
-      - get_keymap(keymap_mode, has_head_pose=True, include_aria_keypoints=False)
-      - get_transform_list(mode, stride=3)
-    Per-episode camera intrinsics travel in ``batch["intrinsics"]`` (from
-    zarr.json); ``cls.INTRINSICS`` is only a fallback for legacy episodes that
-    lack them. The canonical keypoints are MANO for every vendor.
-    """
-    INTRINSICS = ARIA_INTRINSICS  # fallback only — real value comes from the batch
-    ACTION_HORIZON = 30
-    # Front-image key for Pi/PaliGemma-style naming (any "_pi"-suffixed mode);
-    # Pi's _fill_missing_images auto-duplicates the absent wrist keys.
-    PI_FRONT_KEY = "base_0_rgb"
-    T_RGB_CPF = ARIA_T_RGB_CPF  # for the opt-in aria gaze viz
-    # Canonical MANO 21-keypoint topology: 0=wrist, 1-4 thumb, 5-8 index, ...
-    FINGER_EDGES = [
-        (0, 1), (1, 2), (2, 3), (3, 4),         # thumb
-        (0, 5), (5, 6), (6, 7), (7, 8),         # index
-        (0, 9), (9, 10), (10, 11), (11, 12),    # middle
-        (0, 13), (13, 14), (14, 15), (15, 16),  # ring
-        (0, 17), (17, 18), (18, 19), (19, 20),  # pinky
-    ]
-    FINGER_COLORS = {
-        "thumb": (255, 100, 100),
-        "index": (100, 255, 100),
-        "middle": (100, 100, 255),
-        "ring": (255, 255, 100),
-        "pinky": (255, 100, 255),
-    }
-    FINGER_EDGE_RANGES = [
-        ("thumb", 0, 4),
-        ("index", 4, 8),
-        ("middle", 8, 12),
-        ("ring", 12, 16),
-        ("pinky", 16, 20),
-    ]
-    DOT_COLOR = (255, 165, 0)
+    ACTION_STRIDE = 3
 
     @classmethod
     def viz(
         cls,
         image,
         viz_data,
-        mode=Literal[
-            "traj", "traj+rotation", "axes", "annotations", "keypoints", "gaze"
-        ],
-        intrinsics=None,
-        finger_edges=None,
-        finger_edge_ranges=None,
+        mode=Literal["traj", "traj+rotation", "axes", "annotations", "keypoints"],
+        intrinsics_key=None,
         **kwargs,
     ):
-        K = intrinsics if intrinsics is not None else cls.INTRINSICS
-        if mode == "gaze":
-            return _viz_gaze(
-                image=image,
-                gaze_data=viz_data,
-                intrinsics=K,
-                t_rgb_cpf=cls.T_RGB_CPF,
-                **kwargs,
-            )
         if mode == "keypoints":
+            intrinsics_key = intrinsics_key or cls.VIZ_INTRINSICS_KEY
             color = kwargs.get("color", None)
             if color is not None and ColorPalette.is_valid(color):
                 n = len(cls.FINGER_COLORS)
@@ -170,83 +51,228 @@ class Human(Embodiment):
             return _viz_keypoints(
                 image=image,
                 actions=viz_data,
-                intrinsics=K,
-                edges=finger_edges if finger_edges is not None else cls.FINGER_EDGES,
-                edge_ranges=(
-                    finger_edge_ranges
-                    if finger_edge_ranges is not None
-                    else cls.FINGER_EDGE_RANGES
-                ),
+                intrinsics_key=intrinsics_key,
+                edges=cls.FINGER_EDGES,
+                edge_ranges=cls.FINGER_EDGE_RANGES,
                 colors=colors,
                 dot_color=dot_color,
                 **kwargs,
             )
-        return super().viz(image, viz_data, mode=mode, intrinsics=intrinsics, **kwargs)
+        return super().viz(
+            image, viz_data, mode=mode, intrinsics_key=intrinsics_key, **kwargs
+        )
+
+    @abstractmethod
+    def _get_keymap(
+        cls, mode: Literal["cartesian", "keypoints"], annotation_key: str = None
+    ):
+        pass
+
+    @abstractmethod
+    def get_transform_list(
+        cls,
+        mode: str,
+    ) -> list[Transform]:
+        pass
+
+
+class Aria(Human):
+    VIZ_INTRINSICS_KEY = "base"
+    ACTION_STRIDE = 3
+    FINGER_EDGES = [
+        (
+            5,
+            6,
+        ),
+        (6, 7),
+        (7, 0),  # thumb
+        (5, 8),
+        (8, 9),
+        (9, 10),
+        (9, 1),  # index
+        (5, 11),
+        (11, 12),
+        (12, 13),
+        (13, 2),  # middle
+        (5, 14),
+        (14, 15),
+        (15, 16),
+        (16, 3),  # ring
+        (5, 17),
+        (17, 18),
+        (18, 19),
+        (19, 4),  # pinky
+    ]
+    FINGER_COLORS = {
+        "thumb": (255, 100, 100),  # red
+        "index": (100, 255, 100),  # green
+        "middle": (100, 100, 255),  # blue
+        "ring": (255, 255, 100),  # yellow
+        "pinky": (255, 100, 255),  # magenta
+    }
+    FINGER_EDGE_RANGES = [
+        ("thumb", 0, 3),
+        ("index", 3, 7),
+        ("middle", 7, 11),
+        ("ring", 11, 15),
+        ("pinky", 15, 19),
+    ]
+    DOT_COLOR = (255, 165, 0)
 
     @classmethod
-    def get_keymap(
+    def get_transform_list(
         cls,
-        keymap_mode: str,
-        has_head_pose: bool = True,
-        include_aria_keypoints: bool = False,
-        norm_mode: bool = False,
-        annotation_key: str = None,
-    ):
-        """Build the keymap. Per-vendor knobs are explicit args from the data
-        config: ``has_head_pose`` (Scale=False) and ``include_aria_keypoints``
-        (Aria=True). ``norm_mode``/``annotation_key`` behave as in the base.
-        """
-        key_map = cls._get_keymap(
-            keymap_mode,
-            has_head_pose=has_head_pose,
-            include_aria_keypoints=include_aria_keypoints,
-        )
-        if annotation_key is not None and not norm_mode:
-            key_map[annotation_key] = {
-                "key_type": "annotation_keys",
-                "zarr_key": annotation_key,
-            }
-        if norm_mode:
-            to_delete = [
-                k
-                for k, v in key_map.items()
-                if v.get("key_type") in ("camera_keys", "annotation_keys")
-            ]
-            for k in to_delete:
-                del key_map[k]
-        return key_map
+        mode: Literal[
+            "cartesian",
+            "cartesian_wristframe_ypr",
+            "keypoints_headframe_ypr",
+            "keypoints_headframe_quat",
+            "keypoints_wristframe_ypr",
+            "keypoints_wristframe_quat",
+        ],
+    ) -> list[Transform]:
+        if mode == "cartesian":
+            return _build_aria_cartesian_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE
+            )
+        elif mode == "cartesian_wristframe_ypr":
+            return _build_aria_cartesian_eef_frame_transform_list(
+                stride=cls.ACTION_STRIDE
+            )
+        elif mode == "keypoints_headframe_ypr":
+            return _build_aria_keypoints_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE, is_quat=False
+            )
+        elif mode == "keypoints_headframe_quat":
+            return _build_aria_keypoints_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE, is_quat=True
+            )
+        elif mode == "keypoints_wristframe_ypr":
+            return _build_aria_keypoints_eef_frame_transform_list(
+                stride=cls.ACTION_STRIDE, is_quat=False
+            )
+        elif mode == "keypoints_wristframe_quat":
+            return _build_aria_keypoints_eef_frame_transform_list(
+                stride=cls.ACTION_STRIDE, is_quat=True
+            )
 
     @classmethod
     def _get_keymap(
         cls,
-        keymap_mode: str,
-        has_head_pose: bool = True,
-        include_aria_keypoints: bool = False,
+        keymap_mode: Literal["cartesian", "keypoints"],
     ):
-        """Canonical MANO keymap. A ``_pi`` suffix swaps the front image key to
-        ``PI_FRONT_KEY``; ``include_aria_keypoints`` additionally exposes the raw
-        Aria-layout proprio keypoints alongside the MANO ones.
-        """
-        is_pi = keymap_mode.endswith("_pi")
-        base_mode = keymap_mode[: -len("_pi")] if is_pi else keymap_mode
-        front_key = cls.PI_FRONT_KEY if is_pi else cls.VIZ_IMAGE_KEY
-        horizon = cls.ACTION_HORIZON
-
-        if base_mode == "cartesian":
-            key_map = {
-                front_key: {
+        if keymap_mode == "cartesian":
+            return {
+                cls.VIZ_IMAGE_KEY: {
                     "key_type": "camera_keys",
                     "zarr_key": "images.front_1",
                 },
                 "right.action_ee_pose": {
                     "key_type": "action_keys",
                     "zarr_key": "right.obs_ee_pose",
-                    "horizon": horizon,
+                    "horizon": 30,
                 },
                 "left.action_ee_pose": {
                     "key_type": "action_keys",
                     "zarr_key": "left.obs_ee_pose",
-                    "horizon": horizon,
+                    "horizon": 30,
+                },
+                "right.obs_ee_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_ee_pose",
+                },
+                "left.obs_ee_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_ee_pose",
+                },
+                "obs_head_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "obs_head_pose",
+                },
+            }
+        elif keymap_mode == "keypoints":
+            return {
+                cls.VIZ_IMAGE_KEY: {
+                    "key_type": "camera_keys",
+                    "zarr_key": "images.front_1",
+                },
+                "left.action_keypoints": {
+                    "key_type": "action_keys",
+                    "zarr_key": "left.obs_keypoints",
+                    "horizon": 30,
+                },
+                "right.action_keypoints": {
+                    "key_type": "action_keys",
+                    "zarr_key": "right.obs_keypoints",
+                    "horizon": 30,
+                },
+                "left.action_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_wrist_pose",
+                    "horizon": 30,
+                },
+                "right.action_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_wrist_pose",
+                    "horizon": 30,
+                },
+                "left.obs_keypoints": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_keypoints",
+                },
+                "right.obs_keypoints": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_keypoints",
+                },
+                "left.obs_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_wrist_pose",
+                },
+                "right.obs_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_wrist_pose",
+                },
+                "obs_head_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "obs_head_pose",
+                },
+            }
+
+
+class Scale(Human):
+    VIZ_INTRINSICS_KEY = "scale"
+    ACTION_STRIDE = 1
+
+    @classmethod
+    def get_transform_list(
+        cls,
+        mode: Literal["cartesian",],
+    ) -> list[Transform]:
+        if mode == "cartesian":
+            return _build_aria_cartesian_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE
+            )
+
+    @classmethod
+    def _get_keymap(
+        cls,
+        keymap_mode: Literal["cartesian", "keypoints"],
+    ):
+        if keymap_mode == "cartesian":
+            return {
+                cls.VIZ_IMAGE_KEY: {
+                    "key_type": "camera_keys",
+                    "zarr_key": "images.front_1",
+                },
+                "right.action_ee_pose": {
+                    "key_type": "action_keys",
+                    "zarr_key": "right.obs_ee_pose",
+                    "horizon": 30,
+                },
+                "left.action_ee_pose": {
+                    "key_type": "action_keys",
+                    "zarr_key": "left.obs_ee_pose",
+                    "horizon": 30,
                 },
                 "right.obs_ee_pose": {
                     "key_type": "proprio_keys",
@@ -257,40 +283,39 @@ class Human(Embodiment):
                     "zarr_key": "left.obs_ee_pose",
                 },
             }
-        elif base_mode == "keypoints":
-            kp = "obs_keypoints"  # canonical MANO keypoints for every vendor
-            key_map = {
-                front_key: {
+        elif keymap_mode == "keypoints":
+            return {
+                cls.VIZ_IMAGE_KEY: {
                     "key_type": "camera_keys",
                     "zarr_key": "images.front_1",
                 },
                 "left.action_keypoints": {
                     "key_type": "action_keys",
-                    "zarr_key": f"left.{kp}",
-                    "horizon": horizon,
+                    "zarr_key": "left.obs_keypoints",
+                    "horizon": 30,
                 },
                 "right.action_keypoints": {
                     "key_type": "action_keys",
-                    "zarr_key": f"right.{kp}",
-                    "horizon": horizon,
+                    "zarr_key": "right.obs_keypoints",
+                    "horizon": 30,
                 },
                 "left.action_wrist_pose": {
                     "key_type": "proprio_keys",
                     "zarr_key": "left.obs_wrist_pose",
-                    "horizon": horizon,
+                    "horizon": 30,
                 },
                 "right.action_wrist_pose": {
                     "key_type": "proprio_keys",
                     "zarr_key": "right.obs_wrist_pose",
-                    "horizon": horizon,
+                    "horizon": 30,
                 },
                 "left.obs_keypoints": {
                     "key_type": "proprio_keys",
-                    "zarr_key": f"left.{kp}",
+                    "zarr_key": "left.obs_keypoints",
                 },
                 "right.obs_keypoints": {
                     "key_type": "proprio_keys",
-                    "zarr_key": f"right.{kp}",
+                    "zarr_key": "right.obs_keypoints",
                 },
                 "left.obs_wrist_pose": {
                     "key_type": "proprio_keys",
@@ -301,73 +326,125 @@ class Human(Embodiment):
                     "zarr_key": "right.obs_wrist_pose",
                 },
             }
-            if include_aria_keypoints:
-                # Raw Aria-layout keypoints exposed alongside the canonical MANO
-                # ones (proprio, no horizon: no transform consumes them).
-                for side in ("left", "right"):
-                    key_map[f"{side}.obs_aria_keypoints"] = {
-                        "key_type": "proprio_keys",
-                        "zarr_key": f"{side}.obs_aria_keypoints",
-                    }
-        else:
-            raise ValueError(
-                f"Unsupported keymap_mode '{keymap_mode}' for {cls.__name__}. "
-                "Expected 'cartesian' or 'keypoints' (optionally with a '_pi' suffix)."
-            )
 
-        if has_head_pose:
-            key_map["obs_head_pose"] = {
-                "key_type": "proprio_keys",
-                "zarr_key": "obs_head_pose",
-            }
-        return key_map
+
+class Mecka(Human):
+    VIZ_INTRINSICS_KEY = "mecka"
+    ACTION_STRIDE = 1
 
     @classmethod
     def get_transform_list(
         cls,
-        mode: Literal[
-            "cartesian",
-            "cartesian_padded",
-            "cartesian_wristframe_ypr",
-            "keypoints_headframe_ypr",
-            "keypoints_headframe_quat",
-            "keypoints_wristframe_ypr",
-            "keypoints_wristframe_quat",
-        ],
-        stride: int = 3,
+        mode: Literal["cartesian",],
     ) -> list[Transform]:
-        """Transform pipeline. ``stride`` is the per-vendor action stride
-        (Aria/LightWheel=3, Scale/Mecka=1), supplied by the data config.
-        """
         if mode == "cartesian":
-            return _build_human_cartesian_bimanual_transform_list(stride=stride)
-        if mode == "cartesian_padded":
-            return _build_human_cartesian_bimanual_transform_list(
-                stride=stride
-            ) + [PadGripperZeros(action_key="actions_cartesian")]
-        if mode == "cartesian_wristframe_ypr":
-            return _build_human_cartesian_eef_frame_transform_list(stride=stride)
-        if mode == "keypoints_headframe_ypr":
-            return _build_human_keypoints_bimanual_transform_list(
-                stride=stride, is_quat=False
+            return _build_aria_cartesian_bimanual_transform_list(
+                stride=cls.ACTION_STRIDE
             )
-        if mode == "keypoints_headframe_quat":
-            return _build_human_keypoints_bimanual_transform_list(
-                stride=stride, is_quat=True
+
+    @classmethod
+    def get_keymap(
+        cls,
+        mode: Literal["cartesian", "keypoints"],
+        annotations: bool = False,
+        norm_mode: bool = False,
+    ):
+        if mode == "cartesian":
+            key_map = {
+                cls.VIZ_IMAGE_KEY: {
+                    "key_type": "camera_keys",
+                    "zarr_key": "images.front_1",
+                },
+                "right.action_ee_pose": {
+                    "key_type": "action_keys",
+                    "zarr_key": "right.obs_ee_pose",
+                    "horizon": 30,
+                },
+                "left.action_ee_pose": {
+                    "key_type": "action_keys",
+                    "zarr_key": "left.obs_ee_pose",
+                    "horizon": 30,
+                },
+                "right.obs_ee_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_ee_pose",
+                },
+                "left.obs_ee_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_ee_pose",
+                },
+                "obs_head_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "obs_head_pose",
+                },
+            }
+        elif mode == "keypoints":
+            key_map = {
+                cls.VIZ_IMAGE_KEY: {
+                    "key_type": "camera_keys",
+                    "zarr_key": "images.front_1",
+                },
+                "left.action_keypoints": {
+                    "key_type": "action_keys",
+                    "zarr_key": "left.obs_keypoints",
+                    "horizon": 30,
+                },
+                "right.action_keypoints": {
+                    "key_type": "action_keys",
+                    "zarr_key": "right.obs_keypoints",
+                    "horizon": 30,
+                },
+                "left.action_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_wrist_pose",
+                    "horizon": 30,
+                },
+                "right.action_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_wrist_pose",
+                    "horizon": 30,
+                },
+                "left.obs_keypoints": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_keypoints",
+                },
+                "right.obs_keypoints": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_keypoints",
+                },
+                "left.obs_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "left.obs_wrist_pose",
+                },
+                "right.obs_wrist_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "right.obs_wrist_pose",
+                },
+                "obs_head_pose": {
+                    "key_type": "proprio_keys",
+                    "zarr_key": "obs_head_pose",
+                },
+            }
+        else:
+            raise ValueError(
+                f"Unsupported mode '{mode}'. Expected one of: 'cartesian', 'keypoints'."
             )
-        if mode == "keypoints_wristframe_ypr":
-            return _build_human_keypoints_eef_frame_transform_list(
-                stride=stride, is_quat=False
-            )
-        if mode == "keypoints_wristframe_quat":
-            return _build_human_keypoints_eef_frame_transform_list(
-                stride=stride, is_quat=True
-            )
-        raise ValueError(f"Unsupported transform_list mode '{mode}' for {cls.__name__}")
+        if annotations:
+            key_map["annotations"] = {
+                "key_type": "annotation_keys",
+                "zarr_key": "annotations",
+            }
+        if norm_mode:
+            # norm-stats build (trainHydra sets norm_mode=True): drop camera keys
+            # since image tensors are not normalized. Mirrors human_span_keymap.
+            key_map = {
+                k: v for k, v in key_map.items() if v.get("key_type") != "camera_keys"
+            }
+        return key_map
 
 
 # this works for quat and ypr since actionChunkCoordinateFrameTransform works for both
-def _build_human_keypoints_revert_eef_frame_transform_list(
+def _build_aria_keypoints_revert_eef_frame_transform_list(
     *,
     action_key: str = "actions_keypoints",
     obs_key: str = "observations.state.keypoints",
@@ -454,7 +531,7 @@ def _build_human_keypoints_revert_eef_frame_transform_list(
     return transform_list
 
 
-def _build_human_keypoints_eef_frame_transform_list(
+def _build_aria_keypoints_eef_frame_transform_list(
     *,
     target_world: str = "obs_head_pose",
     target_world_ypr: str = "obs_head_pose_ypr",
@@ -486,7 +563,7 @@ def _build_human_keypoints_eef_frame_transform_list(
     stride: int = 3,
     is_quat: bool = True,
 ) -> list[Transform]:
-    transform_list = _build_human_keypoints_bimanual_transform_list(
+    transform_list = _build_aria_keypoints_bimanual_transform_list(
         target_world=target_world,
         target_world_ypr=target_world_ypr,
         target_world_is_quat=target_world_is_quat,
@@ -645,7 +722,7 @@ def _build_human_keypoints_eef_frame_transform_list(
     return transform_list
 
 
-def _build_human_keypoints_bimanual_transform_list(
+def _build_aria_keypoints_bimanual_transform_list(
     *,
     target_world: str = "obs_head_pose",
     target_world_ypr: str = "obs_head_pose_ypr",
@@ -864,7 +941,7 @@ def _build_human_keypoints_bimanual_transform_list(
     return transform_list
 
 
-def _build_human_cartesian_revert_eef_frame_transform_list(
+def _build_aria_cartesian_revert_eef_frame_transform_list(
     *,
     action_key: str = "actions_cartesian",
     obs_key: str = "observations.state.ee_pose",
@@ -878,7 +955,7 @@ def _build_human_cartesian_revert_eef_frame_transform_list(
 ) -> list[Transform]:
     """Revert wrist-frame ARIA cartesian actions back to head (camera) frame.
 
-    Inverse of ``_build_human_cartesian_eef_frame_transform_list`` for viz: the
+    Inverse of ``_build_aria_cartesian_eef_frame_transform_list`` for viz: the
     action chunks live in each side's wrist frame, the proprio ee-poses live in
     headframe (= Aria camera frame). Re-composes ``target_headframe @ chunk_wristframe``
     so action chunks are back in headframe / camera frame.
@@ -923,7 +1000,7 @@ def _build_human_cartesian_revert_eef_frame_transform_list(
     return transform_list
 
 
-def _build_human_cartesian_eef_frame_transform_list(
+def _build_aria_cartesian_eef_frame_transform_list(
     *,
     target_world: str = "obs_head_pose",
     target_world_ypr: str = "obs_head_pose_ypr",
@@ -1041,7 +1118,7 @@ def _build_human_cartesian_eef_frame_transform_list(
     return transform_list
 
 
-def _build_human_cartesian_bimanual_transform_list(
+def _build_aria_cartesian_bimanual_transform_list(
     *,
     target_world: str = "obs_head_pose",
     target_world_ypr: str = "obs_head_pose_ypr",

--- a/egomimic/rldb/embodiment/pushshapes.py
+++ b/egomimic/rldb/embodiment/pushshapes.py
@@ -1,0 +1,315 @@
+"""Keymap helper and validation-time visualization for the pushshapes_sim
+embodiment.
+
+`get_keymap()` is referenced from `egomimic/hydra_configs/data/tsimulation.yaml`
+so it sets the shape of every training batch. `viz_gt_preds()` is referenced
+from `egomimic/hydra_configs/visualization/cartesian.yaml` and is called
+during validation to render the GT/predicted trajectories overlaid on each
+observation image.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cv2
+import numpy as np
+import torch
+
+from egomimic.rldb.embodiment.embodiment import get_embodiment
+from egomimic.utils.viz_utils import draw_dot_on_frame
+
+# ImageNet normalization constants applied by eval_image_augs; we invert them
+# before rendering so the image looks correct in the viz frame.
+_IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+_IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+# PushShapes world is always 512x512 px; observations are rendered at
+# image_size (default 96). We upscale the obs image by UP_SCALE before
+# drawing trajectories so the video is readable.
+_WORLD_SIZE = 512.0
+UP_SCALE = 4
+
+# Trajectory styling. Match the main-branch ``draw_actions`` pattern:
+# render each chunk as palette-graded dots (light→dark = early→late) on a
+# single frame, GT in Greens and pred in Reds.
+_GT_PALETTE = "Greens"
+_PRED_PALETTE = "Reds"
+_DOT_RADIUS = 3
+# Per-chunk we render ONE frame (not T frames repeated). Repeat that frame
+# this many times so each chunk gets ~1 sec of dwell at 30 fps in the mp4.
+_CHUNK_DWELL_FRAMES = 30
+
+
+def _draw_chunk(
+    frame: np.ndarray,
+    actions: np.ndarray,
+    scale: float,
+    palette: str,
+    dot_size: int = _DOT_RADIUS,
+) -> np.ndarray:
+    """Draw an action chunk as palette-graded dots on ``frame``.
+
+    ``actions`` is (N, D) with world xy in the first two coordinates; optional
+    extra coordinates (for example U-socket theta) are ignored by this xy
+    trajectory overlay. ``scale`` maps world→pixel.
+    Uses ``draw_dot_on_frame`` (main-branch pattern) so consecutive dots are
+    colored along a perceptual gradient — viewer can see chunk ordering at a
+    glance. Returns the modified frame (draw_dot_on_frame returns a copy).
+    """
+    arr = np.asarray(actions, dtype=np.float32)
+    if arr.ndim == 1:
+        arr = arr[None, :]
+    if arr.shape[-1] < 2:
+        raise ValueError(f"PushShapes visualization needs xy actions, got {arr.shape}")
+    pix = arr.reshape(-1, arr.shape[-1])[:, :2] * float(scale)
+    return draw_dot_on_frame(
+        frame, pix.tolist(), show=False, palette=palette, dot_size=dot_size
+    )
+
+
+def get_keymap_hpt(action_horizon: int = 32, **kwargs) -> dict:
+    """HPT-specific keymap: SINGLE-FRAME obs + action_horizon-long action chunk.
+
+    HPT's contract is "one current obs -> predict next action_horizon actions".
+    Unlike H-Net (which sees a per-token obs window aligned with actions and
+    is meant to encode trajectories), HPT must condition on the CURRENT obs
+    only. Returning windowed obs would make training trivial (model just reads
+    the future obs out of its context) while inference, which only has the
+    current obs, becomes wildly OOD. Diagnosed 2026-05-19: closed-loop sim
+    rollout was failing despite low training loss because obs windowing
+    let the model cheat at train time.
+
+    Extra kwargs (e.g. ``norm_mode=True`` from trainHydra) are accepted and
+    ignored so norm-stat collection doesn't crash.
+    """
+    return {
+        "front_img_1": {
+            "key_type": "camera_keys",
+            "zarr_key": "observations.images.front_img_1",
+            # no horizon -> single-frame obs (B, C, H, W) per sample
+        },
+        "state_agent_obj": {
+            "key_type": "proprio_keys",
+            "zarr_key": "observations.state",
+            # no horizon -> single-frame (B, D) per sample
+        },
+        "actions": {
+            "key_type": "action_keys",
+            "zarr_key": "actions",
+            "horizon": int(action_horizon),
+        },
+    }
+
+
+def get_keymap(action_horizon: int = 32, **kwargs) -> dict:
+    """Return the key_map for pushshapes_sim ZarrDataset.
+
+    Args:
+        action_horizon: number of future actions returned per sample. Must
+            match the model's ``trunk.action_horizon`` / head ``act_seq``.
+            Wire it from the data config (see
+            ``egomimic/hydra_configs/data/tsimulation.yaml``) so there's one
+            source of truth shared with the model config.
+
+    Extra kwargs (e.g. ``norm_mode=True`` injected by trainHydra) are accepted
+    and ignored so that norm-stat collection doesn't crash by passing
+    sentinel keys through to the inner key_map iteration.
+    """
+    # Per-frame obs (obs_t aligned with action_t): give the obs keys the same
+    # horizon as actions so the dataloader returns (T, ...) windows rather than
+    # a single broadcast frame. CondEncoderModule.encode then skips its
+    # unsqueeze-and-expand branch (kicks in only when x.dim()==2 for state /
+    # ==4 for images), and AdaLN sees a true per-token cond.
+    return {
+        "front_img_1": {
+            "key_type": "camera_keys",
+            "zarr_key": "observations.images.front_img_1",
+            "horizon": int(action_horizon),
+        },
+        "state_agent_obj": {
+            "key_type": "proprio_keys",
+            "zarr_key": "observations.state",
+            "horizon": int(action_horizon),
+        },
+        "actions": {
+            "key_type": "action_keys",
+            "zarr_key": "actions",
+            "horizon": int(action_horizon),
+        },
+    }
+
+
+def get_keymap_with_pusher_cmd(action_horizon: int = 32, **kwargs) -> dict:
+    """Training keymap plus the commanded pusher pose used for SDP tail HOLD.
+
+    ``observations.pusher_cmd_pose`` is identical to ``actions`` in the
+    circle/U-socket collector, including the U-socket theta coordinate. It is
+    kept out of the observation encoders and consumed only by ``SDPHead`` for
+    episode-tail padding, avoiding a coordinate/normalization mismatch with
+    the lagging actual pusher state.
+    """
+    key_map = get_keymap(action_horizon=action_horizon, **kwargs)
+    key_map["pusher_cmd_pose"] = {
+        "key_type": "proprio_keys",
+        "zarr_key": "observations.pusher_cmd_pose",
+        "horizon": int(action_horizon),
+    }
+    return key_map
+
+
+def get_keymap_eval(action_horizon: int = 32, **kwargs) -> dict:
+    """``get_keymap`` plus a ``goal_pose`` passthrough for closed-loop sim eval.
+
+    ``PackedSimEval.batch_to_env_init`` (``egomimic/eval/core/eval_sim.py``)
+    reads ``batch["goal_pose"]`` to set the PushShapes env goal when the rollout
+    inits from a replayed val episode. The training keymap omits it (training
+    never uses the goal). ``goal_pose`` is declared with ``key_type:
+    "goal_keys"``, which is **not** in
+    ``MultiDataset.NORMALIZE_KEY_TYPES = ("proprio_keys", "action_keys")``, so
+    NormStats reads it into the packed batch and passes it straight through —
+    raw, un-normalized — to the evaluator. Same map serves both circle proxies.
+
+    NOTE: this intentionally omits EgoVerse2's extra ``init_action`` passthrough
+    (a raw-actions seed for delta-rollout integration). pact-2's eval stack uses
+    ``init_mode: "replay"`` and never reads ``init_action`` (verified: no
+    reference in ``egomimic/eval`` or ``egomimic/algo``), so adding it would be
+    dead weight. If a delta-rollout path lands later, re-add it then.
+    """
+    km = get_keymap(action_horizon=action_horizon)
+    km["goal_pose"] = {
+        "key_type": "goal_keys",
+        "zarr_key": "goal_pose",
+        "horizon": int(action_horizon),
+    }
+    return km
+
+
+# ---------------------------------------------------------------------- #
+# Validation viz
+# ---------------------------------------------------------------------- #
+
+
+def _as_numpy(arr: Any) -> np.ndarray:
+    """Detach torch → cpu → float32 numpy. Pass-through for ndarrays."""
+    if isinstance(arr, torch.Tensor):
+        return arr.detach().cpu().float().numpy()
+    return np.asarray(arr)
+
+
+def _denormalize_imagenet(images: np.ndarray) -> np.ndarray:
+    """Reverse ImageNet normalisation. Accepts a (B, C, H, W) or
+    (B, T, C, H, W) float batch and returns matching shape with channel
+    last, dtype uint8 ((B, H, W, C) or (B, T, H, W, C))."""
+    mean = _IMAGENET_MEAN.reshape((1,) * (images.ndim - 3) + (3, 1, 1))
+    std = _IMAGENET_STD.reshape((1,) * (images.ndim - 3) + (3, 1, 1))
+    out = images * std + mean
+    out = np.clip(out, 0.0, 1.0)
+    # Move channels last (last axis = C).
+    out = np.moveaxis(out, -3, -1)
+    return (out * 255).astype(np.uint8)
+
+
+def viz_gt_preds(
+    predictions: dict,
+    batch: dict,
+    image_key: str = "front_img_1",
+    action_key: str = "actions",
+    mode: str = "traj",
+    seq_lens: np.ndarray | None = None,
+    **_unused_kwargs: Any,
+) -> np.ndarray:
+    """Render validation frames with GT (green) and predicted (red) trajectories.
+
+    Two input modes:
+      * Single-frame per episode (legacy): ``batch[image_key]`` is
+        ``(B, C, H, W)``. Output ``(B, H', W', 3)`` — one frame per
+        episode with full-episode trajectories overlaid.
+      * Per-frame video (full episode): ``batch[image_key]`` is
+        ``(B, T, C, H, W)``. Output is the concatenated per-episode
+        video ``(sum(T_b), H', W', 3)`` so the saved .mp4 plays each
+        episode in turn. ``seq_lens (B,)`` masks zero-padded tail frames.
+
+    Returns:
+        (N, H', W', 3) uint8 array, ``H'/W' = image_size * UP_SCALE``.
+    """
+    embodiment_name = get_embodiment(int(batch["embodiment"][0].item())).lower()
+
+    images = _denormalize_imagenet(_as_numpy(batch[image_key]))
+    gt_actions = _as_numpy(batch[action_key]) if action_key in batch else None
+    pred_actions_raw = predictions.get(f"{embodiment_name}_{action_key}")
+    pred_actions = _as_numpy(pred_actions_raw) if pred_actions_raw is not None else None
+    if seq_lens is None and "seq_lens" in batch:
+        seq_lens = _as_numpy(batch["seq_lens"])
+
+    # Per-frame mode: images is (B, T, H, W, C). Emit ONE output panel-frame
+    # per REAL timestep so this panel is length-aligned with PCA + boundary
+    # strip panels (both also per-timestep). The composite then has all
+    # panels temporally in sync — no chunk-dwell, no padding-to-black.
+    if images.ndim == 5:
+        B, T_max, h, w, _ = images.shape
+        out_h, out_w = h * UP_SCALE, w * UP_SCALE
+        scale = out_w / _WORLD_SIZE
+        if seq_lens is None:
+            seq_lens = np.full(B, T_max, dtype=np.int64)
+        else:
+            seq_lens = np.asarray(seq_lens).astype(np.int64)
+
+        # Allow callers (e.g. HNetEvalVideo via **_unused_kwargs) to cap
+        # episodes via max_videos; default = no cap. Keeps composite
+        # panels short and aligned with other evals that cap the same way.
+        max_videos = _unused_kwargs.get("max_videos")
+        B_render = min(B, int(max_videos)) if max_videos is not None else B
+        frames: list[np.ndarray] = []
+        for b in range(B_render):
+            T_b = max(1, int(seq_lens[b]))
+            for t in range(T_b):
+                base = cv2.resize(
+                    images[b, t], (out_w, out_h), interpolation=cv2.INTER_LINEAR
+                )
+                # Overlay full GT + pred trajectories on every frame (static
+                # trail; the moving obs background is what differentiates
+                # frames). Palette-graded dots: light=early, dark=late.
+                if gt_actions is not None:
+                    base = _draw_chunk(base, gt_actions[b, :T_b], scale, _GT_PALETTE)
+                if pred_actions is not None:
+                    base = _draw_chunk(
+                        base, pred_actions[b, :T_b], scale, _PRED_PALETTE
+                    )
+                frames.append(base)
+            # 5-frame black separator between episodes — matches PCA +
+            # boundary strip separator behaviour for clean per-episode breaks.
+            if b < B_render - 1:
+                sep = np.zeros((5, out_h, out_w, 3), dtype=np.uint8)
+                frames.extend(list(sep))
+        return np.stack(frames, axis=0)
+
+    # Single-frame legacy path: (B, H, W, C). One image per sample with the
+    # same palette-graded chunk overlay.
+    b_count, h, w, _ = images.shape
+    out_h, out_w = h * UP_SCALE, w * UP_SCALE
+    scale = out_w / _WORLD_SIZE
+
+    frames = []
+    for i in range(b_count):
+        frame = cv2.resize(images[i], (out_w, out_h), interpolation=cv2.INTER_LINEAR)
+        if gt_actions is not None:
+            frame = _draw_chunk(frame, gt_actions[i], scale, _GT_PALETTE)
+        if pred_actions is not None:
+            frame = _draw_chunk(frame, pred_actions[i], scale, _PRED_PALETTE)
+        frames.append(frame)
+    return np.stack(frames, axis=0)
+
+
+def get_rotvec_transform_list():
+    """u_socket theta -> (cos, sin) on actions + commanded pose (load-time,
+    pre-NormStats). Pair with 4-dim action norm stats (ws512_u3rv json) and
+    ``action_dims: {pushshapes_sim_u_socket: 4}``. Rollout eval needs an
+    atan2 decode before env.step -- NOT yet wired (2026-08-01); offline TF
+    training/val only until it is.
+    """
+    from egomimic.rldb.zarr.action_chunk_transforms import ThetaToRotVec
+    return [ThetaToRotVec(keys=["actions",
+                                "pusher_cmd_pose",
+                                "observations.pusher_cmd_pose"],
+                          angle_col=2)]

--- a/egomimic/rldb/embodiment/pushshapes_sim.py
+++ b/egomimic/rldb/embodiment/pushshapes_sim.py
@@ -1,0 +1,73 @@
+"""PushShapes sim-eval glue: env-output <-> canonical zarr-key conversion.
+
+These helpers translate the ``Tsimulation.pushshapes.PushShapesEnv`` native
+obs into the canonical zarr-key dict the dataset emits (so the algo's keymap +
+transforms apply unchanged), and split a flat state vector back into the env's
+``set_state`` args for replay-mode init. They are pushshapes-embodiment-specific
+glue and therefore live with the embodiment, not in the algo-agnostic
+``eval/core/eval_sim.py`` evaluator.
+
+Extracted (byte-identical) from ``egomimic/eval/core/eval_sim.py`` during the
+eval+pl_utils hierarchy pass; ``eval_sim`` now imports ``_env_to_zarr_pushshapes``,
+``_state_to_init`` and ``_ENV_TO_ZARR`` from here. The legacy import paths
+``egomimic.eval.eval_sim._env_to_zarr_pushshapes`` / ``._state_to_init`` and
+``egomimic.eval.core.eval_sim._state_to_init`` keep resolving because those
+names are re-exported back into ``eval_sim``'s namespace.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+
+def _env_to_zarr_pushshapes(obs_env: dict, device: torch.device) -> dict:
+    """PushShapesEnv obs -> canonical zarr-key dict (B=1).
+
+    Keys match pushshapes.get_keymap:
+      state_agent_obj: (1, 5) = concat(pusher_xy, obj_xyangle)
+      front_img_1: (1, 3, H, W) float [0,1]
+    """
+    state_5 = np.concatenate(
+        [obs_env["agent_pos"], obs_env["object_pose"]], axis=0
+    ).astype(np.float32)
+    image_chw = np.transpose(obs_env["image"], (2, 0, 1)).astype(np.float32) / 255.0
+    return {
+        "state_agent_obj": torch.from_numpy(state_5).unsqueeze(0).to(device),
+        "front_img_1": torch.from_numpy(image_chw).unsqueeze(0).to(device),
+    }
+
+
+def _env_to_zarr_pushshapes_usocket(obs_env: dict, device: torch.device) -> dict:
+    """u_socket variant: state_agent_obj (1, 6) = concat(pusher_xy, pusher_angle,
+    obj_xyangle) -- matches the u_socket training zarr layout, where the emb-19
+    obs spec slices [0:3] = pusher (x, y, theta). The generic 5-dim converter
+    would silently feed (x, y, obj_x) into that slice."""
+    state_6 = np.concatenate(
+        [obs_env["agent_pos"], obs_env["agent_angle"], obs_env["object_pose"]],
+        axis=0,
+    ).astype(np.float32)
+    image_chw = np.transpose(obs_env["image"], (2, 0, 1)).astype(np.float32) / 255.0
+    return {
+        "state_agent_obj": torch.from_numpy(state_6).unsqueeze(0).to(device),
+        "front_img_1": torch.from_numpy(image_chw).unsqueeze(0).to(device),
+    }
+
+
+_ENV_TO_ZARR = {
+    "pushshapes_sim": _env_to_zarr_pushshapes,
+    "pushshapes_sim:u_socket": _env_to_zarr_pushshapes_usocket,
+}
+
+
+def _state_to_init(state: np.ndarray) -> tuple:
+    """Split (5,) state vector into PushShapesEnv set_state args.
+    state = concat(pusher_xy, object_xyangle).
+    """
+    state = np.asarray(state, dtype=np.float32).reshape(-1)
+    if state.shape[0] < 5:
+        raise ValueError(f"expected state of len >= 5, got {state.shape}")
+    return (
+        (float(state[0]), float(state[1])),
+        (float(state[2]), float(state[3]), float(state[4])),
+    )

--- a/egomimic/rldb/zarr/_common.py
+++ b/egomimic/rldb/zarr/_common.py
@@ -1,0 +1,181 @@
+"""Shared read/decode helpers for the zarr loader paths.
+
+Both zarr loader paths — the padded/windowed reader
+(``ZarrDataset.__getitem__``) and the packed/span reader
+(``ZarrDataset._read_span``, consumed by ``ZarrEpisodePackedDataset``) — used
+to inline byte-for-byte copies of the same JPEG/JSON decode, float32
+tensorization, and embodiment-tagging logic. Collapse 3 factors that shared
+logic here so there is ONE source of truth; each loader keeps only its genuine
+differences (windowing+padding+resample loop vs. exact-span read + ``seq_len``
+metadata).
+
+Every function here is a pure transformation extracted verbatim from the
+pre-collapse loader bodies — see ``tests/test_loader_equality.py`` for the
+behavioral-equality proof (frozen reference hashes + cross-loader
+``torch.equal``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import simplejpeg
+import torch
+
+from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+
+__all__ = [
+    "decode_jpeg_single",
+    "decode_jpeg_window",
+    "decode_jpeg_window_strided",
+    "decode_video_span",
+    "decode_json_array",
+    "tensorize_float32",
+    "tag_embodiment",
+]
+
+
+def decode_jpeg_single(buf) -> np.ndarray:
+    """Decode one JPEG buffer to a CHW float image in ``[0, 1]``.
+
+    Verbatim extraction of the single-frame decode shared by
+    ``ZarrDataset.__getitem__`` (no-horizon image read) and
+    ``ZarrActionExpertDataset._load_obs_at``.
+    """
+    decoded = simplejpeg.decode_jpeg(buf, colorspace="RGB")
+    return np.transpose(decoded, (2, 0, 1)) / 255.0
+
+
+def decode_jpeg_window(buffers) -> np.ndarray:
+    """Decode an array of per-frame JPEG buffers to a stacked ``(T, C, H, W)``.
+
+    simplejpeg can't vectorize across the buffer-array dtype, so each frame is
+    decoded individually then stacked. Verbatim extraction of the windowed
+    image decode shared by ``ZarrDataset.__getitem__`` (horizon > 1) and
+    ``ZarrDataset._read_span``.
+    """
+    frames = []
+    for buf in buffers:
+        decoded = simplejpeg.decode_jpeg(buf, colorspace="RGB")
+        frames.append(np.transpose(decoded, (2, 0, 1)) / 255.0)
+    return np.stack(frames, axis=0)
+
+
+def decode_jpeg_window_strided(buffers, stride: int) -> np.ndarray:
+    """Decode ONLY every ``stride``-th frame of a JPEG-buffer array.
+
+    FREE decode-waste elimination for STRIDED packed training: the model only
+    consumes every ``stride``-th frame per span (``TargetBuilder`` keeps
+    ``kept = arange(0, seq_len, stride)`` per episode via ``strided_view`` and
+    decimates every ``obs/*`` key with ``v[kept]``). The other frames are
+    decoded and then thrown away. This decodes exactly the kept frames and
+    leaves the discarded positions as cheap zero placeholders, so:
+
+      * the returned tensor keeps the SAME ``(T, C, H, W)`` full-rate shape and
+        dtype as :func:`decode_jpeg_window` (so ``pack_collate`` /
+        ``TargetBuilder`` need no change and per-frame alignment is untouched),
+      * the KEPT frames are byte-identical to :func:`decode_jpeg_window`
+        (same simplejpeg decode + transpose + ``/255``), and
+      * decode cost drops ~``stride``x.
+
+    ``stride <= 1`` routes to :func:`decode_jpeg_window` verbatim (OFF = no-op).
+
+    NOTE: ``stride`` MUST equal the pipeline ``TargetBuilder.stride`` — the
+    kept-frame set here (``range(0, T, stride)`` per span) is exactly what
+    ``strided_view`` selects at each ``cu_seqlens`` boundary. The equivalence
+    gate (tests/scratch) proves this for the fold ``stride=4`` configs.
+    """
+    if int(stride) <= 1:
+        return decode_jpeg_window(buffers)
+    stride = int(stride)
+    T = len(buffers)
+    out = None
+    for i in range(0, T, stride):
+        decoded = simplejpeg.decode_jpeg(buffers[i], colorspace="RGB")
+        frame = np.transpose(decoded, (2, 0, 1)) / 255.0
+        if out is None:
+            out = np.zeros((T,) + frame.shape, dtype=frame.dtype)
+        out[i] = frame
+    return out
+
+
+def decode_json_array(arr, decode_entry) -> list:
+    """Decode an array of JSON-encoded entries via ``decode_entry``.
+
+    ``decode_entry`` is ``ZarrDataset._decode_json_entry`` (a staticmethod);
+    passed in to avoid a circular import. Verbatim extraction of the
+    list-comprehension shared by both loader paths.
+    """
+    return [decode_entry(v) for v in arr]
+
+
+def tensorize_float32(data: dict, *, skip_object_dtype: bool) -> dict:
+    """In-place convert every ndarray value in ``data`` to a float32 tensor.
+
+    The two loaders differ by exactly one predicate:
+      - ``_read_span`` skips object-dtype arrays (``skip_object_dtype=True``)
+        because annotation lists can leave object arrays in the dict.
+      - ``__getitem__`` converts every ndarray (``skip_object_dtype=False``).
+
+    Both originals iterated and replaced in place; this preserves that.
+    """
+    if skip_object_dtype:
+        for k, v in list(data.items()):
+            if isinstance(v, np.ndarray) and v.dtype != object:
+                data[k] = torch.from_numpy(v).to(torch.float32)
+    else:
+        for k, v in data.items():
+            if isinstance(v, np.ndarray):
+                data[k] = torch.from_numpy(v).to(torch.float32)
+    return data
+
+
+def tag_embodiment(data: dict, embodiment) -> dict:
+    """Stamp ``embodiment`` + ``metadata.robot_name`` with the embodiment id.
+
+    Verbatim extraction of the two-line tag both loaders append at the end.
+    """
+    emb_id = get_embodiment_id(embodiment)
+    data["embodiment"] = emb_id
+    data["metadata.robot_name"] = emb_id
+    return data
+
+
+def decode_video_span(store_array, video_meta: dict, start: int, end: int,
+                      stride: int = 1):
+    """Decode frames ``[start, end)`` from a CHUNKED h264 image array.
+
+    The array holds one mp4 per ``frames_per_chunk`` frames, so frame f lives in
+    chunk ``f // fpc`` at offset ``f % fpc``. Decode only the covering chunks,
+    concatenate, then slice -- reading the whole episode per span would pull
+    ~10x more than needed.
+
+    Returns ``(end-start, 3, H, W)`` float in [0,1] -- byte-compatible with
+    :func:`decode_jpeg_window`, so pack_collate / TargetBuilder need no change.
+
+    ``stride>1`` mirrors decode_jpeg_window_strided: full-rate shape, with the
+    discarded positions left as zeros.
+    """
+    import numpy as np
+    from egomimic.rldb.zarr.video_codec import decode_chunk
+
+    fpc = int(video_meta.get("frames_per_chunk") or 0)
+    if fpc <= 0:
+        raise ValueError(f"video_meta missing frames_per_chunk: {video_meta!r}")
+    c0, c1 = start // fpc, (end - 1) // fpc + 1
+    frames = []
+    for ci in range(c0, c1):
+        frames.append(decode_chunk(store_array[ci]))
+    block = np.concatenate(frames, axis=0) if frames else np.zeros((0, 1, 1, 3), np.uint8)
+    lo = start - c0 * fpc
+    win = block[lo : lo + (end - start)]
+    if len(win) != end - start:
+        raise ValueError(
+            f"video span [{start},{end}) resolved {len(win)} frames from chunks "
+            f"[{c0},{c1}) (fpc={fpc}) -- chunk/frame arithmetic mismatch"
+        )
+    out = np.transpose(win, (0, 3, 1, 2)).astype(np.float64) / 255.0
+    if stride and stride > 1:
+        keep = np.zeros(len(out), dtype=bool)
+        keep[::stride] = True
+        out[~keep] = 0.0
+    return out

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -366,6 +366,30 @@ class DeleteKeys(Transform):
         return batch
 
 
+class DeltaAction(Transform):
+    """Per-step delta: ``out[t] = arr[t] - arr[t-1]``, with ``out[0] = 0``.
+
+    Operates on any tensor-like ``(T, ...)`` value where time is the leading
+    dim. Used to convert absolute action targets into velocity-style targets
+    so the model learns small smooth quantities. To recover absolute actions
+    at inference, integrate (cumulative sum) the predicted deltas and add the
+    initial state.
+    """
+
+    def __init__(self, input_key: str, output_key: str | None = None):
+        self.input_key = input_key
+        self.output_key = output_key or input_key
+
+    def transform(self, batch: dict) -> dict:
+        arr = np.asarray(batch[self.input_key])
+        delta = np.empty_like(arr)
+        delta[0] = 0
+        if arr.shape[0] > 1:
+            delta[1:] = arr[1:] - arr[:-1]
+        batch[self.output_key] = delta
+        return batch
+
+
 class XYZWXYZ_to_XYZYPR(Transform):
     """Convert listed keys from xyz+quat(wxyz) to xyz+ypr in-place."""
 
@@ -512,38 +536,6 @@ class ConcatKeys(Transform):
         return batch
 
 
-class PadGripperZeros(Transform):
-    """Pad a 12D bimanual cartesian action chunk to 14D by inserting a zero
-    gripper slot at position 6 (end of left arm) and position 13 (end of right
-    arm), matching the canonical [L xyz ypr g, R xyz ypr g] layout used by Eva.
-
-    Used so aria (which has no gripper signal) can share an FM denoiser head
-    sized for 14D actions without needing in-model padding branches.
-    """
-
-    def __init__(self, action_key: str = "actions_cartesian"):
-        self.action_key = action_key
-
-    def transform(self, batch: dict) -> dict:
-        actions = batch[self.action_key]
-        is_tensor = isinstance(actions, torch.Tensor)
-        arr = actions.cpu().numpy() if is_tensor else np.asarray(actions)
-        if arr.shape[-1] != 12:
-            raise ValueError(
-                f"PadGripperZeros expects last-dim 12, got {arr.shape} for "
-                f"'{self.action_key}'"
-            )
-        pad_shape = (*arr.shape[:-1], 1)
-        pad = np.zeros(pad_shape, dtype=arr.dtype)
-        padded = np.concatenate(
-            (arr[..., :6], pad, arr[..., 6:], pad), axis=-1
-        )
-        batch[self.action_key] = (
-            torch.from_numpy(padded) if is_tensor else padded
-        )
-        return batch
-
-
 class Reshape(Transform):
     def __init__(self, input_key: str, output_key: str, shape: tuple):
         self.input_key = input_key
@@ -574,4 +566,38 @@ class NumpyToTensor(Transform):
                 raise ValueError(
                     f"NumpyToTensor expects key '{key}' to be a numpy array or torch tensor, got {type(batch[key])}"
                 )
+        return batch
+
+
+
+class ThetaToRotVec(Transform):
+    """Replace a trailing angle column with its (cos, sin) rotation vector.
+
+    ``(T, D)`` with the angle at ``angle_col`` -> ``(T, D+1)`` where the angle
+    column is replaced by ``cos(theta), sin(theta)``. Removes the 2*pi wrap
+    discontinuity from regression/diffusion targets (u_socket theta actions).
+    Applied at load time, BEFORE NormStats -- provide (D+1)-dim stats.
+
+    ``keys`` lists every batch key to convert; keys absent from an episode are
+    skipped (leaf key naming differs between keymap name and zarr path, so
+    list both spellings where unsure).
+    """
+
+    def __init__(self, keys, angle_col: int = 2):
+        self.keys = list(keys)
+        self.angle_col = int(angle_col)
+
+    def transform(self, batch: dict) -> dict:
+        for k in self.keys:
+            if k not in batch:
+                continue
+            a = np.asarray(batch[k])
+            if a.ndim != 2 or a.shape[1] <= self.angle_col:
+                continue
+            th = a[:, self.angle_col]
+            batch[k] = np.concatenate(
+                [a[:, : self.angle_col],
+                 np.cos(th)[:, None].astype(a.dtype),
+                 np.sin(th)[:, None].astype(a.dtype),
+                 a[:, self.angle_col + 1:]], axis=1)
         return batch

--- a/egomimic/rldb/zarr/video_codec.py
+++ b/egomimic/rldb/zarr/video_codec.py
@@ -1,0 +1,146 @@
+"""H.264 image storage for EgoVerse zarr episodes.
+
+WHY: per-frame JPEG codes every frame independently, so it cannot exploit the
+temporal redundancy of 30fps video. Measured on real fold episodes:
+
+    JPEG (q75, as shipped)   44.8 KB/frame   8.33 ms/frame decode
+    h264 crf15               20.2 KB/frame   1.68 ms/frame decode
+                             2.2x smaller    5.0x faster
+
+At EQUAL bytes h264 also beats JPEG on PSNR (+2.4 to +2.9 dB in the 4-8 KB
+range), so this is not a quality-for-size trade -- it is strictly better coding.
+
+LAYOUT: one mp4 per GROUP of ``frames_per_chunk`` frames, stored as the elements
+of a VariableLengthBytes array. NOT one blob per episode: a span read would then
+have to pull the whole episode (~68 MB) to decode any window, and we read ~13
+spans per episode. Frame f lives in chunk ``f // frames_per_chunk`` at offset
+``f % frames_per_chunk``.
+
+The reader learns everything it needs from ``_features[key]``::
+
+    {"dtype": "h264", "shape": [H, W, 3], "video": {
+        "codec", "crf", "gop", "pix_fmt", "fps", "frames_per_chunk",
+        "total_frames", "n_chunks"}}
+
+``dtype`` stays "jpeg" for JPEG episodes, so existing data and readers are
+untouched -- dispatch on it.
+"""
+from __future__ import annotations
+
+import io
+import os
+
+import numpy as np
+
+DEFAULT_CODEC = "h264"
+DEFAULT_CRF = 15          # decode speed is flat across CRF, so don't over-compress
+DEFAULT_GOP = 30          # 1 s at 30 fps; bounds worst-case seek within a chunk
+DEFAULT_PIX_FMT = "yuv420p"
+DEFAULT_FRAMES_PER_CHUNK = 300   # 10 s; a multiple of GOP so chunks start on a keyframe
+
+
+def codec_settings_from_env() -> dict:
+    """Read encode settings from env so a run is reproducible from its launch.
+
+    These names are forwarded to Ray workers by run_conversion.py; without that
+    forwarding a worker silently falls back to these defaults.
+    """
+    fpc = int(os.environ.get("EGOVERSE_VIDEO_FRAMES_PER_CHUNK", DEFAULT_FRAMES_PER_CHUNK))
+    gop = int(os.environ.get("EGOVERSE_VIDEO_GOP", DEFAULT_GOP))
+    if fpc % gop:
+        raise ValueError(
+            f"frames_per_chunk ({fpc}) must be a multiple of gop ({gop}) so every "
+            f"chunk starts on a keyframe -- otherwise decoding a chunk requires "
+            f"the previous one."
+        )
+    return {
+        "codec": os.environ.get("EGOVERSE_IMAGE_CODEC", DEFAULT_CODEC),
+        "crf": int(os.environ.get("EGOVERSE_VIDEO_CRF", DEFAULT_CRF)),
+        "gop": gop,
+        "pix_fmt": os.environ.get("EGOVERSE_VIDEO_PIXFMT", DEFAULT_PIX_FMT),
+        "frames_per_chunk": fpc,
+    }
+
+
+def image_codec_enabled() -> bool:
+    """True when episodes should be written as video instead of per-frame JPEG."""
+    return os.environ.get("EGOVERSE_IMAGE_CODEC", "jpeg").lower() in ("h264", "avc", "video")
+
+
+def encode_chunk(frames_hwc_rgb: np.ndarray, settings: dict, fps: int = 30) -> bytes:
+    """Encode a (T, H, W, 3) uint8 RGB block to a self-contained mp4.
+
+    Self-contained matters: the first frame of every chunk must be a keyframe so
+    a reader can decode the chunk without touching its neighbours.
+    """
+    import av
+
+    if frames_hwc_rgb.dtype != np.uint8:
+        raise ValueError(f"expected uint8 frames, got {frames_hwc_rgb.dtype}")
+    if frames_hwc_rgb.ndim != 4 or frames_hwc_rgb.shape[-1] != 3:
+        raise ValueError(f"expected (T,H,W,3), got {frames_hwc_rgb.shape}")
+
+    T, H, W, _ = frames_hwc_rgb.shape
+    buf = io.BytesIO()
+    enc = "libx264rgb" if settings["pix_fmt"] == "rgb24" else "libx264"
+    with av.open(buf, mode="w", format="mp4") as container:
+        stream = container.add_stream(enc, rate=fps)
+        stream.width, stream.height = W, H
+        stream.pix_fmt = settings["pix_fmt"]
+        stream.options = {
+            "crf": str(settings["crf"]),
+            "g": str(settings["gop"]),
+            # keyint_min=g stops x264 inserting EXTRA keyframes on scene cuts,
+            # which would desync the frame->chunk arithmetic the reader relies on.
+            "keyint_min": str(settings["gop"]),
+            "sc_threshold": "0",
+        }
+        for i in range(T):
+            container.mux(stream.encode(
+                av.VideoFrame.from_ndarray(np.ascontiguousarray(frames_hwc_rgb[i]),
+                                           format="rgb24")))
+        container.mux(stream.encode())
+    return buf.getvalue()
+
+
+def decode_chunk(blob: bytes, n_expected: int | None = None) -> np.ndarray:
+    """Decode an mp4 chunk back to (T, H, W, 3) uint8 RGB. Reader-side helper.
+
+    Kept here so writer and reader share one definition of the container format.
+    """
+    import av
+
+    # zarr hands back VLenBytes elements wrapped in (possibly nested) 0-d
+    # object arrays; bytes() on those yields garbage, not the payload.
+    while isinstance(blob, np.ndarray):
+        blob = blob.item() if blob.shape == () else blob[0]
+    if isinstance(blob, memoryview):
+        blob = blob.tobytes()
+
+    out = []
+    with av.open(io.BytesIO(bytes(blob))) as container:
+        for frame in container.decode(video=0):
+            out.append(frame.to_ndarray(format="rgb24"))
+    arr = np.stack(out, axis=0) if out else np.zeros((0, 0, 0, 3), np.uint8)
+    if n_expected is not None and len(arr) != n_expected:
+        raise ValueError(f"chunk decoded {len(arr)} frames, expected {n_expected}")
+    return arr
+
+
+def build_feature_entry(img_shape, settings: dict, total_frames: int, fps: int) -> dict:
+    fpc = settings["frames_per_chunk"]
+    return {
+        "dtype": settings["codec"],          # "h264" -- readers dispatch on this
+        "shape": list(img_shape),
+        "names": ["height", "width", "channel"],
+        "video": {
+            "codec": settings["codec"],
+            "crf": settings["crf"],
+            "gop": settings["gop"],
+            "pix_fmt": settings["pix_fmt"],
+            "fps": fps,
+            "frames_per_chunk": fpc,
+            "total_frames": int(total_frames),
+            "n_chunks": int((total_frames + fpc - 1) // fpc),
+        },
+    }

--- a/egomimic/rldb/zarr/zarr_dataset_multi.py
+++ b/egomimic/rldb/zarr/zarr_dataset_multi.py
@@ -34,12 +34,23 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 import numpy as np
 import pandas as pd
-import simplejpeg
 import torch
 import zarr
 from tqdm import tqdm
 
 from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+
+# Shared read/decode helpers used by BOTH loader paths (padded __getitem__ and
+# packed _read_span). See _common.py + tests/test_loader_equality.py.
+from egomimic.rldb.zarr._common import (
+    decode_jpeg_single,
+    decode_jpeg_window,
+    decode_jpeg_window_strided,
+    decode_video_span,
+    decode_json_array,
+    tag_embodiment,
+    tensorize_float32,
+)
 
 # from action_chunk_transforms import Transform
 from egomimic.rldb.filters import DatasetFilter
@@ -117,6 +128,13 @@ def _is_missing_filter_value(value: object) -> bool:
     return isinstance(missing, (bool, np.bool_)) and bool(missing)
 
 
+def _first_present(*values: object) -> object | None:
+    for value in values:
+        if not _is_missing_filter_value(value):
+            return value
+    return None
+
+
 def _normalize_filter_row(
     row: Mapping[str, Any],
     *,
@@ -129,6 +147,14 @@ def _normalize_filter_row(
 
     if _is_missing_filter_value(normalized.get("is_deleted")):
         normalized["is_deleted"] = False
+
+    robot_name = _first_present(
+        normalized.get("robot_name"),
+        normalized.get("robot_type"),
+        normalized.get("embodiment"),
+    )
+    if robot_name is not None:
+        normalized["robot_name"] = robot_name
 
     return normalized
 
@@ -195,11 +221,24 @@ class EpisodeResolver:
         key_map: dict | None = None,
         transform_list: list | None = None,
     ):
-        self.folder_path = Path(folder_path)
+        # folder_path accepts a SINGLE path (legacy, unchanged) or a LIST.
+        # Multi-folder lets a data yaml point at the real, separate source
+        # folders (in-domain + gen) rather than a merged symlink view.
+        if isinstance(folder_path, (list, tuple)) or type(folder_path).__name__ == "ListConfig":
+            self.folder_paths = [Path(p) for p in folder_path]
+        else:
+            self.folder_paths = [Path(folder_path)]
+        if not self.folder_paths:
+            raise ValueError("folder_path resolved to an empty list of folders.")
+        self.multi_folder = len(self.folder_paths) > 1
+        # Legacy attribute (first folder) so existing readers of .folder_path
+        # keep working untouched.
+        self.folder_path = self.folder_paths[0]
         self.key_map = key_map
         self.transform_list = transform_list
 
-    def _load_zarr_datasets(self, search_path: Path, valid_folder_names: set[str]):
+    def _load_zarr_datasets(self, search_path: Path, valid_folder_names: set[str],
+                            key_prefix: str = ""):
         """
         Loads multiple Zarr datasets from the specified folder path, filtering only those whose hashes
         are present in the valid_folder_names set.
@@ -231,7 +270,7 @@ class EpisodeResolver:
                     key_map=self.key_map,
                     transform_list=self.transform_list,
                 )
-                datasets[name] = ds_obj
+                datasets[key_prefix + name] = ds_obj
             except Exception as e:
                 logger.error(f"Failed to load dataset at {p}: {e}")
                 skipped.append(p.name)
@@ -490,123 +529,6 @@ class S3EpisodeResolver(EpisodeResolver):
         return filtered_paths
 
 
-# ---------------------------------------------------------------------------
-# Safer variant: S3EpisodeResolver subclass that filters out unusable episodes
-# (missing required keymap keys, corrupt JPEGs, or — optionally — episodes
-# without a language-annotation field).
-# ---------------------------------------------------------------------------
-def _jpeg_probe_failed(ds_obj: "ZarrDataset") -> tuple[str, str] | None:
-    """Try decoding 5 sampled frames per image key. If every probe fails
-    for a key, return (key, reason); else None."""
-    image_keys = getattr(ds_obj, "_image_keys", None) or set()
-    for img_key in image_keys:
-        try:
-            arr = ds_obj.episode_reader._store[img_key]
-            n = arr.shape[0] if hasattr(arr, "shape") else len(arr)
-            if n == 0:
-                return (img_key, "empty")
-            probe_idx = sorted({0, n // 4, n // 2, 3 * n // 4, n - 1})
-            ok_any = False
-            last_err = ""
-            for i in probe_idx:
-                try:
-                    simplejpeg.decode_jpeg(arr[i : i + 1][0], colorspace="RGB")
-                    ok_any = True
-                    break
-                except Exception as e:
-                    last_err = str(e)
-            if not ok_any:
-                return (img_key, f"all probes failed: {last_err}")
-        except Exception as e:
-            return (img_key, str(e))
-    return None
-
-
-def _has_annotation(ds_obj: "ZarrDataset", annotation_key: str = "annotations") -> bool:
-    try:
-        arr = ds_obj.episode_reader._store[annotation_key]
-    except Exception:
-        return False
-    try:
-        n = arr.shape[0] if hasattr(arr, "shape") else len(arr)
-    except Exception:
-        return False
-    return n > 0
-
-
-class SafeS3EpisodeResolver(S3EpisodeResolver):
-    """Drop-in replacement for `S3EpisodeResolver` that filters unusable
-    episodes after the underlying resolver has discovered them. Skips
-    episodes that:
-      - are missing any keymap-required key,
-      - have unrecoverably-corrupt JPEG image streams (verified by
-        spot-decoding a handful of frames), or
-      - (optionally) lack a non-empty language-annotation field."""
-
-    def __init__(
-        self,
-        *args,
-        require_annotations: bool = False,
-        annotation_key: str = "annotations",
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
-        self.require_annotations = require_annotations
-        self.annotation_key = annotation_key
-
-    def resolve(self, filters=None) -> dict[str, "ZarrDataset"]:
-        datasets = super().resolve(filters=filters)
-        if self.key_map is None:
-            return datasets
-
-        required = {
-            spec["zarr_key"]
-            for spec in self.key_map.values()
-            if isinstance(spec, dict)
-            and spec.get("key_type") != "annotation_keys"
-            and spec.get("zarr_key") is not None
-        }
-
-        kept: dict[str, "ZarrDataset"] = {}
-        for ep_hash, ds_obj in datasets.items():
-            available = set(getattr(ds_obj, "keys_dict", {}))
-            missing = required - available
-            if missing:
-                logger.warning(
-                    "SafeS3EpisodeResolver: skipping %s (missing %s)",
-                    ep_hash,
-                    sorted(missing),
-                )
-                continue
-            bad = _jpeg_probe_failed(ds_obj)
-            if bad is not None:
-                logger.warning(
-                    "SafeS3EpisodeResolver: skipping %s (JPEG probe failed for %s: %s)",
-                    ep_hash,
-                    bad[0],
-                    bad[1],
-                )
-                continue
-            if self.require_annotations and not _has_annotation(
-                ds_obj, self.annotation_key
-            ):
-                logger.warning(
-                    "SafeS3EpisodeResolver: skipping %s (no '%s' field — episode has no language annotation)",
-                    ep_hash,
-                    self.annotation_key,
-                )
-                continue
-            kept[ep_hash] = ds_obj
-
-        if not kept:
-            logger.warning(
-                "SafeS3EpisodeResolver: every episode was filtered out — "
-                "the keymap may demand a key your data does not have, or "
-                "require_annotations=true is too strict."
-            )
-        return kept
-
-
 class LocalEpisodeResolver(EpisodeResolver):
     """
     Resolves episodes from local Zarr stores, filtering via local metadata.
@@ -617,7 +539,8 @@ class LocalEpisodeResolver(EpisodeResolver):
         folder_path: Path,
         key_map: dict | None = None,
         transform_list: list | None = None,
-        debug=False,
+        norm_stats: dict | None = None,
+        debug: int | bool | None = None,
     ):
         super().__init__(folder_path, key_map, transform_list)
         self.debug = debug
@@ -667,7 +590,16 @@ class LocalEpisodeResolver(EpisodeResolver):
                 logger.info("Debug mode: limiting to %d datasets.", k)
             filtered = filtered[:k]
 
-        logger.info("Local filtered paths: %s", filtered)
+        # Log the COUNT, not the list. Dumping every episode path wrote tens of
+        # MB per job start; across ~113k SLURM .out files that reached ~385 GB.
+        # Set EGOMIMIC_LOG_EPISODE_PATHS=1 to restore the full dump for debugging.
+        if os.environ.get("EGOMIMIC_LOG_EPISODE_PATHS"):
+            logger.info("Local filtered paths: %s", filtered)
+        else:
+            logger.info("Local filtered paths: %d episodes (first=%s, last=%s)",
+                        len(filtered),
+                        filtered[0][1] if filtered else "-",
+                        filtered[-1][1] if filtered else "-")
         return filtered
 
     def resolve(
@@ -685,21 +617,43 @@ class LocalEpisodeResolver(EpisodeResolver):
 
         filters = _ensure_dataset_filter(filters)
 
-        filtered_paths = self._get_local_filtered_paths(
-            self.folder_path, filters, debug=self.debug
-        )
-
-        valid_folder_names = {folder_name for _, folder_name in filtered_paths}
-        logger.info(f"Valid folder names: {valid_folder_names}")
-        if not valid_folder_names:
-            raise ValueError(
-                "No valid collection names from local filtering: "
-                "filters matched no episodes in the local directory."
+        datasets: dict = {}
+        per_folder_counts = []
+        for folder in self.folder_paths:
+            filtered_paths = self._get_local_filtered_paths(
+                folder, filters, debug=self.debug
             )
+            valid_folder_names = {folder_name for _, folder_name in filtered_paths}
+            if not valid_folder_names:
+                raise ValueError(
+                    "No valid collection names from local filtering: filters "
+                    f"matched no episodes in {folder}."
+                )
+            # Namespace keys per folder ONLY when merging several folders, so
+            # single-folder runs keep byte-identical bare keys.
+            key_prefix = f"{folder.name}__" if self.multi_folder else ""
+            found = self._load_zarr_datasets(
+                search_path=folder,
+                valid_folder_names=valid_folder_names,
+                key_prefix=key_prefix,
+            )
+            collisions = set(found) & set(datasets)
+            if collisions:
+                raise ValueError(
+                    f"Episode key collision across folders for {folder}: "
+                    f"{sorted(collisions)[:5]} -- namespacing failed."
+                )
+            datasets.update(found)
+            per_folder_counts.append((str(folder), len(found)))
 
-        datasets = self._load_zarr_datasets(
-            search_path=self.folder_path, valid_folder_names=valid_folder_names
-        )
+        if self.multi_folder:
+            logger.info(
+                "Multi-folder resolve: %s -> %d episodes total",
+                ", ".join(f"{p}={n}" for p, n in per_folder_counts),
+                len(datasets),
+            )
+        else:
+            logger.info(f"Valid folder names: {len(datasets)} episodes")
 
         return datasets
 
@@ -755,6 +709,14 @@ class MultiDataset(torch.utils.data.Dataset):
         self.shapes: dict[int, dict[str, tuple]] = {}
         self.norm_stats: dict[int, dict[str, dict[str, np.ndarray]]] = {}
         self._norm_run_metadata: dict[str, float | int | None] | None = None
+
+        # When True, ``__getitem__`` still LOGS bounds violations but does
+        # NOT resample to a fresh index — the slightly-out-of-quantile
+        # sample is returned as-is. Useful when norm stats are reused
+        # across datasets (~1-2% of frames naturally lie outside the
+        # precomputed q1/q99) and the per-sample resample loop dominates
+        # data-loading time.
+        self.skip_bounds_check = bool(kwargs.get("skip_bounds_check", False))
 
         # ---- Dataset graph fields ----
         self.datasets: dict = {}
@@ -926,7 +888,7 @@ class MultiDataset(torch.utils.data.Dataset):
                 return data
 
             violation = self._check_bounds(data, dataset, local_idx, dataset_name)
-            if violation is not None:
+            if violation is not None and not self.skip_bounds_check:
                 next_idx, attempts = self._next_after_failure(
                     idx,
                     dataset_name,
@@ -980,12 +942,27 @@ class MultiDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def _iter_leaves(ds):
-        """Yield non-MultiDataset leaves from possibly nested wrappers."""
+        """Yield non-MultiDataset leaves from possibly nested wrappers.
+
+        Also descends into ``ZarrEpisodePackedDataset``, which owns the same
+        ``dict[str, ZarrDataset]`` shape as ``MultiDataset.datasets``. The
+        leaves carry ``.embodiment`` / ``.key_map`` and that's what
+        ``populate_from_datasets`` probes.
+        """
         if isinstance(ds, MultiDataset):
             for child in ds.datasets.values():
                 yield from MultiDataset._iter_leaves(child)
-        else:
-            yield ds
+            return
+        # Lazy import to avoid cycle.
+        from egomimic.rldb.zarr.zarr_dataset_packed import (
+            ZarrEpisodePackedDataset as _ZEP,
+        )
+
+        if isinstance(ds, _ZEP):
+            for child in ds.datasets.values():
+                yield from MultiDataset._iter_leaves(child)
+            return
+        yield ds
 
     def populate_from_datasets(self, datasets: dict | None = None) -> None:
         """
@@ -994,6 +971,10 @@ class MultiDataset(torch.utils.data.Dataset):
         ``self.datasets`` so the typical call is just ``mds.populate_from_datasets()``.
         """
         graph = datasets if datasets is not None else self.datasets
+        # Leaves under the same wrapper share the same embodiment / key_map,
+        # so probing one is enough — the rest produce identical info and
+        # ``leaf[0]`` is expensive (JPEG decode + horizon-window read).
+        probed_embodiments: set = set()
         for ds in graph.values():
             for leaf in self._iter_leaves(ds):
                 emb = getattr(leaf, "embodiment", None)
@@ -1001,6 +982,9 @@ class MultiDataset(torch.utils.data.Dataset):
                 if emb is None or key_map is None:
                     continue
                 emb_id = emb if isinstance(emb, int) else get_embodiment_id(emb)
+                if emb_id in probed_embodiments:
+                    continue
+                probed_embodiments.add(emb_id)
                 self.embodiments.add(emb_id)
                 self.key_types.setdefault(emb_id, {})
                 self.zarr_keys.setdefault(emb_id, {})
@@ -1118,21 +1102,25 @@ class MultiDataset(torch.utils.data.Dataset):
             if os.path.isfile(precomputed_file):
                 with open(precomputed_file, "r") as f:
                     payload = json.load(f)
-                if str(embodiment) not in payload["stats"]:
-                    raise ValueError(
-                        f"norm_stats file {precomputed_file} has no entry for "
-                        f"embodiment id {embodiment} (available: "
-                        f"{sorted(payload['stats'])}). Stats are keyed by numeric "
-                        "EMBODIMENT id, and ids were renumbered by the human/eva "
-                        "embodiment collapse — recompute norm stats instead of "
-                        "reusing a pre-collapse norm_stats.json."
-                    )
-                self.norm_stats[embodiment] = payload["stats"][str(embodiment)]
+                self.norm_stats[embodiment] = payload["stats"].get(str(embodiment), {})
                 self._norm_run_metadata = payload.get("norm_run_metadata", None)
                 logger.info(
                     f"[MultiDataset] Loaded precomputed stats for embodiment={embodiment}"
                 )
                 return
+
+        # Packed datasets return variable-length per-episode tensors; default
+        # collate would torch.stack them and crash. Use pack_collate when the
+        # dataset is a ``ZarrEpisodePackedDataset``; in that case n_samples is
+        # interpreted as frames (since each packed batch contributes many
+        # frames at once via ``batch[zarr_key].shape[0] == T_total``).
+        from egomimic.rldb.zarr.zarr_dataset_packed import (
+            ZarrEpisodePackedDataset,
+            pack_collate,
+        )
+
+        is_packed = isinstance(dataset, ZarrEpisodePackedDataset)
+        collate_fn = pack_collate if is_packed else None
 
         loader = torch.utils.data.DataLoader(
             dataset,
@@ -1140,18 +1128,28 @@ class MultiDataset(torch.utils.data.Dataset):
             num_workers=num_workers,
             shuffle=True,
             generator=torch.Generator().manual_seed(seed),
+            collate_fn=collate_fn,
         )
         N = len(dataset)
         if N <= 0:
             raise ValueError("Dataset is empty")
-        n_samples = int(math.ceil(sample_frac * N))
-        n_samples = max(1, min(n_samples, N))
+        if is_packed:
+            # Frames, not episodes — sample_frac applies to the full frame budget.
+            total_frames = sum(end - start for _key, start, end in dataset.index)
+            n_samples = int(math.ceil(sample_frac * total_frames))
+            n_samples = max(1, min(n_samples, total_frames))
+        else:
+            n_samples = int(math.ceil(sample_frac * N))
+            n_samples = max(1, min(n_samples, N))
         if max_samples is not None:
             n_samples = min(n_samples, max_samples)
 
         logger.info(f"[MultiDataset] embodiment={embodiment} norm_keys={norm_keys}")
+        unit = "frames" if is_packed else "samples"
+        denom = total_frames if is_packed else N
         logger.info(
-            f"[MultiDataset] sampling {n_samples}/{N} (~{100 * sample_frac:.1f}%)"
+            f"[MultiDataset] sampling {n_samples}/{denom} {unit} "
+            f"(~{100 * sample_frac:.1f}%)"
         )
 
         loading_start = time.time()
@@ -1430,95 +1428,6 @@ class MultiDataset(torch.utils.data.Dataset):
             self.norm_stats.setdefault(emb, {})
 
 
-# ---------------------------------------------------------------------------
-# Per-episode subsampling wrapper around MultiDataset (K evenly-spaced
-# frames OR every Sth frame within each episode).
-# ---------------------------------------------------------------------------
-def _evenly_spaced_indices(n: int, k: int) -> list[int]:
-    if n <= 0:
-        return []
-    if k >= n:
-        return list(range(n))
-    if k == 1:
-        return [n // 2]
-    return [int(round(i * (n - 1) / (k - 1))) for i in range(k)]
-
-
-def _strided_indices(n: int, stride: int) -> list[int]:
-    if n <= 0 or stride <= 0:
-        return []
-    return list(range(0, n, stride))
-
-
-class EvenStrideDataset(MultiDataset):
-    """Wraps a `MultiDataset` to subsample frames per underlying episode.
-    Pass exactly one of `frames_per_episode` (K evenly-spaced) or
-    `stride` (every Sth frame). Subclasses `MultiDataset` so trainHydra's
-    isinstance check passes; we skip the parent `__init__` and adopt its
-    class identity only, delegating to `self.base`."""
-
-    def __init__(
-        self, base, frames_per_episode: int | None = None, stride: int | None = None
-    ):
-        if (frames_per_episode is None) == (stride is None):
-            raise ValueError(
-                "EvenStrideDataset requires exactly ONE of "
-                "`frames_per_episode` or `stride` to be set "
-                f"(got frames_per_episode={frames_per_episode}, stride={stride})."
-            )
-        gibd = getattr(base, "_global_indices_by_dataset", None)
-        if gibd is None:
-            raise ValueError(
-                f"EvenStrideDataset requires a MultiDataset exposing "
-                f"_global_indices_by_dataset, got {type(base).__name__}"
-            )
-        torch.utils.data.Dataset.__init__(self)
-        self.base = base
-        self.frames_per_episode = frames_per_episode
-        self.stride = stride
-        self.datasets = base.datasets
-
-        keep: list[int] = []
-        for ep_name, idxs in gibd.items():
-            n = len(idxs)
-            if stride is not None:
-                picks = _strided_indices(n, stride)
-                rule = f"stride={stride}"
-            else:
-                picks = _evenly_spaced_indices(n, frames_per_episode)
-                rule = f"k={frames_per_episode}"
-            chosen = [idxs[i] for i in picks]
-            actual_stride = n / max(1, len(chosen))
-            logger.info(
-                "EvenStrideDataset: %s -> %d / %d frames (%s, actual stride ~%.1f)",
-                ep_name,
-                len(chosen),
-                n,
-                rule,
-                actual_stride,
-            )
-            keep.extend(chosen)
-        self.indices = sorted(keep)
-
-    def __len__(self):
-        return len(self.indices)
-
-    def __getitem__(self, idx):
-        return self.base[self.indices[idx]]
-
-    def set_data_schematic(self, data_schematic) -> None:
-        self.base.set_data_schematic(data_schematic)
-        self.data_schematic = data_schematic
-
-    def __getattr__(self, item):
-        if item == "base":
-            raise AttributeError(item)
-        base = self.__dict__.get("base")
-        if base is None:
-            raise AttributeError(item)
-        return getattr(base, item)
-
-
 class ZarrDataset(torch.utils.data.Dataset):
     """
     Base Zarr Dataset object, Just intializes as pass through to read from zarr episode
@@ -1556,13 +1465,10 @@ class ZarrDataset(torch.utils.data.Dataset):
         self.total_frames = self.metadata["total_frames"]
         self.embodiment = self.metadata["embodiment"]
         self.keys_dict = {k: (0, None) for k in self.episode_reader._collect_keys()}
+
+        # Detect JPEG-encoded image keys from metadata
         self._image_keys = self._detect_image_keys()
         self._json_keys = self._detect_json_keys()
-
-    @property
-    def intrinsics(self) -> np.ndarray | dict[str, np.ndarray] | None:
-        """Pass-through to ZarrEpisode.intrinsics (read from zarr metadata)."""
-        return self.episode_reader.intrinsics
 
     def _detect_image_keys(self) -> set[str]:
         """
@@ -1573,6 +1479,21 @@ class ZarrDataset(torch.utils.data.Dataset):
         """
         features = self.metadata.get("features", {})
         return {key for key, info in features.items() if info.get("dtype") == "jpeg"}
+
+    @property
+    def _video_keys(self) -> set:
+        """Image keys stored as CHUNKED H264 rather than per-frame JPEG.
+
+        These arrays are indexed by CHUNK, not frame -- a frame-range slice
+        would read the wrong elements entirely, so they need their own path.
+        """
+        features = self.metadata.get("features", {})
+        return {key for key, info in features.items()
+                if info.get("dtype") in ("h264", "avc", "video")}
+
+    def _video_meta(self, zarr_key: str) -> dict:
+        return (self.metadata.get("features", {})
+                .get(zarr_key, {}).get("video", {}) or {})
 
     def _detect_json_keys(self) -> set[str]:
         """
@@ -1598,21 +1519,63 @@ class ZarrDataset(torch.utils.data.Dataset):
             return json.loads(value)
         return value
 
-    def _load_annotations(self) -> list[dict]:
+    def _annotation_zarr_keys(self) -> list[str]:
+        """All LANGUAGE annotation arrays present in this episode.
+
+        The annotation ROLE is encoded in the key NAME (``annotations``,
+        ``annotations_task``, ``annotations_subtask``) — entries are plain
+        ``{"text", "start_idx", "end_idx"}`` spans with no level field.
+
+        Listed from the actual zarr STORE, not the ``features`` attrs: arrays
+        injected post-hoc (``ZarrWriter.append_annotations``) never updated
+        ``features``, so a metadata listing would silently miss them.
+
+        STRUCTURAL span keys that do NOT start with ``annotations`` (e.g.
+        ``fold_segments``) are deliberately EXCLUDED — they define training
+        windows, not language, and must not reach the batch as a text role.
         """
-        Load and cache decoded language annotations.
+        if getattr(self, "_annotation_keys_cache", None) is None:
+            try:
+                names = list(self.episode_reader._store.array_keys())
+            except Exception:
+                names = list(getattr(self, "keys_dict", []) or [])
+            self._annotation_keys_cache = sorted(
+                k for k in names if k.startswith("annotations")
+            )
+        return self._annotation_keys_cache
+
+    def _load_annotations(self, zarr_key: str = "annotations") -> list[dict]:
+        """
+        Load and cache decoded span annotations for ``zarr_key``.
 
         Expected format per entry:
             {"text": str, "start_idx": int, "end_idx": int}
+
+        ``zarr_key`` defaults to ``"annotations"`` so every pre-existing caller
+        is byte-identical. Cache is PER-KEY: the previous single-slot cache
+        would alias, returning the first-loaded key's spans for every other key.
+        An absent array yields ``[]`` rather than raising, so a structural key
+        missing on some episodes degrades to "no spans" instead of a crash.
         """
-        if self._annotations is not None:
+        cache = getattr(self, "_annotations_by_key", None)
+        if cache is None:
+            cache = self._annotations_by_key = {}
+        if zarr_key in cache:
+            return cache[zarr_key]
+        if zarr_key == "annotations" and self._annotations is not None:
+            cache[zarr_key] = self._annotations
             return self._annotations
-
-        raw = self.episode_reader._store["annotations"][:]
-
+        try:
+            raw = self.episode_reader._store[zarr_key][:]
+        except (KeyError, IndexError):
+            cache[zarr_key] = []
+            return cache[zarr_key]
         decoded = [self._decode_json_entry(x) for x in raw]
-        self._annotations = [d for d in decoded if isinstance(d, dict)]
-        return self._annotations
+        out = [d for d in decoded if isinstance(d, dict)]
+        cache[zarr_key] = out
+        if zarr_key == "annotations":
+            self._annotations = out
+        return out
 
     def _annotation_text_for_frame(self, frame_idx: int) -> str:
         """
@@ -1626,6 +1589,21 @@ class ZarrDataset(torch.utils.data.Dataset):
             if start_idx <= frame_idx < end_idx:
                 valid_annotations.append(ann.get("text", ""))
         return valid_annotations
+
+    def _annotations_for_span(self, start: int, end: int) -> list[str]:
+        """Return all annotation texts whose [start_idx, end_idx) overlap [start, end)."""
+        out: list[str] = []
+        for ann in self._load_annotations():
+            a_start = int(ann.get("start_idx", -1))
+            a_end = int(ann.get("end_idx", -1))
+            if a_start < 0 or a_end <= a_start:
+                continue
+            if a_end <= start or a_start >= end:
+                continue
+            text = ann.get("text", "")
+            if text:
+                out.append(text)
+        return out
 
     def __len__(self) -> int:
         return self.total_frames
@@ -1652,6 +1630,93 @@ class ZarrDataset(torch.utils.data.Dataset):
                     padding = np.repeat(last_frame, pad_len, axis=0)
                     data[k] = np.concatenate([data[k], padding], axis=0)
 
+        return data
+
+    def _read_span(
+        self,
+        start: int,
+        end: int,
+        *,
+        episode_idx: int | None = None,
+        img_decode_stride: int = 1,
+    ) -> dict:
+        """Read a variable-length span ``[start, end)`` for every key in ``key_map``.
+
+        Unlike ``__getitem__``, this performs no horizon-based windowing or
+        padding — each per-frame key is read exactly over the span. Designed
+        for packed dataloaders that batch multiple variable-length samples
+        into a single stream.
+
+        Returns a dict containing:
+          - per-frame tensors of shape ``(end - start, ...)`` for camera /
+            proprio / action keys
+          - the configured annotation key (``key_type == "annotation_keys"``)
+            → ``list[str]`` of annotation texts whose spans overlap
+            ``[start, end)``
+          - ``"seq_len"`` (int)
+          - ``"embodiment"`` and ``"metadata.robot_name"`` (int embodiment id)
+          - ``"episode_idx"`` if provided
+
+        Errors (bad JPEG, transform failure) propagate to the caller; the
+        wrapping packed dataset is responsible for resampling.
+        """
+        if end <= start:
+            raise ValueError(
+                f"_read_span requires end > start (got start={start}, end={end})"
+            )
+        if start < 0 or end > self.total_frames:
+            raise ValueError(
+                f"_read_span out of range [0, {self.total_frames}): "
+                f"start={start}, end={end}"
+            )
+
+        seq_len = end - start
+        data: dict = {}
+
+        for k in self.key_map:
+            spec = self.key_map[k]
+            zarr_key = spec["zarr_key"]
+            key_type = spec.get("key_type", None)
+
+            if key_type == "annotation_keys":
+                data[k] = self._annotations_for_span(start, end)
+                continue
+
+            if key_type == "metadata_keys":
+                continue
+
+            if zarr_key in self._video_keys:
+                # Chunk-indexed: resolve frames -> chunks BEFORE any slice.
+                data[k] = decode_video_span(
+                    self.episode_reader._store[zarr_key],
+                    self._video_meta(zarr_key),
+                    start, end, stride=img_decode_stride,
+                )
+                continue
+
+            arr = self.episode_reader.read({zarr_key: (start, end)})[zarr_key]
+
+            if zarr_key in self._image_keys:
+                # img_decode_stride>1: decode only the kept (every-stride-th)
+                # frames the strided model consumes; the rest are zero
+                # placeholders TargetBuilder discards. stride==1 == verbatim
+                # decode_jpeg_window (byte-identical default-OFF behaviour).
+                arr = decode_jpeg_window_strided(arr, img_decode_stride)
+            elif zarr_key in self._json_keys:
+                arr = decode_json_array(arr, self._decode_json_entry)
+
+            data[k] = arr
+
+        if self.transform:
+            for transform in self.transform:
+                data = transform.transform(data)
+
+        tensorize_float32(data, skip_object_dtype=True)
+
+        data["seq_len"] = seq_len
+        tag_embodiment(data, self.embodiment)
+        if episode_idx is not None:
+            data["episode_idx"] = int(episode_idx)
         return data
 
     def __getitem__(
@@ -1711,15 +1776,22 @@ class ZarrDataset(torch.utils.data.Dataset):
                 if zarr_key in self._image_keys:
                     jpeg_bytes = data[k]
                     try:
-                        decoded = simplejpeg.decode_jpeg(jpeg_bytes, colorspace="RGB")
+                        if horizon is not None and horizon > 1:
+                            # Windowed image read: jpeg_bytes is an array of
+                            # per-frame JPEG buffers. decode_jpeg_window decodes
+                            # each frame individually (simplejpeg can't
+                            # vectorize across the buffer-array dtype) and
+                            # stacks — same path _read_span uses.
+                            data[k] = decode_jpeg_window(jpeg_bytes)
+                        else:
+                            data[k] = decode_jpeg_single(jpeg_bytes)
                     except Exception:
                         idx = _next("JPEG decode failed", key=k)
                         retry = True
                         break
-                    data[k] = np.transpose(decoded, (2, 0, 1)) / 255.0
                 elif zarr_key in self._json_keys:
                     if isinstance(data[k], np.ndarray):
-                        data[k] = [self._decode_json_entry(v) for v in data[k]]
+                        data[k] = decode_json_array(data[k], self._decode_json_entry)
                     else:
                         data[k] = self._decode_json_entry(data[k])
             if retry:
@@ -1729,37 +1801,9 @@ class ZarrDataset(torch.utils.data.Dataset):
                 for transform in self.transform or []:
                     data = transform.transform(data)
 
-            for k, v in data.items():
-                if isinstance(v, np.ndarray):
-                    data[k] = torch.from_numpy(v).to(torch.float32)
+            tensorize_float32(data, skip_object_dtype=False)
 
-            data["embodiment"] = get_embodiment_id(self.embodiment)
-            # Per-episode camera intrinsics travel with the batch so a single
-            # data-driven embodiment can project without a hardcoded class const.
-            # Single-camera -> (3,4) K matrix; no/multi-camera -> NaN sentinel,
-            # which _intrinsics_from_batch treats as "fall back to cls.INTRINSICS".
-            K = self.intrinsics
-            if isinstance(K, dict):
-                # Multi-camera rig: project against the front camera (viz/projection
-                # target the front image). Prefer a "front"-keyed entry, else the
-                # first available camera.
-                K = next(
-                    (v for k, v in K.items() if "front" in str(k).lower()),
-                    next(iter(K.values()), None) if K else None,
-                )
-            if K is not None:
-                K = np.asarray(K, dtype=np.float32)
-                if K.shape == (3, 3):
-                    # Normalize a 3x3 K to the canonical 3x4 (zeros last column);
-                    # some contributors store 3x3 (e.g. microagi).
-                    K = np.concatenate([K, np.zeros((3, 1), dtype=np.float32)], axis=1)
-                if K.shape != (3, 4):  # unexpected -> sentinel (viz falls back to const)
-                    K = np.full((3, 4), np.nan, dtype=np.float32)
-            else:
-                K = np.full((3, 4), np.nan, dtype=np.float32)
-            data["intrinsics"] = torch.from_numpy(np.ascontiguousarray(K))
-            ep_name = Path(self.episode_path).name
-            data["episode_hash"] = ep_name[:-5] if ep_name.endswith(".zarr") else ep_name
+            tag_embodiment(data, self.embodiment)
             _ = origin  # preserved for symmetry with prior API
             return data
 
@@ -1827,6 +1871,7 @@ class ZarrEpisode:
     __slots__ = (
         "_path",
         "_store",
+        "_pid",
         "metadata",
         "keys",
     )
@@ -1838,26 +1883,17 @@ class ZarrEpisode:
             path: Path to the .zarr episode directory
         """
         self._path = Path(path)
+        self._pid = os.getpid()
         self._store = zarr.open_group(str(self._path), mode="r")
         self.metadata = dict(self._store.attrs)
         self.keys = self.metadata["features"]
 
-    @property
-    def intrinsics(self) -> np.ndarray | dict[str, np.ndarray] | None:
-        """
-        Camera intrinsics persisted in zarr metadata, deserialized to ndarray(s).
-
-        Returns:
-            - np.ndarray for a single-camera episode,
-            - dict[str, np.ndarray] for multi-camera episodes,
-            - None if no intrinsics were written.
-        """
-        raw = self.metadata.get("intrinsics")
-        if raw is None:
-            return None
-        if isinstance(raw, dict):
-            return {k: np.asarray(v) for k, v in raw.items()}
-        return np.asarray(raw)
+    def _get_store(self):
+        # zarr v3 uses asyncio internally which is not fork-safe; reopen after fork
+        if os.getpid() != self._pid:
+            self._store = zarr.open_group(str(self._path), mode="r")
+            self._pid = os.getpid()
+        return self._store
 
     def read(
         self, keys_with_ranges: dict[str, tuple[int, int | None]]
@@ -1877,9 +1913,10 @@ class ZarrEpisode:
             ...     "rewards": (20, None),     # Read single frame at index 20
             ... })
         """
+        store = self._get_store()
         result = {}
         for key, (start, end) in keys_with_ranges.items():
-            arr = self._store[key]
+            arr = store[key]
             if end is not None:
                 data = arr[start:end]
             else:
@@ -1910,3 +1947,39 @@ class ZarrEpisode:
     def __repr__(self) -> str:
         """String representation of the episode."""
         return f"ZarrEpisode(path={self._path}, frames={len(self)})"
+
+
+class LocalEpisodeResolverWithEmbodimentOverride(LocalEpisodeResolver):
+    """Like LocalEpisodeResolver, but overrides the embodiment string read
+    from zarr metadata with a config-supplied value.
+
+    Cotrain use-case: the same on-disk dataset (e.g. PushShapes-style
+    pushshapes_sim) is split into multiple logical embodiments (circle,
+    stick) that share the metadata tag. The data-config supplies a per-folder
+    embodiment_override so the model dispatch can tell them apart.
+    """
+
+    def __init__(
+        self,
+        folder_path,
+        key_map=None,
+        transform_list=None,
+        norm_stats=None,
+        debug=None,
+        embodiment_override: str | None = None,
+    ):
+        super().__init__(
+            folder_path=folder_path,
+            key_map=key_map,
+            transform_list=transform_list,
+            norm_stats=norm_stats,
+            debug=debug,
+        )
+        self.embodiment_override = embodiment_override
+
+    def resolve(self, *args, **kwargs):
+        datasets = super().resolve(*args, **kwargs)
+        if self.embodiment_override is not None:
+            for ds in datasets.values():
+                ds.embodiment = self.embodiment_override
+        return datasets

--- a/egomimic/rldb/zarr/zarr_dataset_packed.py
+++ b/egomimic/rldb/zarr/zarr_dataset_packed.py
@@ -1,0 +1,470 @@
+"""
+Packed Zarr datasets and a pack_collate for flattened, variable-length sample
+batching.
+
+Each sample is one full episode (or one chunk of a long episode) read at the
+native per-frame resolution by ``ZarrDataset._read_span``. The collator
+concatenates samples along the time axis and emits ``cu_seqlens`` so the
+downstream model can recover per-sample boundaries (FlashAttention-style).
+
+Currently implemented:
+  - ``ZarrEpisodePackedDataset``: one sample per episode (or per chunk of a
+    long episode), intended for verifying full-episode loading paths.
+  - ``pack_collate``: tensor-side concatenation + cu_seqlens emission, plus
+    pass-through of variable-length list-valued keys (e.g. annotations).
+
+The base ``_read_span`` and the collator are deliberately written to be
+reusable by a future annotation-level packed dataset; only the index-building
+logic differs between the two flavours.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset, default_collate
+
+from egomimic.rldb.zarr.zarr_dataset_multi import (
+    EpisodeResolver,
+    LocalEpisodeResolver,
+    ZarrDataset,
+    get_fallback_idx,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+ChunkingMode = Literal["sequential", "none"]
+
+
+class ZarrEpisodePackedDataset(Dataset):
+    """One sample per episode (or per chunk of a long episode).
+
+    Each ``__getitem__`` call returns the dict produced by
+    ``ZarrDataset._read_span``, i.e. variable-length per-frame tensors plus
+    metadata. Samples are intended to flow into :func:`pack_collate`.
+
+    Args:
+        datasets: dict of episode-key -> per-episode ``ZarrDataset``. Same
+            shape returned by ``LocalEpisodeResolver.resolve`` /
+            ``S3EpisodeResolver.resolve``.
+        max_seq_len: hard cap on sample length. With ``chunking="sequential"``
+            an episode longer than this is split into consecutive chunks of
+            length ``max_seq_len`` (last chunk may be shorter). ``None``
+            disables chunking.
+        min_seq_len: drop chunks shorter than this. Useful for the trailing
+            chunk of an episode.
+        chunking: ``"sequential"`` for consecutive non-overlapping chunks,
+            ``"none"`` to emit each episode as a single sample (raises if
+            ``max_seq_len`` is exceeded — caller should pre-filter).
+        max_resample_attempts: per ``__getitem__`` cap on resampling after a
+            read failure (bad JPEG, transform failure, etc.).
+    """
+
+    def __init__(
+        self,
+        datasets: dict[str, ZarrDataset],
+        max_seq_len: int | None = None,
+        min_seq_len: int = 1,
+        chunking: ChunkingMode = "sequential",
+        max_resample_attempts: int | None = None,
+        img_decode_stride: int = 1,
+        annotation_key: str = "annotations",
+        span_indices: list[int] | None = None,
+    ):
+        if not datasets:
+            raise ValueError("ZarrEpisodePackedDataset received an empty datasets dict")
+        if min_seq_len < 1:
+            raise ValueError(f"min_seq_len must be >= 1, got {min_seq_len}")
+        if chunking not in ("sequential", "none"):
+            raise ValueError(f"Unknown chunking mode: {chunking}")
+        if int(img_decode_stride) < 1:
+            raise ValueError(
+                f"img_decode_stride must be >= 1, got {img_decode_stride}")
+
+        self.datasets = datasets
+        self.max_seq_len = max_seq_len
+        self.min_seq_len = min_seq_len
+        self.chunking = chunking
+        self.max_resample_attempts = max_resample_attempts
+        # FREE decode-waste elimination: decode only every `img_decode_stride`-th
+        # frame per span (the frames a stride-`img_decode_stride` TargetBuilder
+        # keeps). 1 == OFF (decode all; byte-identical to the un-strided reader).
+        # MUST equal the pipeline TargetBuilder.stride for the fullep configs.
+        self.img_decode_stride = int(img_decode_stride)
+        # Which zarr array holds the span index. Default "annotations" keeps
+        # every pre-existing config byte-identical. STRUCTURAL segmentations
+        # (fold_segments) live outside the annotations* namespace so they never
+        # reach the batch as a language role -- they only define train windows.
+        self.annotation_key = str(annotation_key)
+        # Keep only these spans (per episode, in span order). None => all.
+        # Lets an overfit target ONE segmented demonstration out of an episode
+        # that holds many, without touching the shared zarr.
+        self.span_indices = (None if span_indices is None
+                             else sorted({int(i) for i in span_indices}))
+
+        # Stable episode-index assignment: sorted by key.
+        self._episode_keys: list[str] = sorted(datasets.keys())
+        self._episode_idx_by_key: dict[str, int] = {
+            key: i for i, key in enumerate(self._episode_keys)
+        }
+
+        self.index: list[tuple[str, int, int]] = self._build_index()
+        if not self.index:
+            raise ValueError(
+                "ZarrEpisodePackedDataset built an empty index — every episode "
+                f"was shorter than min_seq_len={min_seq_len}."
+            )
+
+        super().__init__()
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_index(self) -> list[tuple[str, int, int]]:
+        index: list[tuple[str, int, int]] = []
+        max_len = self.max_seq_len
+        for key in self._episode_keys:
+            ds = self.datasets[key]
+            episode_len = int(ds.total_frames)
+            if episode_len < self.min_seq_len:
+                continue
+
+            if max_len is None or self.chunking == "none":
+                if max_len is not None and episode_len > max_len:
+                    raise ValueError(
+                        f"Episode {key} has {episode_len} frames > max_seq_len="
+                        f"{max_len} but chunking='none'. Either enable "
+                        f"chunking or raise max_seq_len."
+                    )
+                index.append((key, 0, episode_len))
+                continue
+
+            # Sequential chunking.
+            for start in range(0, episode_len, max_len):
+                end = min(start + max_len, episode_len)
+                if end - start < self.min_seq_len:
+                    continue
+                index.append((key, start, end))
+
+        return index
+
+    @classmethod
+    def from_resolver(
+        cls,
+        resolver: EpisodeResolver,
+        *,
+        max_seq_len: int | None = None,
+        min_seq_len: int = 1,
+        chunking: ChunkingMode = "sequential",
+        max_resample_attempts: int | None = None,
+        img_decode_stride: int = 1,
+        annotation_key: str = "annotations",
+        span_indices: list[int] | None = None,
+        **resolve_kwargs,
+    ) -> "ZarrEpisodePackedDataset":
+        """Build from an ``EpisodeResolver`` (mirrors ``MultiDataset._from_resolver``)."""
+        if isinstance(resolver, LocalEpisodeResolver):
+            datasets = resolver.resolve(**resolve_kwargs)
+        else:
+            datasets = resolver.resolve(**resolve_kwargs)
+        return cls(
+            datasets=datasets,
+            max_seq_len=max_seq_len,
+            min_seq_len=min_seq_len,
+            chunking=chunking,
+            max_resample_attempts=max_resample_attempts,
+            img_decode_stride=img_decode_stride,
+            annotation_key=annotation_key,
+            span_indices=span_indices,
+        )
+
+    @classmethod
+    def from_local_folder(
+        cls,
+        folder_path: str | Path,
+        *,
+        key_map: dict,
+        transform_list: list | None = None,
+        debug: int | bool | None = None,
+        max_seq_len: int | None = None,
+        min_seq_len: int = 1,
+        chunking: ChunkingMode = "sequential",
+        max_resample_attempts: int | None = None,
+        img_decode_stride: int = 1,
+        annotation_key: str = "annotations",
+        span_indices: list[int] | None = None,
+        filters=None,
+    ) -> "ZarrEpisodePackedDataset":
+        """Convenience factory that discovers all episodes under a local folder.
+
+        Useful for smoke tests against a known local dataset (e.g. the pushT
+        ``test_demos`` directory) without needing the SQL-backed resolver.
+        """
+        resolver = LocalEpisodeResolver(
+            folder_path=Path(folder_path),
+            key_map=key_map,
+            transform_list=transform_list,
+            debug=debug,
+        )
+        return cls.from_resolver(
+            resolver,
+            max_seq_len=max_seq_len,
+            min_seq_len=min_seq_len,
+            chunking=chunking,
+            max_resample_attempts=max_resample_attempts,
+            img_decode_stride=img_decode_stride,
+            annotation_key=annotation_key,
+            span_indices=span_indices,
+            filters=filters,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Norm-stat plumbing (trainHydra parity with MultiDataset)
+    # ------------------------------------------------------------------ #
+
+    def set_norm_stats_from(self, source) -> None:
+        """No-op compatibility hook.
+
+        ``MultiDataset.set_norm_stats_from`` wires per-key normalization
+        stats into the dataset so that ``__getitem__`` normalizes at read
+        time. The packed dataset deliberately keeps reads raw — normalization
+        for the algo's packed batches happens algo-side in
+        ``HNet.process_batch_for_training`` via ``norm_stats.normalize(...)``.
+
+        Implemented as a no-op so trainHydra's
+        ``for ds in datasets: ds.set_norm_stats_from(norm_stats)`` loop runs
+        uniformly across padded and packed datasets.
+        """
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Dataset protocol
+    # ------------------------------------------------------------------ #
+
+    def __len__(self) -> int:
+        return len(self.index)
+
+    def __getitem__(self, i: int) -> dict:
+        attempts = 0
+        max_attempts = self.max_resample_attempts or len(self.index)
+        idx = i
+        while True:
+            key, start, end = self.index[idx]
+            ds = self.datasets[key]
+            try:
+                data = ds._read_span(
+                    start,
+                    end,
+                    episode_idx=self._episode_idx_by_key[key],
+                    img_decode_stride=self.img_decode_stride,
+                )
+            except Exception as e:
+                attempts += 1
+                if attempts >= max_attempts:
+                    raise RuntimeError(
+                        f"ZarrEpisodePackedDataset exhausted resampling after "
+                        f"{attempts} attempts; last error on episode {key} "
+                        f"[{start}, {end}): {type(e).__name__}: {e}"
+                    ) from e
+                logger.warning(
+                    "Read failed on episode %s [%d, %d) — %s: %s | "
+                    "attempt %d, resampling",
+                    key,
+                    start,
+                    end,
+                    type(e).__name__,
+                    e,
+                    attempts,
+                )
+                # Pick another index uniformly at random.
+                next_idx, _ = get_fallback_idx(
+                    idx=idx,
+                    candidates=range(len(self.index)),
+                    _attempts=attempts,
+                    max_attempts=max_attempts + 1,
+                    exhausted_error=(
+                        "ZarrEpisodePackedDataset cannot find any valid index"
+                    ),
+                )
+                idx = next_idx
+                continue
+
+            data["chunk_offset"] = int(start)
+            return data
+
+
+class ZarrAnnotationSpanPackedDataset(ZarrEpisodePackedDataset):
+    """One packed sample per annotation span ``{text, start_idx, end_idx}``
+    (span-as-episode). Reads the hardcoded ``annotations`` zarr key via each
+    episode dataset's ``_load_annotations`` and packs the [start, end) window at
+    native per-frame resolution. Ported from EgoVerse-gmm-dualstream for the
+    robot-human fold cotrain (paired with fold_span_transforms)."""
+
+    def _build_index(self) -> list[tuple[str, int, int]]:
+        index: list[tuple[str, int, int]] = []
+        seen: set = set()
+        for key in self._episode_keys:
+            ds = self.datasets[key]
+            try:
+                anns = ds._load_annotations(self.annotation_key)
+            except Exception as e:
+                logger.warning(
+                    "episode %s: annotations load failed (%s); skipping", key, e)
+                continue
+            total_frames = int(ds.total_frames)
+            if self.span_indices is not None:
+                anns = [a for i, a in enumerate(anns) if i in set(self.span_indices)]
+            for ann in anns:
+                start = max(int(ann.get("start_idx", -1)), 0)
+                end = min(int(ann.get("end_idx", -1)), total_frames)
+                if end <= start or (key, start, end) in seen:
+                    continue
+                seen.add((key, start, end))
+                if end - start < self.min_seq_len:
+                    continue
+                if self.max_seq_len is not None and end - start > self.max_seq_len:
+                    if self.chunking == "sequential":
+                        for s in range(start, end, self.max_seq_len):
+                            e = min(s + self.max_seq_len, end)
+                            if e - s >= self.min_seq_len:
+                                index.append((key, s, e))
+                        continue
+                    end = start + self.max_seq_len
+                index.append((key, start, end))
+        return index
+
+
+# ---------------------------------------------------------------------- #
+# Pack collator
+# ---------------------------------------------------------------------- #
+
+
+def _is_per_frame_tensor(value, seq_len: int) -> bool:
+    """A tensor is "per-frame" if its first dim equals the sample's seq_len."""
+    if isinstance(value, torch.Tensor):
+        return value.ndim >= 1 and value.shape[0] == seq_len
+    if isinstance(value, np.ndarray):
+        return value.ndim >= 1 and value.shape[0] == seq_len
+    return False
+
+
+PACK_COLLATE_MAX_TOTAL_FRAMES = (
+    int(os.environ.get("PACK_COLLATE_MAX_TOTAL_FRAMES", "0")) or None
+)
+
+
+def pack_collate(batch: list[dict]) -> dict:
+    """Pack variable-length samples into a single flattened batch.
+
+    Concatenates per-frame tensors along the time axis and emits
+    ``cu_seqlens`` (cumulative sequence lengths) so the downstream model can
+    recover per-sample boundaries — same convention as FlashAttention's
+    variable-length API.
+
+    Output keys:
+      - per-frame tensors: shape ``(sum(seq_lens), ...)`` along the
+        concatenated time axis.
+      - ``"seq_lens"``: ``LongTensor`` of length ``B`` with each sample's
+        length.
+      - ``"cu_seqlens"``: ``LongTensor`` of length ``B + 1``, ``cu[0] == 0``
+        and ``cu[i] == sum(seq_lens[:i])``.
+      - ``"max_seq_len"``: int, ``max(seq_lens)``.
+      - ``"batch_size"``: int, number of samples in the pack.
+      - List-valued keys (e.g. annotations) → ``list[list[str]]`` (one entry
+        per sample), preserving the existing ``annotation_collate``
+        contract.
+      - Scalar-per-sample keys (e.g. ``embodiment``, ``episode_idx``,
+        ``chunk_offset``) → ``LongTensor`` of length ``B``.
+
+    ``PACK_COLLATE_MAX_TOTAL_FRAMES`` env var (set in the launcher) caps the
+    combined number of frames across all samples in the pack. When the
+    incoming ``batch`` would exceed it, trailing samples are dropped until
+    ``sum(seq_lens) <= cap``. Always keeps at least one sample so the loader
+    can't produce an empty batch.
+    """
+    if not batch:
+        raise ValueError("pack_collate received an empty batch")
+
+    cap = PACK_COLLATE_MAX_TOTAL_FRAMES
+    if cap is not None:
+        acc = 0
+        keep = 0
+        for s in batch:
+            sl = int(s["seq_len"])
+            if keep > 0 and acc + sl > cap:
+                break
+            acc += sl
+            keep += 1
+        if keep < len(batch):
+            batch = batch[:keep]
+
+    seq_lens = [int(s["seq_len"]) for s in batch]
+    cu_seqlens = [0]
+    acc = 0
+    for sl in seq_lens:
+        acc += sl
+        cu_seqlens.append(acc)
+
+    # Discover per-frame tensor keys vs. list keys vs. scalar keys, using the
+    # first sample as the schema. All samples must share keys.
+    first = batch[0]
+    per_frame_keys: list[str] = []
+    list_keys: list[str] = []
+    scalar_keys: list[str] = []
+
+    for k, v in first.items():
+        if k == "seq_len":
+            continue
+        if isinstance(v, list):
+            list_keys.append(k)
+        elif _is_per_frame_tensor(v, seq_lens[0]):
+            per_frame_keys.append(k)
+        else:
+            scalar_keys.append(k)
+
+    out: dict = {}
+
+    # Per-frame tensors: torch.cat along dim 0.
+    for k in per_frame_keys:
+        parts = []
+        for sample in batch:
+            v = sample[k]
+            if isinstance(v, np.ndarray):
+                v = torch.from_numpy(v)
+            parts.append(v)
+        out[k] = torch.cat(parts, dim=0)
+
+    # List-valued keys: pass through as list-of-lists (matches annotation_collate).
+    for k in list_keys:
+        out[k] = [sample[k] for sample in batch]
+
+    # Scalar-per-sample keys: collate into a 1D tensor where possible.
+    for k in scalar_keys:
+        values = [sample[k] for sample in batch]
+        try:
+            out[k] = default_collate(values)
+        except Exception:
+            out[k] = values
+
+    out["seq_lens"] = torch.as_tensor(seq_lens, dtype=torch.long)
+    out["cu_seqlens"] = torch.as_tensor(cu_seqlens, dtype=torch.long)
+    out["max_seq_len"] = int(max(seq_lens))
+    out["batch_size"] = len(batch)
+    return out
+
+
+__all__ = [
+    "ZarrEpisodePackedDataset",
+    "ZarrAnnotationSpanPackedDataset",
+    "pack_collate",
+]


### PR DESCRIPTION
Video image storage (video_codec.py, _common.decode_video_span, zarr_writer,
zarr_dataset_multi): store frames as one mp4 per group of frames_per_chunk
instead of per-frame JPEG. Measured on real fold episodes: 44.8 -> 20.2 KB/frame
and 8.33 -> 1.68 ms/frame decode, and h264 also beats JPEG at EQUAL bytes
(+2.4..2.9 dB PSNR at 4-8 KB), so it is strictly better coding rather than a
quality-for-size trade. crf15/gop30/yuv420p; decode speed is flat across CRF, so
compressing harder would buy only disk.

Layout: chunk-indexed, NOT one blob per episode -- a span read would otherwise
pull the whole episode (~68 MB) and we read ~13 spans/episode. Frame f lives in
chunk f//fpc at offset f%fpc; chunks start on a keyframe (keyint_min=g,
sc_threshold=0) so each decodes independently. Readers dispatch on
_features[key]["dtype"] ("jpeg" vs "h264"), so existing episodes are untouched
and both formats coexist. decode_video_span returns the same (T,3,H,W) float
array as decode_jpeg_window, so pack_collate/TargetBuilder need no change;
equivalence-gated against the JPEG path on the same episode (38.6-39.1 dB,
including a chunk-boundary span and the partial tail chunk) and stride parity
matches decode_jpeg_window_strided.

annotation_processing.py: port of the role-in-key-name scheme -- role lives in
the zarr key NAME (annotations_task/annotations_subtask), entries are plain
{text,start_idx,end_idx} spans. _load_annotations is now per-key (the previous
single-slot cache aliased across keys) and an absent key degrades to [] rather
than raising.

zarr_dataset_packed: annotation_key + span_indices, so a run can read a
structural segmentation key (fold_segments) and select individual spans. Note
fold_segments deliberately sits OUTSIDE the annotations* glob -- those spans
define training windows, not language, and must not reach the batch as a text
role.

fold_span_transforms: RH_WRIST_MODE=none -> 126-dim keypoints-only (the wrist
pose is redundant with the keypoints). ypr(138)/pos(132) unchanged; default
still pos.