### PR TITLE
fix(zarr): repair an unresolvable import, and share two copy-pasted helpers

### DIFF
--- a/egomimic/rldb/zarr/hdf5_to_zarr.py
+++ b/egomimic/rldb/zarr/hdf5_to_zarr.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import numpy as np
 
 from egomimic.rldb.zarr import ZarrWriter
-from egomimic.scripts.eva_process.zarr_utils import EvaHD5Extractor
+from egomimic.scripts.eva_process.eva_utils import EvaHD5Extractor
 from egomimic.rldb.embodiment.eva import Eva
 
 

--- a/egomimic/robot/calibrate_utils.py
+++ b/egomimic/robot/calibrate_utils.py
@@ -5,6 +5,7 @@ import time
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
+from egomimic.utils.pose_utils import safe_rot3_from_T
 
 # Make sure we can import oculus_reader from repo root:
 # egomimic/robot/calibrate_utils.py  ->  ../../oculus_reader
@@ -12,16 +13,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "oculus_read
 from oculus_reader import OculusReader  # type: ignore
 
 
-def safe_rot3_from_T(T, ortho_tol=1e-3, det_tol=1e-3):
-    Rm = np.asarray(T, dtype=float)[:3, :3]
-    if Rm.shape != (3, 3) or not np.all(np.isfinite(Rm)):
-        return np.eye(3)
-    det = np.linalg.det(Rm)
-    if det <= 0 or abs(det - 1.0) > det_tol:
-        return np.eye(3)
-    if np.linalg.norm(Rm.T @ Rm - np.eye(3), ord="fro") > ortho_tol:
-        return np.eye(3)
-    return Rm
 
 
 def quat_xyzw_to_wxyz(qxyzw: np.ndarray) -> np.ndarray:

--- a/egomimic/robot/collect_demo.py
+++ b/egomimic/robot/collect_demo.py
@@ -23,6 +23,7 @@ from oculus_reader import OculusReader
 
 # Import local modules
 from egomimic.robot.robot_utils import RateLoop
+from egomimic.utils.pose_utils import safe_rot3_from_T
 
 # Add path to robot_interface
 sys.path.append(os.path.join(os.path.dirname(__file__), "eva/eva_ws/src/eva"))
@@ -125,16 +126,6 @@ def flip_roll_only(R_i, up=np.array([0.0, 0.0, 1.0]), add_pi=True):
     return R_out
 
 
-def safe_rot3_from_T(T, ortho_tol=1e-3, det_tol=1e-3):
-    Rm = np.asarray(T, dtype=float)[:3, :3]
-    if Rm.shape != (3, 3) or not np.all(np.isfinite(Rm)):
-        return np.eye(3)
-    det = np.linalg.det(Rm)
-    if det <= 0 or abs(det - 1.0) > det_tol:
-        return np.eye(3)
-    if np.linalg.norm(Rm.T @ Rm - np.eye(3), ord="fro") > ortho_tol:
-        return np.eye(3)
-    return Rm
 
 
 def normalize_quat_xyzw(q: np.ndarray) -> np.ndarray:

--- a/egomimic/utils/action_utils.py
+++ b/egomimic/utils/action_utils.py
@@ -124,6 +124,24 @@ def _reconstruct_R_from_cols(c1: torch.Tensor, c2: torch.Tensor) -> torch.Tensor
 
 
 # ---------- base interface ----------
