### PR TITLE
feat(rldb): heterogeneous u_socket action support

### DIFF
--- a/egomimic/pipeline/stages_flow.py
+++ b/egomimic/pipeline/stages_flow.py
@@ -315,11 +315,12 @@ class SDPHead(Stage):
         end_mode="masked" (legacy): batch-clamped gather; overrun positions
         masked from the loss (content may be foreign-episode junk in packs).
         end_mode="pusher_hold": per-episode clamp (no cross-episode content)
-        and beyond-end targets = HOLD at the episode's final PUSHER xy (state
-        xy shares the ws512 action bounds, so normalized state values are
-        directly action-space); tail positions are TRAINED (explicit endgame
-        semantics)."""
+        and beyond-end targets = HOLD at the episode's final pusher pose. The
+        first D state coordinates must match the D-dimensional action pose
+        (e.g. xy for a circle pusher, xy-theta for a U-socket); tail positions
+        are TRAINED (explicit endgame semantics)."""
         T = target.shape[0]
+        Dd = target.shape[-1]
         dev = target.device
         ep_end = torch.empty(T, dtype=torch.long, device=dev)
         for b in range(len(cu) - 1):
@@ -327,10 +328,15 @@ class SDPHead(Stage):
         idx = torch.arange(T, device=dev)[:, None] + torch.arange(self.K, device=dev)[None, :]
         valid = idx < ep_end[:, None]                           # (T,K)
         if self.end_mode == "pusher_hold" and state is not None:
+            if state.shape[-1] < Dd:
+                raise ValueError(
+                    f"pusher_hold needs at least {Dd} state coordinates for "
+                    f"a {Dd}D action, got state shape {tuple(state.shape)}"
+                )
             idx_c = torch.minimum(idx, (ep_end - 1)[:, None])
             tgt = target[idx_c]                                 # same-episode only
-            pad = state[(ep_end - 1), :2].to(tgt.dtype)         # (T,2) final pusher xy
-            pad = pad[:, None, None, :].expand(T, self.K, self.C, self.D)
+            pad = state[(ep_end - 1), :Dd].to(tgt.dtype)        # (T,D) final pusher pose
+            pad = pad[:, None, None, :].expand(T, self.K, self.C, Dd)
             tgt = torch.where(valid[..., None, None], tgt, pad)
             valid = torch.ones_like(valid)                      # tail trained
         else:

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -10,6 +10,11 @@ from termcolor import cprint
 from torch.utils.data import DataLoader, default_collate
 from transformers import AutoTokenizer
 
