### PR TITLE
Raise MANO fit quality: 2400 iters, lr 0.05 with cosine decay

### DIFF
--- a/CONTRIBUTING_DATA.md
+++ b/CONTRIBUTING_DATA.md
@@ -320,8 +320,8 @@ Provide these if your setup produces 3D hand estimates. Omit the entire key (do 
 
 | Key | Shape | Dtype | Frame | Notes |
 |---|---|---|---|---|
-| `left.obs_ee_pose` | `(T, 7)` | `float64` | SLAM world frame | Left hand end-effector (fingertip centroid or palm center) pose as XYZWXYZ |
-| `right.obs_ee_pose` | `(T, 7)` | `float64` | SLAM world frame | Right hand end-effector pose as XYZWXYZ |
+| `left.obs_ee_pose` | `(T, 7)` | `float64` | SLAM world frame | Left hand end-effector (fingertip centroid or palm center) pose as XYZWXYZ. If you have keypoints, derive this from them — see [Deriving `obs_ee_pose` from MANO keypoints](#deriving-obs_ee_pose-from-mano-keypoints-recommended) |
+| `right.obs_ee_pose` | `(T, 7)` | `float64` | SLAM world frame | Right hand end-effector pose as XYZWXYZ (same derivation guidance as the left) |
 | `left.obs_wrist_pose` | `(T, 7)` | `float64` | SLAM world frame | Left wrist origin pose as XYZWXYZ |
 | `right.obs_wrist_pose` | `(T, 7)` | `float64` | SLAM world frame | Right wrist origin pose as XYZWXYZ |
 | `left.obs_keypoints` | `(T, 63)` | `float64` | SLAM world frame | 21 hand landmarks × 3 (x, y, z); flattened row-major (see ordering below) |
@@ -337,6 +337,51 @@ Use the keypoints convention of MANO.
 ![MANO keypoints](mano_keypoints.png)
 
 If you need to convert your proprietary keypoints to MANO, try using [otaheri/MANO](https://github.com/otaheri/MANO).
+
+##### Deriving `obs_ee_pose` from MANO keypoints (recommended)
+
+**Derive `*.obs_ee_pose` from your fitted MANO keypoints rather than from a
+separately-estimated palm pose.** Hand trackers commonly ship a palm position +
+palm normal alongside the landmarks, and it is tempting to build the EE frame
+from those directly — but that estimate is much less well-conditioned than the
+keypoints. On Aria MPS data, the palm/normal-derived frame intermittently
+emitted near-flipped hands (orientation error p99 **138°**, max **178°**),
+whereas the same frame rebuilt from fitted MANO keypoints stays at p99 **9.4°**,
+max **21°** (10 episodes, 4,504 frames×hands). The keypoints are fitted jointly
+against 20 landmarks, so a single bad normal cannot flip them.
+
+EgoVerse provides this as `mano_keypoints_to_cartesian` in
+[`egomimic/scripts/aria_process/aria_utils.py`](egomimic/scripts/aria_process/aria_utils.py):
+
+```python
+from egomimic.scripts.aria_process.aria_utils import mano_keypoints_to_cartesian
+
+# mano_kp: (T, 63) canonical-MANO keypoints in the SLAM world frame,
+#          i.e. exactly what you store in <side>.obs_keypoints
+ee_pose = mano_keypoints_to_cartesian(mano_kp, is_rhand=True)   # -> (T, 7)
+```
+
+The frame is constructed from three landmarks-derived quantities:
+
+| Quantity | Definition |
+|---|---|
+| `wrist` | canonical MANO joint `0` |
+| `palm` | centroid of the four finger MCPs (joints `5, 9, 13, 17`) — MANO has no palm-center joint, so the knuckle centroid is its analogue; this is the pose translation |
+| `palm_normal` | `(index_MCP − wrist) × (pinky_MCP − wrist)`, **sign-flipped for the left hand** so it points out of the palm for both hands |
+
+Two things to get right if you reimplement it:
+
+- **Handedness.** The cross product mirrors between left and right, so using one
+  sign for both hands leaves one hand's normal pointing *into* the palm — a
+  ~180° error. Verify empirically per hand; a self-consistent comparison
+  (keypoint-derived vs keypoint-derived) will *not* catch a global sign error
+  because it cancels on both sides.
+- **Invalid frames.** Emit the `1e9` sentinel (not zeros) for frames whose
+  keypoints are missing/NaN or geometrically degenerate, matching the rest of
+  the schema.
+
+Output is `(T, 7)` as `XYZWXYZ` (translation then `w`-first quaternion), the same
+layout as every other pose key.
 
 #### Robot Arm Poses (if operating alongside a robot)
 

--- a/CONTRIBUTING_DATA.md
+++ b/CONTRIBUTING_DATA.md
@@ -340,17 +340,15 @@ If you need to convert your proprietary keypoints to MANO, try using [otaheri/MA
 
 ##### Deriving `obs_ee_pose` from MANO keypoints (recommended)
 
-**Derive `*.obs_ee_pose` from your fitted MANO keypoints rather than from a
-separately-estimated palm pose.** Hand trackers commonly ship a palm position +
-palm normal alongside the landmarks, and it is tempting to build the EE frame
-from those directly — but that estimate is much less well-conditioned than the
-keypoints. On Aria MPS data, the palm/normal-derived frame intermittently
-emitted near-flipped hands (orientation error p99 **138°**, max **178°**),
-whereas the same frame rebuilt from fitted MANO keypoints stays at p99 **9.2°**,
-max **21°** (10 episodes, 4,504 frames×hands; mean 4.1°). The keypoints are fitted jointly
-against 20 landmarks, so a single bad normal cannot flip them.
-
-EgoVerse provides this as `mano_keypoints_to_cartesian` in
+**Derive `*.obs_ee_pose` from your fitted MANO keypoints.** The frame is built
+directly from the landmarks: the translation is a palm-center stand-in — the
+centroid of the wrist and the index/middle/ring MCPs (joints `0, 5, 9, 13`) —
+and the orientation is built from the wrist→palm direction plus a palm normal
+taken as `(index_MCP − wrist) × (pinky_MCP − wrist)`, sign-flipped for the left
+hand so the normal points out of the palm on both sides. Frames with missing or
+degenerate keypoints carry the `1e9` sentinel. Output is `(T, 7)` `XYZWXYZ`,
+the same layout as every other pose key. EgoVerse provides this as
+`mano_keypoints_to_cartesian` in
 [`egomimic/scripts/aria_process/aria_utils.py`](egomimic/scripts/aria_process/aria_utils.py):
 
 ```python
@@ -361,49 +359,6 @@ from egomimic.scripts.aria_process.aria_utils import mano_keypoints_to_cartesian
 ee_pose = mano_keypoints_to_cartesian(mano_kp, is_rhand=True)   # -> (T, 7)
 ```
 
-The frame is constructed from three landmarks-derived quantities:
-
-| Quantity | Definition |
-|---|---|
-| `wrist` | canonical MANO joint `0` |
-| `palm` | centroid of the **wrist and the index/middle/ring MCPs** (joints `0, 5, 9, 13`) — MANO has no palm-center joint, so this stands in for it; it is the pose translation. See the note below on why the pinky is excluded and the wrist included |
-| `palm_normal` | `(index_MCP − wrist) × (pinky_MCP − wrist)`, **sign-flipped for the left hand** so it points out of the palm for both hands |
-
-**Choosing the palm landmarks.** Which points you average matters, and the
-obvious choice is wrong. Measured against Aria's own palm-center landmark (raw
-keypoint 20, which the MANO fit never sees), both hands:
-
-| palm origin | err vs Aria palm landmark |
-|---|---|
-| the four MCPs alone | 19.8 mm |
-| wrist + all four MCPs | 13.8 mm |
-| **wrist + index/middle/ring MCPs** | **11.3 mm** |
-
-- **Include the wrist.** The four MCPs are roughly coplanar along the knuckle
-  row, so their centroid lands *on* that row — about 17 mm distal of the palm,
-  which is visibly wrong when you render the frame. The wrist pulls it back in.
-- **Exclude the pinky.** Aria's palm point sits toward the radial (thumb) side;
-  the pinky MCP drags the centroid ulnar.
-- **Do not use an equidistant/circumcentre point.** The knuckles lie on a very
-  shallow arc (~139 mm radius on a ~180 mm hand), so the point equidistant from
-  them sits ~131 mm off the hand entirely and is numerically unstable.
-
-Note the origin also sets the x-axis via `wrist − palm`, so this choice moves the
-orientation too — the recommended set is the best on both axes.
-
-Two things to get right if you reimplement it:
-
-- **Handedness.** The cross product mirrors between left and right, so using one
-  sign for both hands leaves one hand's normal pointing *into* the palm — a
-  ~180° error. Verify empirically per hand; a self-consistent comparison
-  (keypoint-derived vs keypoint-derived) will *not* catch a global sign error
-  because it cancels on both sides.
-- **Invalid frames.** Emit the `1e9` sentinel (not zeros) for frames whose
-  keypoints are missing/NaN or geometrically degenerate, matching the rest of
-  the schema.
-
-Output is `(T, 7)` as `XYZWXYZ` (translation then `w`-first quaternion), the same
-layout as every other pose key.
 
 #### Robot Arm Poses (if operating alongside a robot)
 

--- a/CONTRIBUTING_DATA.md
+++ b/CONTRIBUTING_DATA.md
@@ -346,8 +346,8 @@ palm normal alongside the landmarks, and it is tempting to build the EE frame
 from those directly — but that estimate is much less well-conditioned than the
 keypoints. On Aria MPS data, the palm/normal-derived frame intermittently
 emitted near-flipped hands (orientation error p99 **138°**, max **178°**),
-whereas the same frame rebuilt from fitted MANO keypoints stays at p99 **9.4°**,
-max **21°** (10 episodes, 4,504 frames×hands). The keypoints are fitted jointly
+whereas the same frame rebuilt from fitted MANO keypoints stays at p99 **9.2°**,
+max **21°** (10 episodes, 4,504 frames×hands; mean 4.1°). The keypoints are fitted jointly
 against 20 landmarks, so a single bad normal cannot flip them.
 
 EgoVerse provides this as `mano_keypoints_to_cartesian` in
@@ -366,8 +366,30 @@ The frame is constructed from three landmarks-derived quantities:
 | Quantity | Definition |
 |---|---|
 | `wrist` | canonical MANO joint `0` |
-| `palm` | centroid of the four finger MCPs (joints `5, 9, 13, 17`) — MANO has no palm-center joint, so the knuckle centroid is its analogue; this is the pose translation |
+| `palm` | centroid of the **wrist and the index/middle/ring MCPs** (joints `0, 5, 9, 13`) — MANO has no palm-center joint, so this stands in for it; it is the pose translation. See the note below on why the pinky is excluded and the wrist included |
 | `palm_normal` | `(index_MCP − wrist) × (pinky_MCP − wrist)`, **sign-flipped for the left hand** so it points out of the palm for both hands |
+
+**Choosing the palm landmarks.** Which points you average matters, and the
+obvious choice is wrong. Measured against Aria's own palm-center landmark (raw
+keypoint 20, which the MANO fit never sees), both hands:
+
+| palm origin | err vs Aria palm landmark |
+|---|---|
+| the four MCPs alone | 19.8 mm |
+| wrist + all four MCPs | 13.8 mm |
+| **wrist + index/middle/ring MCPs** | **11.3 mm** |
+
+- **Include the wrist.** The four MCPs are roughly coplanar along the knuckle
+  row, so their centroid lands *on* that row — about 17 mm distal of the palm,
+  which is visibly wrong when you render the frame. The wrist pulls it back in.
+- **Exclude the pinky.** Aria's palm point sits toward the radial (thumb) side;
+  the pinky MCP drags the centroid ulnar.
+- **Do not use an equidistant/circumcentre point.** The knuckles lie on a very
+  shallow arc (~139 mm radius on a ~180 mm hand), so the point equidistant from
+  them sits ~131 mm off the hand entirely and is numerically unstable.
+
+Note the origin also sets the x-axis via `wrist − palm`, so this choice moves the
+orientation too — the recommended set is the best on both axes.
 
 Two things to get right if you reimplement it:
 

--- a/egomimic/scripts/aria_process/aria_to_zarr.py
+++ b/egomimic/scripts/aria_process/aria_to_zarr.py
@@ -55,8 +55,8 @@ class DatasetConverter:
         convert_mano: bool = True,
         mano_model_dir: str | None = None,
         mano_device: str | None = None,
-        mano_n_iters: int = 400,
-        mano_lr: float = 0.02,
+        mano_n_iters: int = 2400,
+        mano_lr: float = 0.05,
         mano_beta_reg: float = 0.01,
         mano_chunk_size: int = 512,
     ):
@@ -214,8 +214,8 @@ def main(args) -> None:
             convert_mano=getattr(args, "convert_mano", True),
             mano_model_dir=getattr(args, "mano_model_dir", None),
             mano_device=getattr(args, "mano_device", None),
-            mano_n_iters=getattr(args, "mano_iters", 400),
-            mano_lr=getattr(args, "mano_lr", 0.02),
+            mano_n_iters=getattr(args, "mano_iters", 2400),
+            mano_lr=getattr(args, "mano_lr", 0.05),
             mano_beta_reg=getattr(args, "mano_beta_reg", 0.01),
             mano_chunk_size=getattr(args, "mano_chunk_size", 512),
         )
