### PR TITLE
fix(robot): import robot_utils by its package path

### DIFF
--- a/egomimic/robot/collect_demo.py
+++ b/egomimic/robot/collect_demo.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "oculus_reader"))
 from oculus_reader import OculusReader
 
 # Import local modules
-from robot_utils import RateLoop
+from egomimic.robot.robot_utils import RateLoop
 
 # Add path to robot_interface
 sys.path.append(os.path.join(os.path.dirname(__file__), "eva/eva_ws/src/eva"))

--- a/egomimic/robot/rollout.py
+++ b/egomimic/robot/rollout.py
@@ -11,7 +11,7 @@ import cv2
 import h5py
 import numpy as np
 import torch
-from robot_utils import RateLoop
+from egomimic.robot.robot_utils import RateLoop
 from scipy.spatial.transform import Rotation as R
 from torch.utils.data import default_collate
 


### PR DESCRIPTION
rollout.py and collect_demo.py did:

    from robot_utils import RateLoop

but there is no top-level robot_utils package -- the file is
egomimic/robot/robot_utils.py. That bare form only resolves when the script is
run from inside egomimic/robot/ (that directory on sys.path), so importing
either module as part of the package raised ModuleNotFoundError. It is also why
rollout.py looked dead to reference sweeps: it is the sole caller of
egomimicUtils.interpolate_arr / interpolate_arr_euler, and an import-based check
never got far enough to see it.

stream_aria.py and stream_d405.py already use the package-qualified form; this
makes all four consistent.

Verified: egomimic.robot.rollout now imports (previously ModuleNotFoundError).
collect_demo still fails on ppadb, an unrelated optional hardware dependency for
the Oculus reader that is simply absent from the cluster venv.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>