+def _decode_arm_block(actions32: torch.Tensor, start: int):
+    """Decode one 10-wide arm block of a 32-pack into ``(xyz, ypr, gripper)``.
+
+    The four single-arm converters differ only in where their block starts
+    (left at 0, right at 10) and in whether they keep the gripper channel:
+    robot actions are 7-dim (xyz+ypr+gripper), human actions 6-dim.
+    """
+    actions32 = _ensure_bsd(actions32)
+    block = actions32[..., start : start + 10]
+    xyz = block[..., 0:3]
+    c1 = block[..., 3:6]
+    c2 = block[..., 6:9]
+    g = block[..., 9:10]
+    R = _reconstruct_R_from_cols(c1, c2)
+    ypr = _matrix_to_ypr(R)
+    return xyz, ypr, g
+
+
 class BaseActionConverter:
     """
     Implement both directions:
@@ -162,14 +180,7 @@ class RobotLeftCartesianEuler(BaseActionConverter):
         return _pad32(block)
 
     def from32(self, actions32: torch.Tensor) -> torch.Tensor:
-        actions32 = _ensure_bsd(actions32)
-        block = actions32[..., 0:10]  # left block
-        xyz = block[..., 0:3]
-        c1 = block[..., 3:6]
-        c2 = block[..., 6:9]
-        g = block[..., 9:10]
-        R = _reconstruct_R_from_cols(c1, c2)
-        ypr = _matrix_to_ypr(R)
+        xyz, ypr, g = _decode_arm_block(actions32, 0)
         return torch.cat([xyz, ypr, g], dim=-1)  # (B,S,7)
 
 
@@ -193,14 +204,7 @@ class RobotRightCartesianEuler(BaseActionConverter):
         return _pad32(torch.cat([zeros, right], dim=-1))  # (B,S,20) -> pad 32
 
     def from32(self, actions32: torch.Tensor) -> torch.Tensor:
-        actions32 = _ensure_bsd(actions32)
-        block = actions32[..., 10:20]  # right block
-        xyz = block[..., 0:3]
-        c1 = block[..., 3:6]
-        c2 = block[..., 6:9]
-        g = block[..., 9:10]
-        R = _reconstruct_R_from_cols(c1, c2)
-        ypr = _matrix_to_ypr(R)
+        xyz, ypr, g = _decode_arm_block(actions32, 10)
         return torch.cat([xyz, ypr, g], dim=-1)  # (B,S,7)
 
 
@@ -273,12 +277,8 @@ class HumanLeftCartesianEuler(BaseActionConverter):
         return _pad32(block)
 
     def from32(self, actions32: torch.Tensor) -> torch.Tensor:
-        actions32 = _ensure_bsd(actions32)
-        block = actions32[..., 0:10]
-        xyz, c1, c2 = block[..., 0:3], block[..., 3:6], block[..., 6:9]
-        R = _reconstruct_R_from_cols(c1, c2)
-        ypr = _matrix_to_ypr(R)
-        return torch.cat([xyz, ypr], dim=-1)  # (B,S,6)
+        xyz, ypr, _ = _decode_arm_block(actions32, 0)
+        return torch.cat([xyz, ypr], dim=-1)  # (B,S,6) -- human has no gripper
 
 
 class HumanRightCartesianEuler(BaseActionConverter):
@@ -300,12 +300,8 @@ class HumanRightCartesianEuler(BaseActionConverter):
         return _pad32(torch.cat([zeros, block], dim=-1))
 
     def from32(self, actions32: torch.Tensor) -> torch.Tensor:
-        actions32 = _ensure_bsd(actions32)
-        block = actions32[..., 10:20]
-        xyz, c1, c2 = block[..., 0:3], block[..., 3:6], block[..., 6:9]
-        R = _reconstruct_R_from_cols(c1, c2)
-        ypr = _matrix_to_ypr(R)
-        return torch.cat([xyz, ypr], dim=-1)  # (B,S,6)
+        xyz, ypr, _ = _decode_arm_block(actions32, 10)
+        return torch.cat([xyz, ypr], dim=-1)  # (B,S,6) -- human has no gripper
 
 
 class HumanBimanualCartesianEuler(BaseActionConverter):

--- a/egomimic/utils/pose_utils.py
+++ b/egomimic/utils/pose_utils.py
@@ -489,3 +489,21 @@ def get_vector_from_yaw_pitch(
         return unit_dir
     else:
         return unit_dir * depth
+
+
+def safe_rot3_from_T(T, ortho_tol=1e-3, det_tol=1e-3):
+    """Extract a trustworthy 3x3 rotation from a pose matrix, else identity.
+
+    Rejects non-finite entries, a non-positive or off-unit determinant, and
+    columns that have drifted from orthonormal. Used by the teleop/calibration
+    paths, where a silently-degenerate rotation is worse than falling back.
+    """
+    Rm = np.asarray(T, dtype=float)[:3, :3]
+    if Rm.shape != (3, 3) or not np.all(np.isfinite(Rm)):
+        return np.eye(3)
+    det = np.linalg.det(Rm)
+    if det <= 0 or abs(det - 1.0) > det_tol:
+        return np.eye(3)
+    if np.linalg.norm(Rm.T @ Rm - np.eye(3), ord="fro") > ortho_tol:
+        return np.eye(3)
+    return Rm


### PR DESCRIPTION
egomimic/rldb/zarr/hdf5_to_zarr.py imported EvaHD5Extractor from
egomimic.scripts.eva_process.zarr_utils, which exists on no branch -- the class
lives in eva_utils, which the sibling eva_to_zarr.py:18 imports correctly. The
module was therefore unimportable and its CLI could not run. Predates the rename
in #562 (that commit changed no content).

safe_rot3_from_T was defined identically in robot/calibrate_utils.py and
robot/collect_demo.py. It moves to utils/pose_utils.py, next to the other pose
maths. Deliberately NOT hoisted into either robot module: calibrate_utils does a
sys.path.append + "from oculus_reader import OculusReader" at import time, so
importing it for one numpy helper would drag a VR hardware dependency into
collect_demo. pose_utils has no such deps.

The four single-arm from32 converters each re-implemented the same 10-wide block
decode, differing only in offset (left 0, right 10) and whether the gripper
channel is kept -- robot returns 7-dim, human 6-dim. The decode, including the
rotation reconstruction, moves to _decode_arm_block; each converter keeps its own
cat so the arity difference stays visible.

Verified by differential test: all four from32 are bit-identical to the previous
implementation over random inputs. (The ~pi round-trip error on random ypr is a
pre-existing _matrix_to_ypr wrap-around, identical before and after, and vanishes
for ypr in the principal range.)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>