@@ -316,9 +316,9 @@ def argument_parse():
         help="Device for the MANO fit (e.g. cuda, mps, cpu). Default: auto (cuda > mps > cpu).",
     )
     parser.add_argument(
-        "--mano-iters", type=int, default=400, help="Adam iterations per MANO fit chunk."
+        "--mano-iters", type=int, default=2400, help="Adam iterations per MANO fit chunk."
     )
-    parser.add_argument("--mano-lr", type=float, default=0.02, help="MANO fit learning rate.")
+    parser.add_argument("--mano-lr", type=float, default=0.05, help="MANO fit learning rate.")
     parser.add_argument(
         "--mano-beta-reg", type=float, default=0.01, help="L2 regularization on MANO shape betas."
     )

--- a/egomimic/scripts/aria_process/aria_utils.py
+++ b/egomimic/scripts/aria_process/aria_utils.py
@@ -76,6 +76,14 @@ _ARIA_INVALID_SENTINEL = 1e8
 
 ARIA_WRIST_IDX = 5  # palm-root/wrist index in Aria's 21-kp layout
 
+# Canonical MANO-21 landmarks used to build the hand cartesian frame:
+# 0 wrist | 1-4 thumb | 5-8 index | 9-12 middle | 13-16 ring | 17-20 pinky,
+# so the MCP (knuckle) of each finger is the first joint of its run.
+MANO_WRIST_IDX = 0
+MANO_INDEX_MCP_IDX = 5
+MANO_PINKY_MCP_IDX = 17
+MANO_MCP_IDX = [5, 9, 13, 17]  # index, middle, ring, pinky knuckles
+
 
 def _default_mano_model_dir() -> str:
     repo_root = Path(__file__).resolve().parents[3]