+from egomimic.rldb.zarr.zarr_dataset_packed import (
+    ZarrEpisodePackedDataset,
+    pack_collate,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,6 +57,13 @@ class MultiDataModuleWrapper(LightningDataModule):
         self.valid_dataloader_params = valid_dataloader_params
         self.collate_fn = annotation_collate
 
+    def _collate_for(self, dataset):
+        """Packed datasets need ``pack_collate`` (it emits ``cu_seqlens``);
+        everything else uses the configured ``self.collate_fn``."""
+        if isinstance(dataset, ZarrEpisodePackedDataset):
+            return pack_collate
+        return self.collate_fn
+
     def train_dataloader(self):
         iterables = dict()
         for dataset_name, dataset in self.train_datasets.items():
@@ -63,7 +75,7 @@ class MultiDataModuleWrapper(LightningDataModule):
             iterables[dataset_name] = DataLoader(
                 dataset,
                 shuffle=True,
-                collate_fn=self.collate_fn,
+                collate_fn=self._collate_for(dataset),
                 **dataset_params,
             )
 
@@ -82,7 +94,7 @@ class MultiDataModuleWrapper(LightningDataModule):
             iterables[dataset_name] = DataLoader(
                 dataset,
                 shuffle=shuffle,
-                collate_fn=self.collate_fn,
+                collate_fn=self._collate_for(dataset),
                 **dataset_params,
             )
 

--- a/egomimic/rldb/embodiment/embodiment.py
+++ b/egomimic/rldb/embodiment/embodiment.py
@@ -32,6 +32,10 @@ class EMBODIMENT(Enum):
     PUSHSHAPES_SIM = 15
     PUSHSHAPES_SIM_STICK = 16
     PUSHSHAPES_SIM_SMALL_CIRCLE = 17
+    # 19, not 18: 18 was HUMAN_BIMANUAL under the pre-collapse numbering,
+    # and u_socket datasets/checkpoints (bf_*_u3*, the 2026-08 lineage)
+    # already encode 19. Pinned for the same reason as 15/16/17 above.
+    PUSHSHAPES_SIM_U_SOCKET = 19
 
 
 EMBODIMENT_ID_TO_KEY = {member.value: member.name for member in EMBODIMENT}

--- a/egomimic/rldb/embodiment/pushshapes.py
+++ b/egomimic/rldb/embodiment/pushshapes.py
@@ -55,7 +55,12 @@ def _draw_chunk(
     colored along a perceptual gradient — viewer can see chunk ordering at a
     glance. Returns the modified frame (draw_dot_on_frame returns a copy).
     """
-    pix = np.asarray(actions, dtype=np.float32).reshape(-1, 2) * float(scale)
+    arr = np.asarray(actions, dtype=np.float32)
+    if arr.ndim == 1:
+        arr = arr[None, :]
+    if arr.shape[-1] < 2:
+        raise ValueError(f"PushShapes visualization needs xy actions, got {arr.shape}")
+    pix = arr.reshape(-1, arr.shape[-1])[:, :2] * float(scale)
     return draw_dot_on_frame(
         frame, pix.tolist(), show=False, palette=palette, dot_size=dot_size
     )
@@ -274,3 +279,48 @@ def viz_gt_preds(
             frame = _draw_chunk(frame, pred_actions[i], scale, _PRED_PALETTE)
         frames.append(frame)
     return np.stack(frames, axis=0)
+
+
+def get_keymap_with_pusher_cmd(action_horizon: int = 32, **kwargs) -> dict:
+    """Training keymap plus the commanded pusher pose used for SDP tail HOLD.
+
+    ``observations.pusher_cmd_pose`` is identical to ``actions`` in the
+    circle/U-socket collector, including the U-socket theta coordinate. It is
+    kept out of the observation encoders and consumed only by ``SDPHead`` for
+    episode-tail padding, avoiding a coordinate/normalization mismatch with
+    the lagging actual pusher state.
+    """
+    key_map = get_keymap(action_horizon=action_horizon, **kwargs)
+    key_map["pusher_cmd_pose"] = {
+        "key_type": "proprio_keys",
+        "zarr_key": "observations.pusher_cmd_pose",
+        "horizon": int(action_horizon),
+    }
+    return key_map
+
+
+def get_rotvec_transform_list():
+    """u_socket theta -> (cos, sin) on actions + commanded pose (load-time,
+    pre-NormStats). Pair with 4-dim action norm stats (ws512_u3rv json) and
+    ``action_dims: {pushshapes_sim_u_socket: 4}``. Rollout eval reverts via
+    :func:`get_rotvec_revert_transform_list` (wired into SimEval 2026-08-04).
+    """
+    from egomimic.rldb.zarr.action_chunk_transforms import ThetaToRotVec
+    return [ThetaToRotVec(keys=["actions",
+                                "pusher_cmd_pose",
+                                "observations.pusher_cmd_pose"],
+                          angle_col=2)]
+
+
+def get_rotvec_revert_transform_list(keys=None, angle_col: int = 2):
+    """REVERT list for :func:`get_rotvec_transform_list`.
+
+    ``(x, y, cos, sin) -> (x, y, theta)``. Apply to a model prediction before
+    ``env.step`` (the env wants 3-dim u_socket actions). Same convention as the
+    eva/human ``_build_*_revert_*_transform_list`` helpers: a revert is its own
+    transform_list, so the rollout does not hardcode any math.
+    """
+    from egomimic.rldb.zarr.action_chunk_transforms import RotVecToTheta
+    if keys is None:
+        keys = ["actions", "pusher_cmd_pose", "observations.pusher_cmd_pose"]
+    return [RotVecToTheta(keys=list(keys), angle_col=int(angle_col))]

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -600,3 +600,66 @@ class NumpyToTensor(Transform):
                 )
         return batch
 
+
+
+class ThetaToRotVec(Transform):
+    """Replace a trailing angle column with its (cos, sin) rotation vector.
+
+    ``(T, D)`` with the angle at ``angle_col`` -> ``(T, D+1)`` where the angle
+    column is replaced by ``cos(theta), sin(theta)``. Removes the 2*pi wrap
+    discontinuity from regression/diffusion targets (u_socket theta actions).
+    Applied at load time, BEFORE NormStats -- provide (D+1)-dim stats.
+
+    ``keys`` lists every batch key to convert; keys absent from an episode are
+    skipped (leaf key naming differs between keymap name and zarr path, so
+    list both spellings where unsure).
+    """
+
+    def __init__(self, keys, angle_col: int = 2):
+        self.keys = list(keys)
+        self.angle_col = int(angle_col)
+
+    def transform(self, batch: dict) -> dict:
+        for k in self.keys:
+            if k not in batch:
+                continue
+            a = np.asarray(batch[k])
+            if a.ndim != 2 or a.shape[1] <= self.angle_col:
+                continue
+            th = a[:, self.angle_col]
+            batch[k] = np.concatenate(
+                [a[:, : self.angle_col],
+                 np.cos(th)[:, None].astype(a.dtype),
+                 np.sin(th)[:, None].astype(a.dtype),
+                 a[:, self.angle_col + 1:]], axis=1)
+        return batch
+
+
+class RotVecToTheta(Transform):
+    """Revert of :class:`ThetaToRotVec`: ``(cos, sin)`` -> angle.
+
+    ``(T, D+1)`` with ``cos`` at ``angle_col`` and ``sin`` at ``angle_col+1``
+    -> ``(T, D)`` with ``atan2(sin, cos)`` in their place. Used to turn a model
+    prediction back into the env's ``(x, y, theta)`` action before ``env.step``.
+
+    atan2 handles the un-normalised case too: the model's cos/sin need not lie
+    on the unit circle, and only their RATIO matters for the angle, so no
+    renormalisation is required.
+    """
+
+    def __init__(self, keys, angle_col: int = 2):
+        self.keys = list(keys)
+        self.angle_col = int(angle_col)
+
+    def transform(self, batch: dict) -> dict:
+        c = self.angle_col
+        for k in self.keys:
+            if k not in batch:
+                continue
+            a = np.asarray(batch[k])
+            if a.ndim != 2 or a.shape[1] <= c + 1:
+                continue
+            th = np.arctan2(a[:, c + 1], a[:, c])
+            batch[k] = np.concatenate(
+                [a[:, :c], th[:, None].astype(a.dtype), a[:, c + 2:]], axis=1)
+        return batch


### PR DESCRIPTION
Adds what a U-socket pusher needs alongside the 2-D circle embodiments:

- embodiment: pin PUSHSHAPES_SIM_U_SOCKET = 19. 18 was HUMAN_BIMANUAL under
  the pre-collapse numbering and the existing u_socket datasets/checkpoints
  (the bf_*_u3* 2026-08 lineage) already encode 19.
- transforms: ThetaToRotVec / RotVecToTheta, so an angle is carried as
  (cos, sin) and cannot wrap discontinuously during training; the revert is
  needed because env.step still wants a 3-dim u_socket action.
- pushshapes: get_keymap_with_pusher_cmd + the rotvec transform lists.
- stages_flow: generalise pusher_hold from hardcoded 2-D xy to a
  D-dimensional pose (state[:, :Dd]), with a guard that raises when the state
  carries fewer coordinates than the action, instead of silently padding from
  the wrong columns.
- pl_data_utils: route packed datasets through pack_collate, which emits
  cu_seqlens, rather than the configured collate_fn.