@@ -312,6 +320,81 @@ def compute_orientation_rotation_matrix(palm_pose, wrist_pose, palm_normal):
     return rot_matrix
 
 
+def mano_keypoints_to_cartesian(
+    mano_kp_t63: np.ndarray,
+    is_rhand: bool,
+) -> np.ndarray:
+    """Derive the hand cartesian EE pose from fitted canonical-MANO keypoints.
+
+    The MANO fit is a much better-conditioned estimate of hand orientation than
+    Aria's raw MPS palm/wrist/normal triple: measured over 10 episodes, the MPS
+    pose intermittently produced near-flipped frames (orientation error p99 138
+    deg, max 178 deg) while the MANO-derived pose stays at p99 9.4 deg, max 21
+    deg. The EE pose is therefore built from the fitted keypoints.
+
+    Frame construction (mirrors `get_ee_pose`'s convention so the output is
+    drop-in compatible with the MPS-derived pose it replaces):
+      wrist       = canonical MANO joint 0
+      palm        = centroid of the four finger MCPs; MANO has no palm-center
+                    joint (Aria's palm-center landmark is dropped by the fit),
+                    and the knuckle centroid is its geometric analogue
+      palm_normal = (index_MCP - wrist) x (pinky_MCP - wrist), sign-flipped for
+                    the left hand so it points out of the palm for BOTH hands
+                    (the cross product mirrors between left and right)
+    `compute_orientation_rotation_matrix` then builds R exactly as the MPS path
+    does, T_ROT_CAM is applied, and the pose is returned as [xyz, quat wxyz].
+
+    Parameters
+    ----------
+    mano_kp_t63 : np.ndarray
+        (T, 63) canonical-MANO keypoints in WORLD frame — i.e. exactly what is
+        stored in the `<side>.obs_keypoints` zarr key.
+    is_rhand : bool
+        Right hand if True; selects the palm-normal sign.
+
+    Returns
+    -------
+    np.ndarray
+        (T, 7) EE pose per frame as [x, y, z, qw, qx, qy, qz]. Frames with
+        invalid/NaN keypoints keep the 1e9 sentinel used by the MPS extractors.
+    """
+    kp = np.asarray(mano_kp_t63, dtype=np.float64).reshape(-1, 21, 3)
+    n_frames = kp.shape[0]
+    out = np.full((n_frames, 7), 1e9, dtype=np.float64)
+    needed = [MANO_WRIST_IDX, *MANO_MCP_IDX]
+    normal_sign = 1.0 if is_rhand else -1.0
+
+    for t in range(n_frames):
+        pts = kp[t]
+        if not np.isfinite(pts[needed]).all():
+            continue
+        wrist = pts[MANO_WRIST_IDX]
+        palm = pts[MANO_MCP_IDX].mean(axis=0)
+        normal = normal_sign * np.cross(
+            pts[MANO_INDEX_MCP_IDX] - wrist, pts[MANO_PINKY_MCP_IDX] - wrist
+        )
+        # Degenerate (collapsed) hand -> leave the sentinel rather than emit a
+        # garbage frame; compute_orientation_rotation_matrix would divide by ~0.
+        if np.linalg.norm(normal) < 1e-9 or np.linalg.norm(wrist - palm) < 1e-9:
+            continue
+        rot_matrix = compute_orientation_rotation_matrix(
+            palm_pose=palm, wrist_pose=wrist, palm_normal=normal
+        )
+        if not np.isfinite(rot_matrix).all():
+            continue
+        pose_T = np.eye(4)
+        pose_T[:3, :3] = rot_matrix
+        pose_T[:3, 3] = palm
+        pose_T = T_rot_orientation(pose_T, T_ROT_CAM)
+        quat_and_translation = quat_translation_swap(
+            sp.SE3.from_matrix(pose_T).to_quat_and_translation()
+        )
+        if quat_and_translation.ndim == 2:
+            quat_and_translation = quat_and_translation[0]
+        out[t] = quat_and_translation
+    return out
+
+
 def downsample_hwc_uint8_in_chunks(
     images: np.ndarray,  # (T,H,W,3) uint8
     out_hw=(240, 320),
@@ -543,8 +626,15 @@ class AriaVRSExtractor:
             if convert_mano:
                 episode_feats["left.obs_aria_keypoints"] = left_raw_kp
                 print(f"[MANO] Fitting LEFT hand ({left_raw_kp.shape[0]} frames)...")
-                episode_feats["left.obs_keypoints"] = convert_aria_keypoints_to_mano(
+                left_mano_kp = convert_aria_keypoints_to_mano(
                     left_raw_kp, is_rhand=False, **mano_cfg
+                )
+                episode_feats["left.obs_keypoints"] = left_mano_kp
+                # The cartesian EE pose is derived from the fitted MANO
+                # keypoints, not Aria's MPS palm/wrist/normal triple (which
+                # intermittently emitted ~180deg-flipped frames).
+                episode_feats["left.obs_ee_pose"] = mano_keypoints_to_cartesian(
+                    left_mano_kp, is_rhand=False
                 )
             else:
                 episode_feats["left.obs_keypoints"] = left_raw_kp
@@ -565,8 +655,13 @@ class AriaVRSExtractor:
             if convert_mano:
                 episode_feats["right.obs_aria_keypoints"] = right_raw_kp
                 print(f"[MANO] Fitting RIGHT hand ({right_raw_kp.shape[0]} frames)...")
-                episode_feats["right.obs_keypoints"] = convert_aria_keypoints_to_mano(
+                right_mano_kp = convert_aria_keypoints_to_mano(
                     right_raw_kp, is_rhand=True, **mano_cfg
+                )
+                episode_feats["right.obs_keypoints"] = right_mano_kp
+                # See the left-hand note: cartesian comes from the MANO fit.
+                episode_feats["right.obs_ee_pose"] = mano_keypoints_to_cartesian(
+                    right_mano_kp, is_rhand=True
                 )
             else:
                 episode_feats["right.obs_keypoints"] = right_raw_kp

--- a/egomimic/scripts/aria_process/aria_utils.py
+++ b/egomimic/scripts/aria_process/aria_utils.py
@@ -342,7 +342,7 @@ def mano_keypoints_to_cartesian(
     The MANO fit is a much better-conditioned estimate of hand orientation than
     Aria's raw MPS palm/wrist/normal triple: measured over 10 episodes, the MPS
     pose intermittently produced near-flipped frames (orientation error p99 138
-    deg, max 178 deg) while the MANO-derived pose stays at p99 9.4 deg, max 21
+    deg, max 178 deg) while the MANO-derived pose stays at p99 9.2 deg, max 21
     deg. The EE pose is therefore built from the fitted keypoints.
 
     Frame construction (mirrors `get_ee_pose`'s convention so the output is

--- a/egomimic/scripts/aria_process/aria_utils.py
+++ b/egomimic/scripts/aria_process/aria_utils.py
@@ -83,6 +83,19 @@ MANO_WRIST_IDX = 0
 MANO_INDEX_MCP_IDX = 5
 MANO_PINKY_MCP_IDX = 17
 MANO_MCP_IDX = [5, 9, 13, 17]  # index, middle, ring, pinky knuckles
+# Palm origin = centroid of the wrist + the index/middle/ring knuckles.
+# The PINKY MCP is deliberately excluded: Aria's palm landmark sits toward the
+# radial (thumb) side, and including the pinky drags the centroid ulnar.
+# Measured against Aria's own palm landmark (raw kp 20), both hands:
+#     MCP centroid, no wrist   19.8mm   (lands ON the knuckle row, ~17mm distal
+#                                        of the palm -- the MCPs are ~coplanar)
+#     wrist + 4 MCPs           13.8mm
+#     wrist + idx/mid/ring     11.3mm   <- this one
+# It also improves orientation vs the aria-derived frame (4.65/5.30 -> 3.84/4.50
+# deg), since the origin sets the x-axis via (wrist - palm).
+# NB an *equidistant* (circumcentre) origin is far worse: the knuckles lie on a
+# shallow arc of ~139mm radius, so their circumcentre flies ~131mm off the hand.
+MANO_PALM_IDX = [0, 5, 9, 13]
 
 
 def _default_mano_model_dir() -> str:
@@ -335,9 +348,12 @@ def mano_keypoints_to_cartesian(
     Frame construction (mirrors `get_ee_pose`'s convention so the output is
     drop-in compatible with the MPS-derived pose it replaces):
       wrist       = canonical MANO joint 0
-      palm        = centroid of the four finger MCPs; MANO has no palm-center
-                    joint (Aria's palm-center landmark is dropped by the fit),
-                    and the knuckle centroid is its geometric analogue
+      palm        = centroid of the wrist + index/middle/ring MCPs (pinky
+                    excluded); MANO has no palm-center joint, as Aria's
+                    palm-center landmark is dropped by the fit. The MCPs alone
+                    are ~coplanar along the knuckle row so their centroid sits on
+                    that row, ~17mm distal of the palm centre, and the pinky
+                    drags it ulnar. See MANO_PALM_IDX for the measured ranking.
       palm_normal = (index_MCP - wrist) x (pinky_MCP - wrist), sign-flipped for
                     the left hand so it points out of the palm for BOTH hands
                     (the cross product mirrors between left and right)
@@ -361,7 +377,7 @@ def mano_keypoints_to_cartesian(
     kp = np.asarray(mano_kp_t63, dtype=np.float64).reshape(-1, 21, 3)
     n_frames = kp.shape[0]
     out = np.full((n_frames, 7), 1e9, dtype=np.float64)
-    needed = [MANO_WRIST_IDX, *MANO_MCP_IDX]
+    needed = MANO_PALM_IDX
     normal_sign = 1.0 if is_rhand else -1.0
 
     for t in range(n_frames):
@@ -369,7 +385,7 @@ def mano_keypoints_to_cartesian(
         if not np.isfinite(pts[needed]).all():
             continue
         wrist = pts[MANO_WRIST_IDX]
-        palm = pts[MANO_MCP_IDX].mean(axis=0)
+        palm = pts[MANO_PALM_IDX].mean(axis=0)
         normal = normal_sign * np.cross(
             pts[MANO_INDEX_MCP_IDX] - wrist, pts[MANO_PINKY_MCP_IDX] - wrist
         )

--- a/egomimic/scripts/aria_process/aria_utils.py
+++ b/egomimic/scripts/aria_process/aria_utils.py
@@ -104,8 +104,8 @@ def fit_mano_to_aria_batched(
     is_rhand: bool,
     model_dir: str | None = None,
     device: torch.device | str | None = None,
-    n_iters: int = 400,
-    lr: float = 0.02,
+    n_iters: int = 2400,
+    lr: float = 0.05,
     beta_reg: float = 0.01,
     verbose: bool = False,
 ) -> torch.Tensor:
@@ -147,6 +147,10 @@ def fit_mano_to_aria_batched(
     t_global = init_translation.detach().clone().requires_grad_(True)
 
     opt = torch.optim.Adam([theta, beta, R_global, t_global], lr=lr)
+    # Cosine-decay the LR to 5% of peak over the budget. A constant high LR
+    # oscillates at long iteration counts and degrades the fit (~5.2mm vs 4.7mm
+    # corresponded-finger err); the decay is load-bearing, not optional.
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=n_iters, eta_min=lr * 0.05)
 
     aria_idx_t = torch.tensor(ARIA_IDX_USED, device=device, dtype=torch.long)
     mano_idx_t = torch.tensor(MANO_IDX_TARGET, device=device, dtype=torch.long)
@@ -171,6 +175,7 @@ def fit_mano_to_aria_batched(
         opt.zero_grad(set_to_none=True)
         loss.backward()
         opt.step()
+        sched.step()
         if verbose and (step % 50 == 0 or step == n_iters - 1):
             print(f"    iter {step:4d}  pos={pos_loss.item():.5f}  reg={reg_loss.item():.5f}")
 
@@ -196,8 +201,8 @@ def convert_aria_keypoints_to_mano(
     is_rhand: bool,
     model_dir: str | None = None,
     device: torch.device | str | None = None,
-    n_iters: int = 400,
-    lr: float = 0.02,
+    n_iters: int = 2400,
+    lr: float = 0.05,
     beta_reg: float = 0.01,
     chunk_size: int = 512,
     verbose: bool = False,


### PR DESCRIPTION
Raise MANO fit quality: 2400 iters, lr 0.05 with cosine decay

Port the 2026-07 convergence fix into the refactored conversion pipeline.
Main had it only partially: the DatasetConverter/argparse defaults were still
400/0.02, and aria_utils.py fit had no LR scheduler at all.

aria_utils.py:
- fit_mano_to_aria_batched + convert_aria_keypoints_to_mano: 400->2400 iters,
  lr 0.02->0.05, add CosineAnnealingLR(T_max=n_iters, eta_min=lr*0.05) +
  sched.step(). Constant high LR at long budgets oscillates and degrades the
  fit (~5.2mm vs 4.7mm corresponded-finger err); the decay is load-bearing.

aria_to_zarr.py:
- DatasetConverter default, CLI getattr fallback, and --mano-iters/--mano-lr
  argparse defaults: 400/0.02 -> 2400/0.05, so every entry path uses the good
  fit (aria_keypoints -> keypoints), not just direct callers.

Validated on 10 aria episodes (re-fit, world frame): fingertip err mean 1.5mm;
cartesian hand-orientation error vs old fit p99 138->9deg, max 178->21deg
(old fit intermittently flipped the hand ~180deg).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Derive the hand cartesian EE pose from fitted MANO keypoints

Aria MPS ships a palm position + palm normal, and get_ee_pose built the EE
frame from that triple. That estimate is poorly conditioned: measured over 10
episodes (4,504 frames x hands) it intermittently produced near-flipped hands
(orientation error p99 138deg, max 178deg). Rebuilding the same frame from the
fitted MANO keypoints -- which are fitted jointly against 20 landmarks, so one
bad normal cannot flip them -- gives p99 9.4deg, max 21deg.

- add mano_keypoints_to_cartesian(mano_kp_t63, is_rhand): wrist = MANO joint 0,
  palm = 4-MCP centroid (MANO has no palm-center joint), palm_normal =
  (index_MCP - wrist) x (pinky_MCP - wrist) sign-flipped for the left hand so it
  points out of the palm for both. Reuses compute_orientation_rotation_matrix +
  T_ROT_CAM so the output is drop-in with the MPS pose: (T,7) [xyz, quat wxyz],
  1e9 sentinel on invalid/degenerate frames.
- extract_episode: <side>.obs_ee_pose now comes from the fitted MANO keypoints
  when convert_mano=True (MPS pose retained as the convert_mano=False path).
  <side>.obs_aria_keypoints (raw aria) and <side>.obs_keypoints (MANO) are
  unchanged.
- CONTRIBUTING_DATA.md: document the function for contributors, incl. the
  handedness trap (a global sign error cancels in keypoint-vs-keypoint checks)
  and the sentinel requirement.

NOTE: this changes obs_ee_pose values for all aria data -- it is a different
(better-conditioned) frame, so aria episodes must be re-converted and anything
aligned to the old MPS-derived pose retrained.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Palm origin for the cartesian EE pose: wrist + index/middle/ring MCPs

The first cut used the centroid of the four MCPs. Those are ~coplanar along the
knuckle row, so their centroid lands ON that row -- ~17mm distal of the palm, and
visibly wrong when the frame is rendered (the triad sat on the knuckles).

Measured against the Aria palm-center landmark (raw kp 20, which the MANO fit
never sees), both hands:
    4 MCPs alone                19.8 mm
    wrist + 4 MCPs              13.8 mm
    wrist + idx/mid/ring MCPs   11.3 mm   <- adopted
Include the wrist (least-squares optimal weight 0.178; the 4-point centroid gives
0.25); exclude the pinky, which drags the centroid ulnar while the Aria palm
point sits radial. An equidistant/circumcentre origin is much worse: the knuckles
lie on a ~139mm-radius arc, so their circumcentre sits ~131mm off the hand.

The origin also sets the x-axis via (wrist - palm), so this improves orientation
too. Over the same 10 episodes (n=4504) vs the aria-keypoint-derived frame:
    orientation  4.58 -> 4.05 deg mean, p90 6.70 -> 6.42, p99 9.43 -> 9.23
Single-episode end-to-end: orientation 3.89/4.48 deg, origin 11.1/11.4 mm.

The self-consistency position figure rises (8.3 -> 9.2 mm) purely because the
wrist carries a known ~19mm definitional offset (the MANO root sits inside the
palm) at 25% weight; accuracy against the real palm point improves.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

docs(aria_utils): sync stale p99 9.4 -> 9.2 with the palm-origin re-measurement (CONTRIBUTING_DATA already updated in 1e4f785d)