### PR TITLE
feat(pipeline): sequential H-Net pipeline, flat stages instead of a nested trunk

### DIFF
--- a/egomimic/hydra_configs/model/bf/bf_seq_noattn_sdp.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_noattn_sdp.yaml
@@ -1,0 +1,344 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  # separate A / S visual encoders (matches the original ObsEncoders
+  # agnostic+specific split: each stream owns its VisualCore, batch norm)
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img_a
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      in_channels: 3
+      image_size: 96
+      num_kp: 32
+      feature_dimension: 64
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img_s
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      in_channels: 3
+      image_size: 96
+      num_kp: 32
+      feature_dimension: 64
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+      _partial_: true
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim: 2
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img_a
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 64
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img_s
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 64
+    - 64
+    d_out: 64
+    widths:
+    - 64
+    - 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 64
+      num_heads: 2
+      d_intermediate: 256
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_L1
+    - S_L1
+    route_key: route_L1
+    dims:
+    - 256
+    - 64
+    apex_dims:
+    - 512
+    - 128
+    route_on: fused
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    per_emb_keys:
+    - S_L0
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    - S_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+    mask_mode: sym
+    allow_agnostic_cross: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    - S_L1
+    out_keys:
+    - A_L2
+    - S_L2
+    route_key: route_L2
+    dims:
+    - 512
+    - 128
+    apex_dims:
+    - 1024
+    - 128
+    route_on: fused
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    per_emb_keys:
+    - S_L1
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    - S_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    - S_L1d
+    dims:
+    - 512
+    - 128
+    apex_dims:
+    - 1024
+    - 128
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    per_emb_keys:
+    - S_L1d
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    residual_keys:
+    - A_L1@res
+    - S_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    - S_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+    mask_mode: sym
+    allow_agnostic_cross: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    - S_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    - S_L0d
+    dims:
+    - 256
+    - 64
+    apex_dims:
+    - 512
+    - 128
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    per_emb_keys:
+    - S_L0d
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    residual_keys:
+    - A_L0@res
+    - S_L0@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0d
+    - S_L0d
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 64
+      num_heads: 2
+      d_intermediate: 256
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+    mask_mode: sym
+    allow_agnostic_cross: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 64
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 128
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/hydra_configs/model/bf/bf_seq_noattn_sdp_u3rv.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_noattn_sdp_u3rv.yaml
@@ -1,0 +1,354 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_u_socket
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_u_socket: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  # separate A / S visual encoders (matches the original ObsEncoders
+  # agnostic+specific split: each stream owns its VisualCore, batch norm)
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img_a
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      in_channels: 3
+      image_size: 96
+      num_kp: 32
+      feature_dimension: 64
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img_s
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      in_channels: 3
+      image_size: 96
+      num_kp: 32
+      feature_dimension: 64
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+      _partial_: true
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim:
+      pushshapes_sim: 2
+      pushshapes_sim_u_socket: 4
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img_a
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 64
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img_s
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 64
+    - 64
+    d_out: 128
+    widths:
+    - 128
+    - 128
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_L1
+    - S_L1
+    route_key: route_L1
+    dims:
+    - 256
+    - 128
+    apex_dims:
+    - 512
+    - 256
+    route_on: fused
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    per_emb_keys:
+    - S_L0
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    - S_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    - d_model: 256
+      num_heads: 8
+      d_intermediate: 1024
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+    mask_mode: sym
+    allow_agnostic_cross: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    - S_L1
+    out_keys:
+    - A_L2
+    - S_L2
+    route_key: route_L2
+    dims:
+    - 512
+    - 256
+    apex_dims:
+    - 1024
+    - 256
+    route_on: fused
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    per_emb_keys:
+    - S_L1
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    - S_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    - S_L1d
+    dims:
+    - 512
+    - 256
+    apex_dims:
+    - 1024
+    - 256
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    per_emb_keys:
+    - S_L1d
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    residual_keys:
+    - A_L1@res
+    - S_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    - S_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    - d_model: 256
+      num_heads: 8
+      d_intermediate: 1024
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+    mask_mode: sym
+    allow_agnostic_cross: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    - S_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    - S_L0d
+    dims:
+    - 256
+    - 128
+    apex_dims:
+    - 512
+    - 256
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    per_emb_keys:
+    - S_L0d
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    residual_keys:
+    - A_L0@res
+    - S_L0@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0d
+    - S_L0d
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+    mask_mode: sym
+    allow_agnostic_cross: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 128
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 256
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+    action_dims:
+      pushshapes_sim: 2
+      pushshapes_sim_u_socket: 4
+    latent_dim: 4
+    enc_hidden: 256
+    enc_layers: 3
+    enc_residual: false
+    enc_per_stream: false
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/hydra_configs/model/bf/bf_seq_yolo_noshenc_win21.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_yolo_noshenc_win21.yaml
@@ -1,0 +1,318 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img_a
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      norm_layer: group
+      in_channels: 3
+      image_size: 96
+      num_kp: 32
+      feature_dimension: 64
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img_s
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      norm_layer: group
+      in_channels: 3
+      image_size: 96
+      num_kp: 32
+      feature_dimension: 64
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+      _partial_: true
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim: 2
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img_a
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 64
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img_s
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 64
+    - 64
+    d_out: 128
+    widths:
+    - 256
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Framewise
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_p
+    - S_out
+    dims:
+    - 256
+    - 128
+    n_layers: 4
+    per_emb_keys:
+    - S_L0
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    out_keys:
+    - A_L1
+    route_key: route_L1
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    out_keys:
+    - A_L2
+    route_key: route_L2
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L0@res
+  - _target_: egomimic.pipeline.stages_seq.Mix
+    in_keys:
+    - A_L0d
+    - A_p
+    out_key: A_mix
+    dim: 256
+    mixer: mlp
+    mixer_kwargs:
+      n_layers: 4
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_mix
+    - S_out
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 128
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 128
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win21.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win21.yaml
@@ -1,0 +1,297 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      norm_layer: group
+      in_channels: 3
+      image_size: 96
+      num_kp: 96
+      feature_dimension: 192
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim: 2
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 192
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 192
+    - 64
+    d_out: 128
+    widths:
+    - 256
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Framewise
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_p
+    - S_out
+    dims:
+    - 256
+    - 128
+    n_layers: 4
+    per_emb_keys:
+    - S_L0
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    out_keys:
+    - A_L1
+    route_key: route_L1
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    out_keys:
+    - A_L2
+    route_key: route_L2
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L0@res
+  - _target_: egomimic.pipeline.stages_seq.Mix
+    in_keys:
+    - A_L0d
+    - A_p
+    out_key: A_mix
+    dim: 256
+    mixer: mlp
+    mixer_kwargs:
+      n_layers: 4
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_mix
+    - S_out
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 128
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 128
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win21_nocrop.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win21_nocrop.yaml
@@ -1,0 +1,297 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      norm_layer: group
+      in_channels: 3
+      image_size: 96
+      num_kp: 96
+      feature_dimension: 192
+      pretrained: false
+      crop_aug: false
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim: 2
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 192
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 192
+    - 64
+    d_out: 128
+    widths:
+    - 256
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Framewise
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_p
+    - S_out
+    dims:
+    - 256
+    - 128
+    n_layers: 4
+    per_emb_keys:
+    - S_L0
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    out_keys:
+    - A_L1
+    route_key: route_L1
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    out_keys:
+    - A_L2
+    route_key: route_L2
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 1
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L0@res
+  - _target_: egomimic.pipeline.stages_seq.Mix
+    in_keys:
+    - A_L0d
+    - A_p
+    out_key: A_mix
+    dim: 256
+    mixer: mlp
+    mixer_kwargs:
+      n_layers: 4
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_mix
+    - S_out
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 128
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 128
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win22.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win22.yaml
@@ -1,0 +1,297 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_small_circle
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_small_circle: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      norm_layer: group
+      in_channels: 3
+      image_size: 96
+      num_kp: 96
+      feature_dimension: 192
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim: 2
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 192
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 192
+    - 64
+    d_out: 128
+    widths:
+    - 256
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Framewise
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_p
+    - S_out
+    dims:
+    - 256
+    - 128
+    n_layers: 4
+    per_emb_keys:
+    - S_L0
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    out_keys:
+    - A_L1
+    route_key: route_L1
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    out_keys:
+    - A_L2
+    route_key: route_L2
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L0@res
+  - _target_: egomimic.pipeline.stages_seq.Mix
+    in_keys:
+    - A_L0d
+    - A_p
+    out_key: A_mix
+    dim: 256
+    mixer: mlp
+    mixer_kwargs:
+      n_layers: 4
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_mix
+    - S_out
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 128
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_small_circle
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 128
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win22_u3rv.yaml
+++ b/egomimic/hydra_configs/model/bf/bf_seq_yolo_shenc_win22_u3rv.yaml
@@ -1,0 +1,307 @@
+_target_: egomimic.pl_utils.pl_model.ModelWrapper
+robomimic_model:
+  _target_: egomimic.pipeline.algo.PipelineAlgo
+  action_horizon: 2560
+  domains:
+  - pushshapes_sim
+  - pushshapes_sim_u_socket
+  ac_keys:
+    pushshapes_sim: actions
+    pushshapes_sim_u_socket: actions
+  stages:
+  # ======================= OBS =======================
+  - _target_: egomimic.pipeline.stages_io.TargetBuilder
+    chunk_len: 4
+    stride: 4
+  - _target_: egomimic.pipeline.stages_seq.ObsNoise
+    train_only: true
+    transforms:
+    - _target_: egomimic.pipeline.obs_transforms.GaussianImageNoise
+      std: 0.02
+      keys:
+      - front_img_1
+  - _target_: egomimic.pipeline.stages_seq.TimePos
+  - _target_: egomimic.pipeline.stages_seq.VisualEncode
+    in_key: obs/front_img_1
+    out_key: feat_img
+    encoder:
+      _target_: egomimic.models.stems.visual_core.VisualCore
+      norm_layer: group
+      in_channels: 3
+      image_size: 96
+      num_kp: 96
+      feature_dimension: 192
+      pretrained: false
+      crop_aug: true
+      crop_height: 86
+      crop_width: 86
+      crop_eval_mode: random
+      crop_sample_mode: v02
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/object_pose
+    out_key: emb_object
+    input_dim: 4
+    embed_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.ObsEmbed
+    in_key: obs/pusher_pose
+    out_key: emb_pusher
+    input_dim:
+      pushshapes_sim: 2
+      pushshapes_sim_u_socket: 4
+    embed_dim: 64
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_object
+    out_key: A_L0
+    dims:
+    - 192
+    - 64
+    d_out: 256
+    widths:
+    - 256
+    - 256
+  - _target_: egomimic.pipeline.stages_seq.Fuse
+    in_keys:
+    - feat_img
+    - emb_pusher
+    out_key: S_L0
+    dims:
+    - 192
+    - 64
+    d_out: 128
+    widths:
+    - 256
+    per_emb: true
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  # ==================== MAIN TRUNK ===================
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L0
+    - S_L0
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Framewise
+    in_keys:
+    - A_L0
+    - S_L0
+    out_keys:
+    - A_p
+    - S_out
+    dims:
+    - 256
+    - 128
+    n_layers: 4
+    per_emb_keys:
+    - S_L0
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L0
+    out_keys:
+    - A_L1
+    route_key: route_L1
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    level: 0
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Chunk
+    in_keys:
+    - A_L1
+    out_keys:
+    - A_L2
+    route_key: route_L2
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    route_on: a
+    target_compression_ratio: 3.0
+    ratio_loss_weight: 0.0005
+    grab_prev_end: true
+    router_per_emb: true
+    router_fusion: mlp
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    level: 1
+  - _target_: egomimic.pipeline.stages_seq.Apex
+    in_key: A_L2
+    causal: true
+    main_network:
+      arch_layout: T10
+      d_model: 1024
+      d_intermediate: 1536
+      num_heads: 16
+      cond: false
+      rotary_emb_dim: 64
+      dropout: 0.0
+      resid_dropout: 0.0
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L2
+    route_key: route_L2
+    out_keys:
+    - A_L1d
+    dims:
+    - 512
+    apex_dims:
+    - 1024
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L1@res
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_L1d
+    streams_cfg:
+    - d_model: 512
+      num_heads: 8
+      d_intermediate: 2048
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    rotary_emb_dim: 64
+  - _target_: egomimic.pipeline.stages_seq.Dechunk
+    in_keys:
+    - A_L1d
+    route_key: route_L1
+    out_keys:
+    - A_L0d
+    dims:
+    - 256
+    apex_dims:
+    - 512
+    residual_mixer: mlp
+    residual_mixer_kwargs:
+      n_layers: 4
+    residual_keys:
+    - A_L0@res
+  - _target_: egomimic.pipeline.stages_seq.Mix
+    in_keys:
+    - A_L0d
+    - A_p
+    out_key: A_mix
+    dim: 256
+    mixer: mlp
+    mixer_kwargs:
+      n_layers: 4
+  - _target_: egomimic.pipeline.stages_seq.StreamTrunk
+    in_keys:
+    - A_mix
+    - S_out
+    out_keys:
+    - a_top
+    - s
+    streams_cfg:
+    - d_model: 256
+      num_heads: 4
+      d_intermediate: 1024
+    - d_model: 128
+      num_heads: 4
+      d_intermediate: 512
+    n_layers: 4
+    attn_window: 2
+    causal: true
+    mask_mode: sym
+    allow_agnostic_cross: true
+    rotary_emb_dim: 64
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+  # ================ ACTION PREDICTION ================
+  - _target_: egomimic.pipeline.stages_flow.SDPHead
+    d_a: 256
+    d_s: 128
+    action_dim: 2
+    chunk_len: 4
+    embodiments:
+    - pushshapes_sim
+    - pushshapes_sim_u_socket
+    buffer_chunks: 2
+    num_train_timesteps: 100
+    num_inference_steps: 16
+    detach_offregime: true
+    regime_weights:
+    - 0.7
+    - 0.15
+    - 0.15
+    end_mode: pusher_hold
+    denoiser_arch: adaln
+    d_model_a: 256
+    d_model_s: 128
+    n_layers: 4
+    n_heads: 4
+    ffn_mult: 4
+    mask_mode: asym
+    action_dims:
+      pushshapes_sim: 2
+      pushshapes_sim_u_socket: 4
+    latent_dim: 4
+    enc_hidden: 256
+    enc_layers: 3
+    enc_residual: false
+    enc_per_stream: false
+  - _target_: egomimic.pipeline.stages_seq.ScheduledRatioLoss
+    target_ratio:
+    - 3.0
+    - 3.0
+    schedule: null
+    over_steps: 0
+enable_grad_norm: false
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.0
+scheduler:
+  _target_: egomimic.utils.schedulers.warmup_cosine_scheduler
+  _partial_: true
+  max_steps: 300000
+  warmup_steps: 1
+  warmup_start_factor: 1.0
+  eta_min: 5.0e-06

--- a/egomimic/models/hnet/dual_stream_chunker.py
+++ b/egomimic/models/hnet/dual_stream_chunker.py
@@ -65,7 +65,9 @@ class DualStreamRouter(nn.Module):
     def __init__(self, d_a, d_s, d_router=None, n_layers=4, fusion="residual_mlp",
                  router_pre_layout=None, router_pre_detach=False,
                  hidden_mult=4.0, router_core="cossim", router_temp: float = 1.0,
-                 router_sample: bool = False):
+                 router_sample: bool = False,
+                 separate_boundaries: bool = False,
+                 route_on: str = "fused"):
         super().__init__()
         d_router = int(d_router) if d_router else int(d_a)
         self.d_a, self.d_s, self.d_router = int(d_a), int(d_s), d_router
@@ -132,6 +134,45 @@ class DualStreamRouter(nn.Module):
         else:
             raise ValueError(f"router_core must be 'cossim'|'sigmoid', got {router_core!r}")
 
+        # --- ROUTE-ON MODE ------------------------------------------------------
+        # Each router instance emits exactly ONE boundary. `route_on` selects what
+        # enters the cossim core:
+        #   "fused" (legacy) : h = fuse(A, S)
+        #   "a"              : h = solo_a(A) -- AGNOSTIC boundary. Reads only the
+        #                      SHARED stream, so this router can itself be shared
+        #                      across embodiments with no per-emb contamination.
+        #   "s"              : h = solo_s(S) -- SPECIFIC boundary (per-emb).
+        # "fused" auto-falls back to "a" when the streams are already on different
+        # grids (a chunker below split them), where elementwise fusion is undefined.
+        self.route_on = str(route_on)
+        self.separate_boundaries = bool(separate_boundaries)
+        if self.route_on in ("a", "s"):
+            self.solo_a = nn.Linear(d_a, d_router, bias=False)
+            if d_router == int(d_a):
+                with torch.no_grad():
+                    self.solo_a.weight.copy_(torch.eye(d_router))    # exact route-on-A
+                self.solo_a.weight._no_reinit = True
+            else:
+                nn.init.normal_(self.solo_a.weight, mean=0.0, std=0.02)
+            # S needs a REAL init here (the fused path's proj_s is zero-init, which
+            # would make a solo-S router read a constant zero signal).
+            self.solo_s = nn.Linear(d_s, d_router, bias=False)
+            nn.init.normal_(self.solo_s.weight, mean=0.0, std=0.02)
+
+    def _fuse(self, A, S, s_side: bool = False):
+        """Fuse A+S into the router's working representation.
+
+        ``s_side=True`` uses the SPECIFIC-stream head's own (initially identical)
+        parameters. Factored out so both heads share one code path.
+        """
+        if self.fusion == "residual_mlp":
+            if s_side:
+                return self.mixer_s2(self.proj_a_s2(A), self.proj_s_s2(S))
+            return self.mixer(self.proj_a(A), self.proj_s(S))
+        if s_side:
+            return self.fuse_s2(torch.cat([A, S], dim=-1))
+        return self.fuse(torch.cat([A, S], dim=-1))
+
     @staticmethod
     def _build_mlp(d_in, d_out, n_layers, hidden):
         layers = [nn.Linear(d_in, hidden), nn.GELU()]
@@ -140,17 +181,35 @@ class DualStreamRouter(nn.Module):
         layers += [nn.Linear(hidden, d_out)]
         return nn.Sequential(*layers)
 
-    def forward(self, A, S, cu_seqlens=None, max_seqlen=None):
-        if self.fusion == "residual_mlp":
-            h = self.mixer(self.proj_a(A), self.proj_s(S))   # <- enters the cosine
-        else:  # "mlp": pure MLP over concat[A, S]
-            h = self.fuse(torch.cat([A, S], dim=-1))
+    def forward(self, A, S, cu_seqlens=None, max_seqlen=None, cu_seqlens_s=None):
+        """Emit ONE boundary; ``route_on`` picks what enters the cossim core."""
+        mode = self.route_on
+        if mode == "fused" and A.shape[0] != S.shape[0]:
+            # Grids already split -> elementwise fusion is undefined. Routing on
+            # A alone is the right semantics, but solo_a only EXISTS when the
+            # caller asked for it: constructing it here would add parameters
+            # after the optimizer was built and change the state_dict.
+            if not hasattr(self, "solo_a"):
+                raise ValueError(
+                    "DualStreamRouter: streams are on different grids "
+                    "(A has %d tokens, S has %d) so route_on='fused' cannot "
+                    "fuse them, but this router was built without solo_a. "
+                    "Set route_on='a' on this chunker level -- e.g. a flat_s "
+                    "chunker below another chunker, where A is chunked and S "
+                    "is still at frame rate." % (A.shape[0], S.shape[0]))
+            mode = "a"
+        if mode == "a":
+            h, cu_use = self.solo_a(A), cu_seqlens
+        elif mode == "s":
+            h = self.solo_s(S)
+            cu_use = cu_seqlens_s if cu_seqlens_s is not None else cu_seqlens
+        else:
+            h, cu_use = self._fuse(A, S), cu_seqlens
         if self.router_pre is not None:
-            # Private causal transform of the fused stream for the router only.
             if self.router_pre_detach:
                 h = h.detach()
-            h = self.router_pre(h, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
-        return self.router(h, cu_seqlens=cu_seqlens)
+            h = self.router_pre(h, cu_seqlens=cu_use, max_seqlen=max_seqlen)
+        return self.router(h, cu_seqlens=cu_use)
 
 
 class DualStreamChunkerStage(_BaseStage):
@@ -173,6 +232,7 @@ class DualStreamChunkerStage(_BaseStage):
         cond_key: Optional[str] = None,
         embodiments: Optional[List[str]] = None,
         dual_router: bool = True,
+        separate_boundaries: bool = False,
         router_per_emb: bool = True,
         router_fusion: str = "residual_mlp",
         d_router: Optional[int] = None,
@@ -205,6 +265,15 @@ class DualStreamChunkerStage(_BaseStage):
         #     ("emb-specific"); else ONE shared router ("combined"). chunk/dechunk
         #     ops are parameterless + shared. ---
         self.dual_router = bool(dual_router)
+        # NOTE: per-stream boundaries are implemented in the LIVE pyramid class
+        # ``stages_hnet.DualChunkerLevel``. This older stage does not implement the
+        # two-grid chunk/dechunk, so fail loudly rather than silently ignoring it.
+        if separate_boundaries:
+            raise NotImplementedError(
+                "separate_boundaries is implemented in stages_hnet.DualChunkerLevel, "
+                "not DualStreamChunkerStage. Use the DualChunkerLevel pyramid."
+            )
+        self.separate_boundaries = bool(separate_boundaries)
         self.router_per_emb = bool(router_per_emb)
         if self.dual_router:
             router_embs = self._embs if self.router_per_emb else None
@@ -214,7 +283,8 @@ class DualStreamChunkerStage(_BaseStage):
                                          router_pre_detach=router_pre_detach,
                                          n_layers=router_mixer_n_layers,
                                          fusion=router_fusion,
-                                         hidden_mult=router_hidden_mult),
+                                         hidden_mult=router_hidden_mult,
+                                         separate_boundaries=separate_boundaries),
                 router_embs,
             )
         else:

--- a/egomimic/models/hnet/multi_stream_trunk.py
+++ b/egomimic/models/hnet/multi_stream_trunk.py
@@ -67,6 +67,16 @@ def _sdpa(q, k, v, mask, dropout, training):
 _pick = pick  # backward-compatible alias
 
 
+def _per_stream(x, i):
+    """Return the per-stream element when ``x`` is a list/tuple, else ``x`` itself.
+
+    Lets ``mask``/``rope_positions`` be EITHER one shared tensor (legacy: every
+    stream on the same token grid) OR one per stream (per-stream chunk
+    boundaries, where A and S have different lengths).
+    """
+    return x[i] if isinstance(x, (list, tuple)) else x
+
+
 class IntraStreamModule(nn.Module):
     """Self-attention + SwiGLU MLP within ONE stream (its own d_model)."""
 
@@ -205,12 +215,27 @@ class MultiStreamBlock(nn.Module):
         })
 
     def forward(self, xs: List[torch.Tensor], mask, rope_positions, emb_id: Optional[str] = None):
-        xs = [pick(self.intra[i], emb_id)(xs[i], mask, rope_positions) for i in range(len(xs))]
+        xs = [pick(self.intra[i], emb_id)(xs[i], _per_stream(mask, i),
+                                          _per_stream(rope_positions, i))
+              for i in range(len(xs))]
         post_intra = list(xs)  # snapshot -> order-independent comm
         for i, srcs in enumerate(self.adjacency):
             if srcs:
+                # Cross-stream attention is only defined when the source and query
+                # streams live on the SAME token grid. With per-stream chunk
+                # boundaries (separate_boundaries) the grids differ, so the model
+                # must be configured with no inter-stream comm at chunk resolution.
+                if any(post_intra[j].shape[0] != post_intra[i].shape[0] for j in srcs):
+                    raise ValueError(
+                        "cross-stream attention needs equal stream lengths "
+                        f"(stream {i}: {post_intra[i].shape[0]}, sources: "
+                        f"{[post_intra[j].shape[0] for j in srcs]}). With per-stream "
+                        "boundaries set adjacency=[[], []] so the streams stay "
+                        "independent while chunked and rejoin after dechunk."
+                    )
                 inter = pick(self.inter[str(i)], emb_id)
-                xs[i] = inter(post_intra[i], [post_intra[j] for j in srcs], mask, rope_positions)
+                xs[i] = inter(post_intra[i], [post_intra[j] for j in srcs],
+                              _per_stream(mask, i), _per_stream(rope_positions, i))
         return xs
 
 
@@ -267,14 +292,25 @@ class MultiStreamTrunk(nn.Module):
 
     def forward(self, xs: List[torch.Tensor], mask, rope_positions,
                 emb_id: Optional[str] = None,
-                cond: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+                cond: Optional[torch.Tensor] = None,
+                layer_masks: Optional[List] = None) -> List[torch.Tensor]:
+        """layer_masks: optional ONE MASK PER BLOCK (len == n_layers) so a level
+        can give block 0 a narrow window and the rest full history. None
+        (default) => every block uses `mask`, byte-identical to before. Each
+        entry follows the same convention as `mask` (one tensor, or one per
+        stream)."""
+        if layer_masks is not None and len(layer_masks) != len(self.blocks):
+            raise ValueError(
+                "layer_masks has %d entries but the trunk has %d blocks -- "
+                "one mask per block." % (len(layer_masks), len(self.blocks)))
         for li, blk in enumerate(self.blocks):
             if cond is not None and self.adaln_dim:
                 for i in range(1, len(xs)):
                     g, b = self.adaln[li][i - 1](cond).chunk(2, -1)
                     xs = list(xs)
                     xs[i] = xs[i] * (1 + g) + b
-            xs = blk(xs, mask, rope_positions, emb_id)
+            xs = blk(xs, mask if layer_masks is None else layer_masks[li],
+                     rope_positions, emb_id)
         return [pick(self.norm_f[i], emb_id)(xs[i]) for i in range(len(xs))]
 
 

--- a/egomimic/models/stems/cond_encoders.py
+++ b/egomimic/models/stems/cond_encoders.py
@@ -51,6 +51,7 @@ class CondEncoderModule(nn.Module):
         d_cond: int,
         obs_specs: Optional[Dict[str, dict]] = None,
         img_encoders: Optional[Dict[str, nn.Module]] = None,
+        strict_keys: bool = True,
         cond_proj_widths: Optional[List[int]] = None,
         output_key: str = "fused_cond",
         per_obs_keys: bool = False,
@@ -61,6 +62,7 @@ class CondEncoderModule(nn.Module):
         self.per_obs_keys = per_obs_keys
 
         obs_specs = obs_specs or {}
+        self.strict_keys = bool(strict_keys)
         self.obs_keys = sorted(obs_specs.keys())
         self.obs_encoders = nn.ModuleDict()
         # Optional per-key input slice: spec["input_slice"] = [start, end] picks
@@ -118,6 +120,15 @@ class CondEncoderModule(nn.Module):
 
         for key in self.obs_keys:
             if key not in obs:
+                if self.strict_keys:
+                    raise KeyError(
+                        f"CondEncoderModule: declared obs key {key!r} is not in "
+                        f"the batch (have: {sorted(obs)[:12]}). Silently skipping "
+                        f"it would train this encoder on the remaining inputs "
+                        f"only -- e.g. vision with no proprio -- with no error. "
+                        f"Check the KEY_MAP ALIAS (transforms and encoders see "
+                        f"aliases, not zarr paths), or pass strict_keys=False if "
+                        f"the key really is optional.")
                 continue
             x = obs[key]
             if key in self.obs_input_slices:

--- a/egomimic/pipeline/confidence_ssl.py
+++ b/egomimic/pipeline/confidence_ssl.py
@@ -1,0 +1,251 @@
+"""Confidence-side predictive supervision for H-Net chunker levels.
+
+The online view is the dechunked A stream multiplied by the chunker's
+straight-through selected confidence. Its forward value is unchanged, while
+its backward pass gives the router a signed ``(2 * boundary - 1)`` signal.
+Targets are detached so the auxiliary task cannot move its own goalposts.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Dict
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _pool_by_boundaries(
+    values: torch.Tensor,
+    boundary_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Mean-pool packed frame values into the hard chunks in ``boundary_mask``."""
+    if values.ndim != 2:
+        raise ValueError(f"values must have shape (T, D), got {tuple(values.shape)}")
+    boundary_mask = boundary_mask.reshape(-1).to(device=values.device, dtype=torch.bool)
+    if boundary_mask.numel() != values.shape[0]:
+        raise ValueError("boundary_mask and values must have the same token length")
+
+    n_chunks = int(boundary_mask.sum())
+    if n_chunks == 0:
+        return values.new_empty((0, values.shape[-1]))
+
+    chunk_ids = boundary_mask.long().cumsum(dim=0) - 1
+    if bool((chunk_ids < 0).any()):
+        raise ValueError("the first packed token must be a forced boundary")
+
+    sums = values.new_zeros((n_chunks, values.shape[-1]))
+    sums.index_add_(0, chunk_ids, values)
+    counts = values.new_zeros((n_chunks,))
+    counts.index_add_(0, chunk_ids, torch.ones_like(chunk_ids, dtype=values.dtype))
+    return sums / counts.clamp_min(1).unsqueeze(-1)
+
+
+def _chunk_episode_ids(chunk_cu_seqlens: torch.Tensor) -> torch.Tensor:
+    lengths = (chunk_cu_seqlens[1:] - chunk_cu_seqlens[:-1]).long()
+    return torch.repeat_interleave(
+        torch.arange(lengths.numel(), device=lengths.device),
+        lengths,
+    )
+
+
+def _mlp(d_in: int, d_hidden: int, d_out: int) -> nn.Sequential:
+    return nn.Sequential(
+        nn.Linear(d_in, d_hidden),
+        nn.LayerNorm(d_hidden),
+        nn.GELU(),
+        nn.Linear(d_hidden, d_out),
+    )
+
+
+class ConfidenceSSLHead(nn.Module):
+    """JEPA-style next-chunk prediction on a chunker's confidence-side output."""
+
+    def __init__(
+        self,
+        d_model: int,
+        proj_dim: int = 256,
+        hidden_dim: int | None = None,
+        ema_tau: float = 0.99,
+        temperature: float = 0.1,
+        vic_target_std: float = 1.0,
+        enable_pred: bool = True,
+        enable_id: bool = True,
+        enable_vic: bool = True,
+    ):
+        super().__init__()
+        d_model = int(d_model)
+        proj_dim = int(proj_dim)
+        hidden_dim = int(hidden_dim or max(d_model, proj_dim))
+        if not 0.0 <= ema_tau <= 1.0:
+            raise ValueError(f"ema_tau must be in [0, 1], got {ema_tau}")
+        if temperature <= 0:
+            raise ValueError(f"temperature must be positive, got {temperature}")
+
+        self.ema_tau = float(ema_tau)
+        self.temperature = float(temperature)
+        self.vic_target_std = float(vic_target_std)
+        self.enable_pred = bool(enable_pred)
+        self.enable_id = bool(enable_id)
+        self.enable_vic = bool(enable_vic)
+        if not (self.enable_pred or self.enable_id or self.enable_vic):
+            raise ValueError("at least one confidence SSL term must be enabled")
+
+        self.online_projector = _mlp(d_model, hidden_dim, proj_dim)
+        self.predictor = (
+            _mlp(proj_dim, hidden_dim, proj_dim)
+            if self.enable_pred or self.enable_id
+            else None
+        )
+        self.identity_projector = (
+            _mlp(d_model, hidden_dim, proj_dim)
+            if self.enable_id
+            else None
+        )
+        self.target_projector = (
+            copy.deepcopy(self.online_projector)
+            if self.enable_pred
+            else None
+        )
+        if self.target_projector is not None:
+            self.target_projector.requires_grad_(False)
+
+    @torch.no_grad()
+    def update_target(self) -> None:
+        """EMA-update the stop-gradient target from the online projector."""
+        if self.target_projector is None:
+            return
+        tau = self.ema_tau
+        for target, online in zip(
+            self.target_projector.parameters(),
+            self.online_projector.parameters(),
+        ):
+            target.mul_(tau).add_(online, alpha=1.0 - tau)
+        for target, online in zip(
+            self.target_projector.buffers(),
+            self.online_projector.buffers(),
+        ):
+            target.copy_(online)
+
+    def forward(
+        self,
+        confidence_frames: torch.Tensor,
+        latent_frames: torch.Tensor,
+        raw_frames: torch.Tensor,
+        boundary_mask: torch.Tensor,
+        chunk_cu_seqlens: torch.Tensor,
+    ) -> Dict[str, torch.Tensor]:
+        """Return unweighted prediction, identity, and variance losses.
+
+        ``confidence_frames`` is gradient-live through the selected confidence.
+        The latent and raw targets are detached inside this method.
+        """
+        if self.training and self.target_projector is not None:
+            self.update_target()
+
+        chunk_cu = chunk_cu_seqlens.to(
+            device=confidence_frames.device,
+            dtype=torch.long,
+        )
+        zero = confidence_frames.sum() * 0.0
+        n_chunks = int(boundary_mask.sum())
+        if n_chunks == 0:
+            # Keep enabled trainable heads visible to DDP on degenerate packs.
+            for module in (
+                self.online_projector,
+                self.predictor,
+                self.identity_projector,
+            ):
+                if module is not None:
+                    zero = zero + sum(p.sum() * 0.0 for p in module.parameters())
+            return {
+                "pred": zero,
+                "id": zero,
+                "vic": zero,
+                "n_chunks": zero.detach(),
+                "n_pairs": zero.detach(),
+            }
+        if int(chunk_cu[-1]) != n_chunks:
+            raise ValueError(
+                f"chunk_cu_seqlens ends at {int(chunk_cu[-1])}, "
+                f"but boundary_mask contains {n_chunks} chunks"
+            )
+
+        online_frame_z = self.online_projector(confidence_frames.float())
+        online_chunks = _pool_by_boundaries(online_frame_z, boundary_mask)
+
+        target_chunks = None
+        if self.target_projector is not None:
+            with torch.no_grad():
+                target_frame_z = self.target_projector(latent_frames.detach().float())
+                target_chunks = _pool_by_boundaries(target_frame_z, boundary_mask)
+        identity_chunks = None
+        if self.identity_projector is not None:
+            identity_frame_z = self.identity_projector(raw_frames.detach().float())
+            identity_chunks = _pool_by_boundaries(identity_frame_z, boundary_mask)
+
+        episode_ids = _chunk_episode_ids(chunk_cu)
+        if episode_ids.numel() != n_chunks:
+            raise ValueError("chunk_cu_seqlens is inconsistent with boundary_mask")
+
+        if n_chunks > 1:
+            src = torch.arange(n_chunks - 1, device=confidence_frames.device)
+            src = src[episode_ids[:-1] == episode_ids[1:]]
+        else:
+            src = torch.empty(0, device=confidence_frames.device, dtype=torch.long)
+        tgt = src + 1
+
+        predicted = None
+        if self.predictor is not None:
+            # An empty tensor still connects predictor parameters to a zero
+            # loss, which avoids DDP unused-parameter failures on short packs.
+            predicted = F.normalize(self.predictor(online_chunks[src]), dim=-1)
+
+        if self.enable_pred and src.numel():
+            target = F.normalize(target_chunks[tgt], dim=-1)
+            pred_loss = (2.0 - 2.0 * (predicted * target).sum(dim=-1)).mean()
+        elif self.enable_pred:
+            pred_loss = predicted.sum() * 0.0
+        else:
+            pred_loss = zero
+
+        if self.enable_id and src.numel():
+            identities = F.normalize(identity_chunks, dim=-1)
+            logits = predicted @ identities.transpose(0, 1)
+            logits = logits / self.temperature
+
+            # The positive is the next chunk. Only chunks from other episodes
+            # act as negatives, avoiding false negatives within one trajectory.
+            allowed = episode_ids.unsqueeze(0) != episode_ids[src].unsqueeze(1)
+            allowed[torch.arange(src.numel(), device=src.device), tgt] = True
+            has_negative = allowed.sum(dim=1) > 1
+            if bool(has_negative.any()):
+                masked = logits[has_negative].masked_fill(
+                    ~allowed[has_negative],
+                    torch.finfo(logits.dtype).min,
+                )
+                id_loss = F.cross_entropy(masked, tgt[has_negative])
+            else:
+                id_loss = predicted.sum() * 0.0 + identity_chunks.sum() * 0.0
+        elif self.enable_id:
+            id_loss = predicted.sum() * 0.0 + identity_chunks.sum() * 0.0
+        else:
+            id_loss = zero
+
+        if self.enable_vic and online_frame_z.shape[0] > 1:
+            std = torch.sqrt(
+                online_frame_z.var(dim=0, unbiased=False) + 1e-4
+            )
+            vic_loss = F.relu(self.vic_target_std - std).mean()
+        elif self.enable_vic:
+            vic_loss = online_frame_z.sum() * 0.0
+        else:
+            vic_loss = zero
+
+        return {
+            "pred": pred_loss,
+            "id": id_loss,
+            "vic": vic_loss,
+            "n_chunks": zero.new_tensor(float(n_chunks)),
+            "n_pairs": zero.new_tensor(float(src.numel())),
+        }

--- a/egomimic/pipeline/stages_flow.py
+++ b/egomimic/pipeline/stages_flow.py
@@ -30,6 +30,18 @@ from egomimic.models.diffusion.denoising_nets import SinusoidalPosEmb
 from egomimic.pipeline.core import Stage
 
 
+class _ResidualMLPBlock(nn.Module):
+    """Pre-norm residual hidden block for deeper per-embodiment adapters."""
+
+    def __init__(self, width: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(int(width))
+        self.proj = nn.Linear(int(width), int(width))
+
+    def forward(self, x):
+        return x + self.proj(F.silu(self.norm(x)))
+
+
 class _DualStreamBlock(nn.Module):
     """One denoiser block: joint masked attention over [A-tokens | S-tokens]
     (separate per-stream QKV/out to a shared attention dim, trunk idiom) +
@@ -82,7 +94,7 @@ class DualStreamDenoiser(nn.Module):
     def __init__(self, d_a_in: int, d_s_in: int, action_dim: int, chunk_len: int,
                  embodiments: List[str], d_model_a: int = 256, d_model_s: int = 128,
                  n_layers: int = 4, n_heads: int = 4, ffn_mult: int = 4,
-                 mask_mode: str = "asym", n_positions: Optional[int] = None):
+                 mask_mode: str = "sym", n_positions: Optional[int] = None):
         super().__init__()
         C, D = int(chunk_len), int(action_dim)
         L = int(n_positions) if n_positions else C
@@ -151,13 +163,15 @@ class FlowHead(Stage):
                  embodiments: Optional[List[str]] = None,
                  d_model_a: int = 256, d_model_s: int = 128,
                  n_layers: int = 4, n_heads: int = 4, ffn_mult: int = 4,
-                 mask_mode: str = "asym", num_inference_steps: int = 20,
-                 time_dist: str = "beta"):
+                 mask_mode: str = "sym", num_inference_steps: int = 20,
+                 time_dist: str = "beta", denoiser_arch: str = "additive"):
         super().__init__()
         self.C, self.D = int(chunk_len), int(action_dim)
         self.N = int(num_inference_steps)
         self.time_dist = str(time_dist)
-        self.net = DualStreamDenoiser(
+        _cls = (DualStreamDenoiserV2 if str(denoiser_arch) == "adaln"
+                else DualStreamDenoiser)
+        self.net = _cls(
             d_a_in=d_a, d_s_in=d_s, action_dim=action_dim, chunk_len=chunk_len,
             embodiments=list(embodiments) if embodiments else ["shared"],
             d_model_a=d_model_a, d_model_s=d_model_s, n_layers=n_layers,
@@ -238,10 +252,14 @@ class SDPHead(Stage):
                  regime_weights: Optional[List[float]] = None,  # [chunkwise, constant, random]
                  d_model_a: int = 256, d_model_s: int = 128,
                  n_layers: int = 4, n_heads: int = 4, ffn_mult: int = 4,
-                 mask_mode: str = "asym", end_mode: str = "masked",
+                 mask_mode: str = "sym", end_mode: str = "masked",
                  denoiser_arch: str = "additive",
+                 detach_offregime: bool = False,
                  action_dims: Optional[dict] = None, latent_dim: Optional[int] = None,
-                 dual_stream: bool = True, enc_hidden: int = 256):
+                 dual_stream: bool = True, enc_hidden=256, enc_layers=3,
+                 enc_residual=False, head_adapter: str = "latent",
+                 adapter_layers: int = 4, adapter_hidden: Optional[int] = None,
+                 enc_per_stream: bool = False):
         super().__init__()
         self.C, self.D, self.K = int(chunk_len), int(action_dim), int(buffer_chunks)
         self.L = self.K * self.C
@@ -250,8 +268,7 @@ class SDPHead(Stage):
         assert self.S % self.K == 0, "num_inference_steps must divide by buffer_chunks"
         self.rw = list(regime_weights) if regime_weights else [0.7, 0.15, 0.15]
         self.end_mode = str(end_mode)
-        if self.end_mode == "pusher_hold":
-            assert self.D == 2, "pusher_hold pad assumes 2D xy actions"
+        self.detach_offregime = bool(detach_offregime)
         self.register_buffer("abar", _cosine_alphas_cumprod(self.N))
         # inference sub-ladder: index j in [0, S) -> train level (descending)
         self.register_buffer(
@@ -263,7 +280,20 @@ class SDPHead(Stage):
         self.Dmap = {e: int((action_dims or {}).get(e, action_dim)) for e in embs}
         self.dual_stream = bool(dual_stream)
         self.rh = action_dims is not None or latent_dim is not None
-        if self.rh:
+        if self.rh and str(head_adapter) == "direct":
+            # DIRECT hetero adapters: per-emb MLPs straight to/from the trunk
+            # width, no common action-width waist. See DualStreamDenoiserHetero.
+            assert self.dual_stream, "head_adapter=direct requires dual_stream"
+            assert str(denoiser_arch) == "adaln", \
+                "head_adapter=direct is implemented on the adaln core only"
+            self.net = DualStreamDenoiserHetero(
+                d_a_in=d_a, d_s_in=d_s, action_dims=self.Dmap,
+                chunk_len=chunk_len, embodiments=embs,
+                d_model_a=d_model_a, d_model_s=d_model_s, n_layers=n_layers,
+                n_heads=n_heads, ffn_mult=ffn_mult, mask_mode=mask_mode,
+                n_positions=self.L, adapter_layers=adapter_layers,
+                adapter_hidden=adapter_hidden)
+        elif self.rh:
             # hetero-action-dim: noise/x_t/loss stay in the ORIGINAL per-emb dim;
             # per-emb 3-layer SiLU E_e (dim_e -> latent) / D_e (latent -> dim_e)
             # wrap a SHARED denoiser core that runs entirely in the latent.
@@ -274,7 +304,8 @@ class SDPHead(Stage):
                 d_model_a=d_model_a, d_model_s=d_model_s, n_layers=n_layers,
                 n_heads=n_heads, ffn_mult=ffn_mult, mask_mode=mask_mode,
                 n_positions=self.L, dual_stream=self.dual_stream,
-                enc_hidden=int(enc_hidden),
+                enc_hidden=enc_hidden, enc_layers=enc_layers,
+                enc_residual=enc_residual, enc_per_stream=enc_per_stream,
                 dual_arch=("adaln" if str(denoiser_arch) == "adaln" else "v1"))
         else:
             net_cls = (DualStreamDenoiserV2 if str(denoiser_arch) == "adaln"
@@ -306,7 +337,7 @@ class SDPHead(Stage):
         rand = torch.randint(0, N, (T, K), device=device)
         lv = torch.where(pick[:, None] == 0, diag,
                          torch.where(pick[:, None] == 1, const, rand))
-        return lv.clamp(0, N - 1)                               # (T, K)
+        return lv.clamp(0, N - 1), pick                          # (T,K),(T,)
 
     # ---------------- packed multi-chunk targets ---------------- #
     def _buffer_targets(self, target, cu, state=None):
@@ -380,16 +411,28 @@ class SDPHead(Stage):
 
         if "target" in batch:                                   # ---- train loss
             cu = batch["cu_seqlens"].to(device=dev, dtype=torch.long)
+            # New PushShapes datasets expose the commanded pusher pose, which
+            # is in the exact same coordinate system as actions. Prefer it for
+            # tail HOLD padding; legacy datasets fall back to actual state.
+            hold_pose = batch.get(
+                "obs/pusher_cmd_pose", batch.get("obs/state_agent_obj")
+            )
             tgt, valid = self._buffer_targets(
-                batch["target"], cu, batch.get("obs/state_agent_obj"))  # (T,K,C,D)
+                batch["target"], cu, hold_pose)                  # (T,K,C,D)
             Dd = tgt.shape[-1]                                  # per-emb action dim
-            lv = self._sample_levels(T, dev)                    # (T,K)
+            lv, pick = self._sample_levels(T, dev)              # (T,K),(T,)
             noise = torch.randn_like(tgt)
             ab = self.abar[lv][..., None, None]                 # (T,K,1,1)
             x_t = ab.sqrt() * tgt + (1 - ab).sqrt() * noise
             t_pos = lv.repeat_interleave(self.C, dim=1).float() # (T,L)
+            if self.detach_offregime:
+                infm = (pick == 0).float()[:, None]          # (T,1) inference-regime mask
+                a_cond = a_top * infm + a_top.detach() * (1 - infm)
+                s_cond = s * infm + s.detach() * (1 - infm)
+            else:
+                a_cond, s_cond = a_top, s
             eps, e_a, e_s = self.net(x_t.reshape(T, self.L, Dd),
-                                     t_pos, a_top, s, emb)
+                                     t_pos, a_cond, s_cond, emb)
             eps = eps.reshape(T, self.K, self.C, Dd)
             m = valid[..., None, None].float()
             loss = ((eps - noise).pow(2) * m).sum() / (
@@ -475,7 +518,7 @@ class DiffusionHead(Stage):
                  num_train_timesteps: int = 100, num_inference_steps: int = 16,
                  d_model_a: int = 256, d_model_s: int = 128,
                  n_layers: int = 4, n_heads: int = 4, ffn_mult: int = 4,
-                 mask_mode: str = "asym"):
+                 mask_mode: str = "sym"):
         super().__init__()
         self.C, self.D = int(chunk_len), int(action_dim)
         self.N, self.S = int(num_train_timesteps), int(num_inference_steps)
@@ -594,18 +637,85 @@ class DualStreamDenoiserV2(DualStreamDenoiser):
             nn.init.zeros_(m.weight)
             nn.init.zeros_(m.bias)
 
-    def forward(self, x_t, t, a_top, s, emb: str):
+    def forward(self, x_t, t, a_top, s, emb: str, x_s=None):
+        # x_s: optional SEPARATE input for the S stream (per-stream codec).
+        # None -> both streams read x_t, the original shared-codec behaviour.
         T, L, _ = x_t.shape
         e = emb if emb in self.in_s else next(iter(self.in_s))
         cA = self.cond_a(a_top)[:, None, :] + self._temb(self.temb_a, t, T, L)
         cS = self.cond_s[e](s)[:, None, :] + self._temb(self.temb_s, t, T, L)
         A = self.in_a(x_t) + self.pos_a[None, :L]
-        S = self.in_s[e](x_t) + self.pos_s[None, :L]
+        S = self.in_s[e](x_t if x_s is None else x_s) + self.pos_s[None, :L]
         allow = self._allow(L, x_t.device)
         for blk in self.blocks:
             A, S = blk(A, S, allow, cA, cS)
         sh, sc = self.fmod_a(cA).chunk(2, -1)
         v_a = self.vout_a(self.norm_fa(A) * (1 + sc) + sh)
+        sh, sc = self.fmod_s(cS).chunk(2, -1)
+        v_s = self.vout_s[e](self.norm_fs(S) * (1 + sc) + sh)
+        return v_a + v_s, v_a, v_s
+
+
+class DualStreamDenoiserHetero(DualStreamDenoiserV2):
+    """Hetero-action-dim denoiser with DIRECT per-embodiment projections.
+
+    Alternative to LatentRHDenoiser. That wrapper keeps the core homogeneous by
+    squeezing every embodiment through a common action-width waist L:
+
+        act_dim_e -> [E_e: 64] -> L -> [core in: d_model] -> L -> [D_e: 64] -> act_dim_e
+
+    with L pinned to max(action_dims), so the adapters' hidden width cannot
+    carry more than L dimensions of information and the per-emb capacity sits
+    behind a choke. Here the adapters instead map STRAIGHT to the trunk width:
+
+        act_dim_e -> [in_a[e] / in_s[e]: MLP] -> d_model_a / d_model_s
+        d_model_* -> [vout_a[e] / vout_s[e]: MLP] -> act_dim_e
+
+    so per-emb capacity is spent against the 256/128-wide trunk and there is no
+    waist. Consequence to be aware of: `in_a` and `vout_a` become PER-EMB (a
+    single Linear cannot span different input widths), so the A stream's input
+    and output projections are no longer shared across embodiments -- only the
+    transformer blocks are. The latent variant kept those two shared.
+    """
+
+    def __init__(self, *args, action_dims: dict, adapter_layers: int = 4,
+                 adapter_hidden: Optional[int] = None, **kw):
+        Dmap = {str(e): int(d) for e, d in dict(action_dims).items()}
+        # build the parent at the widest dim so every non-projection shape is
+        # valid, then replace all four projection banks with per-emb MLPs
+        super().__init__(*args, action_dim=max(Dmap.values()), **kw)
+        dA, dS = self.pos_a.shape[1], self.pos_s.shape[1]
+        self.Dmap = Dmap
+
+        def mlp(d_in: int, d_out: int, hidden: int) -> nn.Sequential:
+            n = max(1, int(adapter_layers))
+            if n == 1:
+                return nn.Sequential(nn.Linear(int(d_in), int(d_out)))
+            layers = [nn.Linear(int(d_in), hidden), nn.SiLU()]
+            for _ in range(n - 2):
+                layers += [nn.Linear(hidden, hidden), nn.SiLU()]
+            layers.append(nn.Linear(hidden, int(d_out)))
+            return nn.Sequential(*layers)
+
+        hA = int(adapter_hidden) if adapter_hidden else dA
+        hS = int(adapter_hidden) if adapter_hidden else dS
+        self.in_a = nn.ModuleDict({e: mlp(Dmap[e], dA, hA) for e in Dmap})
+        self.in_s = nn.ModuleDict({e: mlp(Dmap[e], dS, hS) for e in Dmap})
+        self.vout_a = nn.ModuleDict({e: mlp(dA, Dmap[e], hA) for e in Dmap})
+        self.vout_s = nn.ModuleDict({e: mlp(dS, Dmap[e], hS) for e in Dmap})
+
+    def forward(self, x_t, t, a_top, s, emb: str):
+        T, L, _ = x_t.shape
+        e = emb if emb in self.in_s else next(iter(self.in_s))
+        cA = self.cond_a(a_top)[:, None, :] + self._temb(self.temb_a, t, T, L)
+        cS = self.cond_s[e](s)[:, None, :] + self._temb(self.temb_s, t, T, L)
+        A = self.in_a[e](x_t) + self.pos_a[None, :L]
+        S = self.in_s[e](x_t) + self.pos_s[None, :L]
+        allow = self._allow(L, x_t.device)
+        for blk in self.blocks:
+            A, S = blk(A, S, allow, cA, cS)
+        sh, sc = self.fmod_a(cA).chunk(2, -1)
+        v_a = self.vout_a[e](self.norm_fa(A) * (1 + sc) + sh)
         sh, sc = self.fmod_s(cS).chunk(2, -1)
         v_s = self.vout_s[e](self.norm_fs(S) * (1 + sc) + sh)
         return v_a + v_s, v_a, v_s
@@ -696,12 +806,14 @@ class SingleStreamDenoiserV2(nn.Module):
 
 
 class LatentRHDenoiser(nn.Module):
-    """Hetero-action-dim wrapper: per-embodiment 3-layer SiLU ENCODER E_e
-    (action_dim_e -> latent L) + DECODER D_e (latent L -> action_dim_e) around a
-    SHARED denoiser core that runs ENTIRELY in the latent. Noise, x_t and the
-    loss stay in the ORIGINAL per-emb dim (the head owns that); the core only
-    ever sees the common latent L (RAE: L must be >= the max per-emb noise dim,
-    else the core cannot denoise the largest embodiment).
+    """Hetero-action-dim wrapper: per-embodiment ENCODER E_e
+    (action_dim_e -> latent L) + DECODER D_e (latent L -> action_dim_e) around
+    a SHARED denoiser core that runs ENTIRELY in the latent. Adapter width,
+    depth, and residual mode may be scalars (legacy/same for every embodiment)
+    or mappings keyed by embodiment. Noise, x_t and the loss stay in the
+    ORIGINAL per-emb dim (the head owns that); the core only ever sees the
+    common latent L (RAE: L must be >= the max per-emb noise dim, else the core
+    cannot denoise the largest embodiment).
 
     dual_stream=True  : core = DualStreamDenoiserV2 (A shared / S per-emb, additive
         v = v_a + v_s in the latent, vA_frac probe). E_e feeds in_a AND in_s[e];
@@ -717,27 +829,52 @@ class LatentRHDenoiser(nn.Module):
                  chunk_len: int, embodiments: List[str],
                  d_model_a: int = 256, d_model_s: int = 192,
                  n_layers: int = 4, n_heads: int = 4, ffn_mult: int = 4,
-                 mask_mode: str = "asym", n_positions: Optional[int] = None,
-                 dual_stream: bool = True, enc_hidden: int = 256,
-                 dual_arch: str = "adaln"):
+                 mask_mode: str = "sym", n_positions: Optional[int] = None,
+                 dual_stream: bool = True, enc_hidden=256,
+                 dual_arch: str = "adaln", enc_layers=3,
+                 enc_residual=False, enc_per_stream: bool = False):
         super().__init__()
         self.dual_stream = bool(dual_stream)
+        self.enc_per_stream = bool(enc_per_stream)
         self.latent = int(latent_dim)
         embs = [str(e) for e in embodiments] if embodiments else ["shared"]
         Dmap = {str(e): int(d) for e, d in dict(action_dims).items()}
         assert self.latent >= max(Dmap.values()), (
             f"latent_dim {self.latent} < max action_dim {max(Dmap.values())} "
             f"(RAE: latent must cover the largest per-emb noise dim)")
-        H, L = int(enc_hidden), self.latent
+        L = self.latent
 
-        def _mlp3(d_in, d_out):                  # 3-layer SiLU MLP
-            return nn.Sequential(
-                nn.Linear(int(d_in), H), nn.SiLU(),
-                nn.Linear(H, H), nn.SiLU(),
-                nn.Linear(H, int(d_out)))
+        def _emb_value(value, emb, name, cast):
+            if hasattr(value, "items"):
+                default = value.get("default") if hasattr(value, "get") else None
+                picked = value.get(emb, default)
+                if picked is None:
+                    raise ValueError(f"{name} has no value for embodiment {emb!r}")
+                return cast(picked)
+            return cast(value)
 
-        self.enc = nn.ModuleDict({e: _mlp3(Dmap[e], L) for e in embs})   # E_e
-        self.dec = nn.ModuleDict({e: _mlp3(L, Dmap[e]) for e in embs})   # D_e
+        def _mlp(emb, d_in, d_out):
+            H = _emb_value(enc_hidden, emb, "enc_hidden", int)
+            n_mlp = max(2, _emb_value(enc_layers, emb, "enc_layers", int))
+            residual = _emb_value(enc_residual, emb, "enc_residual", bool)
+            layers = [nn.Linear(int(d_in), H), nn.SiLU()]
+            for _ in range(n_mlp - 2):
+                if residual:
+                    layers.append(_ResidualMLPBlock(H))
+                else:
+                    layers += [nn.Linear(H, H), nn.SiLU()]
+            layers.append(nn.Linear(H, int(d_out)))
+            return nn.Sequential(*layers)
+
+        self.enc = nn.ModuleDict({e: _mlp(e, Dmap[e], L) for e in embs})  # E_e
+        self.dec = nn.ModuleDict({e: _mlp(e, L, Dmap[e]) for e in embs})  # D_e
+        # PER-STREAM codec: each stream gets its own view of the action instead
+        # of sharing one z. enc/dec above are then used for the A stream only.
+        if self.enc_per_stream:
+            if not self.dual_stream:
+                raise ValueError("enc_per_stream requires dual_stream=True")
+            self.enc_s_codec = nn.ModuleDict({e: _mlp(e, Dmap[e], L) for e in embs})
+            self.dec_s_codec = nn.ModuleDict({e: _mlp(e, L, Dmap[e]) for e in embs})
 
         if self.dual_stream:
             core_cls = (DualStreamDenoiserV2 if str(dual_arch) == "adaln"
@@ -755,6 +892,14 @@ class LatentRHDenoiser(nn.Module):
 
     def forward(self, x_t, t, a_top, s, emb: str):
         e = emb if emb in self.enc else next(iter(self.enc))
+        if self.enc_per_stream:
+            z_a = self.enc[e](x_t)                     # A-stream view
+            z_s = self.enc_s_codec[e](x_t)             # S-stream view
+            _, v_a, v_s = self.core(z_a, t, a_top, s, emb, x_s=z_s)
+            # decode EACH stream with its own decoder, sum in ACTION space
+            d_a = self.dec[e](v_a)
+            d_s = self.dec_s_codec[e](v_s)
+            return d_a + d_s, d_a, d_s
         z = self.enc[e](x_t)                     # (T, L_pos, latent)
         v_lat, v_a, v_s = self.core(z, t, a_top, s, emb)
         v = self.dec[e](v_lat)                   # (T, L_pos, action_dim_e)

--- a/egomimic/pipeline/stages_hnet.py
+++ b/egomimic/pipeline/stages_hnet.py
@@ -33,6 +33,7 @@ from egomimic.models.hnet.routing import ChunkLayer, DeChunkLayer
 from egomimic.models.hnet.stages import _init_isotropic_linears, _ste
 from egomimic.models.hnet.stream_bundle import build_same_episode_causal_mask
 from egomimic.models.hnet.dual_stream_chunker import DualStreamRouter
+from egomimic.pipeline.confidence_ssl import ConfidenceSSLHead
 from egomimic.pipeline.core import Stage, sub_batch
 from egomimic.pipeline import packed
 
@@ -61,6 +62,39 @@ def _ste_scaled(x: torch.Tensor, gain: float) -> torch.Tensor:
 # Levels — nested inside DualstreamTrunk. Each is a Stage (same convention),
 # with `.inner` wired by DualstreamTrunk.
 # --------------------------------------------------------------------------- #
+
+def _norm_window(w, fallback, n_layers):
+    """None -> fallback; int -> int; list/tuple -> list of n_layers ints (each
+    entry may be None = full history for that block)."""
+    if w is None:
+        return fallback
+    # NOTE: hydra hands this over as an omegaconf ListConfig, which is NOT a
+    # list/tuple -- accept any non-string sequence so the yaml path works.
+    if isinstance(w, (list, tuple)) or (
+            hasattr(w, "__iter__") and not isinstance(w, (str, bytes))):
+        w = [None if e is None else int(e) for e in w]
+        if len(w) != int(n_layers):
+            raise ValueError(
+                "attn_window list has %d entries but the level has %d layers."
+                % (len(w), int(n_layers)))
+        return w
+    return int(w)
+
+
+def _masks_for(window, n_tokens, cu, tp, causal, device, n_layers):
+    """One mask, or a per-block list when `window` is a list. Returns
+    (mask, layer_masks) where layer_masks is None in the scalar case."""
+    if not isinstance(window, list):
+        return build_same_episode_causal_mask(n_tokens, cu, tp, causal, device,
+                                              window=window), None
+    cache, per_layer = {}, []
+    for w in window:
+        if w not in cache:
+            cache[w] = build_same_episode_causal_mask(n_tokens, cu, tp, causal,
+                                                      device, window=w)
+        per_layer.append(cache[w])
+    return per_layer[0], per_layer
+
 class DualTrunkLevel(Stage):
     """Dual-stream compute level: MultiStreamTrunk encode -> inner ->
     optional decode-side MultiStreamTrunk (the prenet_decoder split)."""
@@ -73,10 +107,27 @@ class DualTrunkLevel(Stage):
                  embodiments: Optional[List[str]] = None,
                  allow_agnostic_cross: bool = False, decoder_layout=None,
                  adaln_cond: Optional[str] = None, adaln_dim: Optional[int] = None,
-                 ffn_dropout: float = 0.0, attn_window: Optional[int] = None):
+                 ffn_dropout: float = 0.0, attn_window: Optional[int] = None,
+                 attn_window_enc: Optional[int] = None,
+                 attn_window_dec: Optional[int] = None,
+                 stream_keys: Optional[List[str]] = None):
         super().__init__()
         streams_cfg = [dict(s) for s in streams_cfg]
         N = len(streams_cfg)
+        # WHICH batch keys this level's streams are. Default (None) = the
+        # historical ["A", "S"] two-stream level. A single key (e.g. ["A"])
+        # runs the level on that stream alone, so the other stream can be
+        # composed as its own level (see StreamMLP) instead of riding along.
+        # NOTE: in single-stream mode the stream is index 0 = AGNOSTIC, i.e.
+        # SHARED across embodiments even when `embodiments` is given -- that is
+        # correct for ["A"]; a per-emb single stream wants StreamMLP instead.
+        self.stream_keys = [str(k) for k in stream_keys] if stream_keys else ["A", "S"]
+        if len(self.stream_keys) != N:
+            raise ValueError(
+                "DualTrunkLevel: stream_keys %r has %d entries but streams_cfg "
+                "has %d -- one key per stream." % (self.stream_keys, len(self.stream_keys), N))
+        self.reads = list(self.stream_keys) + ["cu_seqlens", "time_pos", "embodiment"]
+        self.writes = list(self.stream_keys)
         if adjacency is None:
             adjacency = ([[j for j in range(N) if j != i] for i in range(N)]
                          if mask_mode == "sym"
@@ -86,6 +137,14 @@ class DualTrunkLevel(Stage):
         # the encode and decode trunks (None = full within-episode history).
         # Apex stays full-history — set this only on non-apex levels.
         self.attn_window = int(attn_window) if attn_window is not None else None
+        # split window: encode trunk vs decode trunk. Default (None) -> the
+        # shared attn_window, so existing configs stay byte-identical.
+        # Either an int (whole trunk) or a LIST of n_layers ints (per block),
+        # so an ablation can window ONLY block 0 -- a 2-token receptive field --
+        # instead of every block, whose windows compound with depth.
+        self._n_layers = int(n_layers)
+        self.attn_window_enc = _norm_window(attn_window_enc, self.attn_window, n_layers)
+        self.attn_window_dec = _norm_window(attn_window_dec, self.attn_window, n_layers)
         self.adaln_cond = str(adaln_cond) if adaln_cond else None
         ad = int(adaln_dim) if (adaln_cond and adaln_dim) else None
         self.trunk = MultiStreamTrunk(streams_cfg, adjacency, n_layers, rotary_emb_dim,
@@ -94,6 +153,7 @@ class DualTrunkLevel(Stage):
                                       allow_agnostic_cross=allow_agnostic_cross,
                                       adaln_dim=ad)
         dec_n = self._dec_layers(decoder_layout)
+        self._n_dec_layers = int(dec_n or 0)
         self.decoder_trunk = (MultiStreamTrunk(streams_cfg, adjacency, dec_n,
                                                rotary_emb_dim, dropout,
                                                ffn_dropout=ffn_dropout,
@@ -112,27 +172,104 @@ class DualTrunkLevel(Stage):
         s = str(layout).strip()
         return int(s[1:] if s[:1] in ("T", "t") else s)
 
+    def _forward_single(self, batch: dict) -> dict:
+        """One stream only (stream_keys has a single entry).
+
+        Same encode -> inner -> decode structure as the two-stream path, minus
+        every per-stream branch that does not apply: no S grid (cu_seqlens_s /
+        time_pos_s), no cross-stream adjacency to honour.
+        """
+        k = self.stream_keys[0]
+        x = batch[k]
+        cu, tp, emb = batch["cu_seqlens"], batch["time_pos"], batch["embodiment"]
+        mask, lmasks = _masks_for(self.attn_window_enc, x.shape[0], cu, tp,
+                                  self.causal, x.device, self._n_layers)
+        rope = tp.to(device=x.device, dtype=torch.long)
+        cond = None
+        if self.adaln_cond and self.adaln_cond in batch:
+            cond = packed.broadcast_per_episode(batch[self.adaln_cond], cu)
+        out = self.trunk([x], mask, rope, emb, cond=cond, layer_masks=lmasks)[0]
+        batch[k] = out
+        # chunkviz probe: (level, encoder tokens, None) -- the S slot is None
+        # because this level HAS no second stream. A consumer that assumes a
+        # tensor there fails loudly rather than silently mislabelling A as S.
+        if "aux/trunk_enc" in batch:
+            batch["aux/trunk_enc"].append(
+                (getattr(self, "viz_level_idx", 0), out.detach(), None))
+        if self.inner is not None:
+            batch = self.inner(batch)
+        if self.decoder_trunk is not None:
+            if self.attn_window_dec == self.attn_window_enc:
+                dmask, dlmasks = mask, lmasks
+            else:
+                dmask, dlmasks = _masks_for(self.attn_window_dec, x.shape[0], cu, tp,
+                                            self.causal, x.device, self._n_dec_layers)
+            dout = self.decoder_trunk([batch[k]], dmask, rope, emb, cond=cond,
+                                      layer_masks=dlmasks)[0]
+            batch[k] = dout
+            if "aux/trunk_dec" in batch:
+                batch["aux/trunk_dec"].append(
+                    (getattr(self, "viz_level_idx", 0), dout.detach(), None))
+        return batch
+
     def forward(self, batch: dict) -> dict:
+        if len(self.stream_keys) == 1:
+            return self._forward_single(batch)
         A, S = batch["A"], batch["S"]
         cu, tp, emb = batch["cu_seqlens"], batch["time_pos"], batch["embodiment"]
-        mask = build_same_episode_causal_mask(A.shape[0], cu, tp, self.causal,
-                                              A.device, window=self.attn_window)
+        mask, lmasks = _masks_for(self.attn_window_enc, A.shape[0], cu, tp,
+                                  self.causal, A.device, self._n_layers)
         rope = tp.to(device=A.device, dtype=torch.long)
+        # PER-STREAM BOUNDARIES: when the chunker below gave S its own grid, the
+        # two streams have different lengths, so each needs its OWN mask + rope.
+        # Absent (legacy) => one shared mask/rope, byte-identical to before.
+        cu_s, tp_s = batch.get("cu_seqlens_s"), batch.get("time_pos_s")
+        if cu_s is not None and tp_s is not None:
+            if isinstance(self.attn_window_enc, list):
+                raise NotImplementedError(
+                    "per-block attn_window is not supported together with "
+                    "per-stream chunk boundaries (separate_boundaries).")
+            mask_s = build_same_episode_causal_mask(S.shape[0], cu_s, tp_s, self.causal,
+                                                   S.device, window=self.attn_window_enc)
+            rope_s = tp_s.to(device=S.device, dtype=torch.long)
+            mask, rope = [mask, mask_s], [rope, rope_s]
         cond = None
         if self.adaln_cond and self.adaln_cond in batch:
             # per-episode z -> per-token at THIS level's resolution (works at
             # every pyramid level: z is episode-constant, cu is this level's).
             cond = packed.broadcast_per_episode(batch[self.adaln_cond], cu)
-        tops = self.trunk([A, S], mask, rope, emb, cond=cond)
-        batch["A"], batch["S"] = tops[0], tops[1]
+        tops = self.trunk([A, S], mask, rope, emb, cond=cond, layer_masks=lmasks)
+        a_out, s_out = tops[0], tops[1]
+        batch["A"], batch["S"] = a_out, s_out
+        # chunkviz probe: the ENCODER-side tokens of this trunk level, i.e. the
+        # representation handed to the chunker/router. Appended in pyramid order
+        # so index 0 is the LOWEST level. Inert unless a caller seeds the list
+        # (only collect_chunkviz does), so training/eval pay nothing.
+        if "aux/trunk_enc" in batch:
+            batch["aux/trunk_enc"].append(
+                (getattr(self, "viz_level_idx", 0), a_out.detach(), s_out.detach()))
         if self.inner is not None:
             batch = self.inner(batch)
         if self.decoder_trunk is not None:
             # decode-side trunk on the chunker's (already residual-mixed) output;
             # same resolution => same mask/rope. No extra residual (the single
             # STE-gated skip lives inside the chunker).
-            douts = self.decoder_trunk([batch["A"], batch["S"]], mask, rope, emb, cond=cond)
+            if self.attn_window_dec == self.attn_window_enc:
+                dmask = mask
+            elif isinstance(mask, list):
+                dmask = [build_same_episode_causal_mask(A.shape[0], cu, tp, self.causal,
+                                                        A.device, window=self.attn_window_dec),
+                         build_same_episode_causal_mask(S.shape[0], cu_s, tp_s, self.causal,
+                                                        S.device, window=self.attn_window_dec)]
+            else:
+                dmask = build_same_episode_causal_mask(A.shape[0], cu, tp, self.causal,
+                                                       A.device, window=self.attn_window_dec)
+            douts = self.decoder_trunk([batch["A"], batch["S"]], dmask, rope, emb, cond=cond)
             batch["A"], batch["S"] = douts[0], douts[1]
+            if "aux/trunk_dec" in batch:
+                batch["aux/trunk_dec"].append(
+                    (getattr(self, "viz_level_idx", 0),
+                     douts[0].detach(), douts[1].detach()))
         return batch
 
     def _init_weights(self, rng: float, parent_residuals: int) -> int:
@@ -162,9 +299,22 @@ class DualChunkerLevel(Stage):
 
     reads = ["A", "S", "cu_seqlens", "max_seq_len", "embodiment", "aux/chunker"]
     writes = ["A", "S", "aux/chunker"]
+    res_scale: float = 1.0  # class default: unpickled pre-knob instances stay inert
+    residual_rank: int = 0  # class default: 0 = full-rank residual_proj (byte-identical)
+    res_anneal_epochs: int = 0  # class default: 0 = no anneal (byte-identical)
+    res_anneal_to: float = 0.05
+    res_anneal_fwd_per_epoch: int = 200
+    res_dropout: bool = True
+    res_grad_scale: float = 1.0
+    # PER-STREAM BOUNDARIES: class default keeps unpickled pre-knob instances inert.
+    separate_boundaries: bool = False
+    ratio_loss_weight_s: float = 0.0
+    target_compression_ratio_s: float = 0.0
 
     def __init__(self, d_a: int, apex_a: int, d_s: Optional[int] = None,
                  apex_s: Optional[int] = None, dual_inner: bool = False,
+                 route_on: Optional[str] = None,
+                 flat_s: bool = False,
                  target_compression_ratio: float = 8.0, ratio_loss_weight: float = 0.03,
                  decisiveness_loss_weight: float = 0.0,
                  spread_loss_weight: float = 0.0, spread_alpha: float = 0.5,
@@ -179,6 +329,16 @@ class DualChunkerLevel(Stage):
                  hard_band_weight: float = 0.0, hard_band_lo: float = 0.25,
                  hard_band_hi: float = 0.45, hard_band_window: int = 12,
                  recon_loss_weight: float = 0.0, recon_hidden_mult: float = 2.0,
+                 confidence_ssl_enable: bool = False,
+                 confidence_ssl_pred_weight: float = 0.0,
+                 confidence_ssl_id_weight: float = 0.0,
+                 confidence_ssl_vic_weight: float = 0.0,
+                 confidence_ssl_proj_dim: int = 256,
+                 confidence_ssl_hidden_dim: Optional[int] = None,
+                 confidence_ssl_ema_tau: float = 0.99,
+                 confidence_ssl_temperature: float = 0.1,
+                 confidence_ssl_vic_target_std: float = 1.0,
+                 confidence_ssl_router_only: bool = False,
                  router_temp: float = 1.0, router_sample: bool = False,
                  cons_loss_weight: float = 0.0, cons_noise_std: float = 0.1,
                  topk_loss_weight: float = 0.0, topk_margin: float = 0.1,
@@ -186,12 +346,28 @@ class DualChunkerLevel(Stage):
                  softrate_vote: str = "sigmoid",
                  softrate_center: float = 0.5,
                  softrate2_weight: float = 0.0, softrate2_center: float = 0.3,
-                 indecision_weight: float = 0.0, indecision_deadzone: float = 0.21):
+                 indecision_weight: float = 0.0, indecision_deadzone: float = 0.21,
+                 res_scale: float = 1.0, residual_rank: int = 0,
+                 res_anneal_epochs: int = 0, res_anneal_to: float = 0.05,
+                 res_anneal_fwd_per_epoch: int = 200,
+                 res_dropout: bool = True,
+                 res_grad_scale: float = 1.0,
+                 separate_boundaries: bool = False,
+                 ratio_loss_weight_s: float = 0.0,
+                 target_compression_ratio_s: float = 0.0,
+                 inner_s=None):
         super().__init__()
         d_s = int(d_s) if d_s is not None else int(d_a)
         apex_s = int(apex_s) if apex_s is not None else d_s
         self.d_a, self.d_s, self.apex_a, self.apex_s = int(d_a), d_s, int(apex_a), apex_s
         self.dual_inner = bool(dual_inner)
+        # flat_s: S skips this chunker entirely (no router/chunk/inner/
+        # dechunk) and stays on the frame-rate grid. A is untouched.
+        self.flat_s = bool(flat_s)
+        # flat_s and dual_inner are ORTHOGONAL: flat_s says S is not chunked
+        # here, dual_inner says the inner chain reads the A/S stream keys
+        # rather than the apex's bare x. Combined, A is chunked into the
+        # inner as "A" while S rides along unchunked as "S".
         self.target_compression_ratio = float(target_compression_ratio)
         self.ratio_loss_weight = float(ratio_loss_weight)
         self.decisiveness_loss_weight = float(decisiveness_loss_weight)
@@ -223,6 +399,32 @@ class DualChunkerLevel(Stage):
                 nn.Linear(int(d_a), _rh), nn.GELU(), nn.Linear(_rh, int(d_a)))
         else:
             self.recon_head = None
+        # Optional confidence-side predictive supervision. With the master
+        # switch off, no module or parameters are constructed and forward does
+        # not add an auxiliary record or loss.
+        self.confidence_ssl_weights = {
+            "pred": float(confidence_ssl_pred_weight),
+            "id": float(confidence_ssl_id_weight),
+            "vic": float(confidence_ssl_vic_weight),
+        }
+        if any(weight < 0 for weight in self.confidence_ssl_weights.values()):
+            raise ValueError("confidence SSL weights must be non-negative")
+        self.confidence_ssl_router_only = bool(confidence_ssl_router_only)
+        self.confidence_ssl = (
+            ConfidenceSSLHead(
+                d_model=int(d_a),
+                proj_dim=int(confidence_ssl_proj_dim),
+                hidden_dim=confidence_ssl_hidden_dim,
+                ema_tau=float(confidence_ssl_ema_tau),
+                temperature=float(confidence_ssl_temperature),
+                vic_target_std=float(confidence_ssl_vic_target_std),
+                enable_pred=self.confidence_ssl_weights["pred"] > 0,
+                enable_id=self.confidence_ssl_weights["id"] > 0,
+                enable_vic=self.confidence_ssl_weights["vic"] > 0,
+            )
+            if confidence_ssl_enable
+            else None
+        )
         # Consistency-under-noise (fence-combat, 2026-07-18): second router
         # pass on input-noised A/S; loss = mean (p1-p2)^2. Near-0.5 probs flip
         # under noise -> penalized; margined probs don't -> free. Manufactures
@@ -244,13 +446,48 @@ class DualChunkerLevel(Stage):
         self.softrate_weight = float(softrate_weight)
         self.softrate_tau = float(softrate_tau)
         self.softrate_center = float(softrate_center)
+        # Bypass narrowing (earn arms, 2026-07-19): scale this level's residual
+        # lanes (A and S) by res_scale before the mixer. <1 makes the bypass
+        # insufficient alone -> the chunk path must carry the output -> seam
+        # boundary quality finally matters to the loss. Default 1.0 = byte-
+        # identical (safe for every existing run on requeue).
+        self.res_scale = float(res_scale)
+        self.residual_rank = int(residual_rank)
+        self.res_anneal_epochs = int(res_anneal_epochs)
+        self.res_anneal_to = float(res_anneal_to)
+        self.res_anneal_fwd_per_epoch = int(res_anneal_fwd_per_epoch)
+        self.res_dropout = bool(res_dropout)
+        self.res_grad_scale = float(res_grad_scale)
+        self.register_buffer("_res_fwd", torch.zeros((), dtype=torch.long), persistent=False)
         self.softrate2_weight = float(softrate2_weight)
         self.softrate_vote = str(softrate_vote)
         self.softrate2_center = float(softrate2_center)
         self.indecision_weight = float(indecision_weight)
         self.indecision_deadzone = float(indecision_deadzone)
 
-        router_embs = self._embs if router_per_emb else None
+        # --- per-stream boundaries -------------------------------------------
+        self.separate_boundaries = bool(separate_boundaries)
+        # S's own ratio loss; fall back to A's setting when unset (0.0).
+        self.ratio_loss_weight_s = (
+            float(ratio_loss_weight_s) if ratio_loss_weight_s else float(ratio_loss_weight))
+        self.target_compression_ratio_s = (
+            float(target_compression_ratio_s) if target_compression_ratio_s
+            else float(target_compression_ratio))
+
+        # PER-STREAM BOUNDARIES layout:
+        #   AGNOSTIC boundary -> ONE router SHARED across embodiments (route_on="a",
+        #     reads the shared A stream only, so sharing introduces no contamination)
+        #   SPECIFIC boundary -> ONE router PER EMBODIMENT (route_on="s")
+        # => 1 + n_emb boundary heads per level (NOT n_emb x 2).
+        # Legacy (separate_boundaries=False): a single fused router, per-emb or not.
+        router_embs = None if separate_boundaries else (self._embs if router_per_emb else None)
+        # ROUTE-ON: what the boundary router reads. Default preserves the
+        # historical derivation. Set explicitly to "a" on any chunker whose two
+        # streams can be on DIFFERENT grids -- e.g. a flat_s chunker below
+        # another chunker, where A arrives chunked and S is still at frame rate.
+        # Fusion is undefined across grids, and the router's own fallback needs
+        # solo_a to have been built (it only is when route_on is "a"/"s").
+        _route_on = str(route_on) if route_on else ("a" if separate_boundaries else "fused")
         self._router = per_emb(
             lambda: DualStreamRouter(d_a, d_s, d_router=d_router,
                                      router_core=router_core,
@@ -260,8 +497,24 @@ class DualChunkerLevel(Stage):
                                      fusion=router_fusion,
                                      hidden_mult=router_hidden_mult,
                                      router_temp=router_temp,
-                                     router_sample=router_sample),
+                                     router_sample=router_sample,
+                                     route_on=_route_on),
             router_embs)
+        # SPECIFIC-stream router: one per embodiment, routes on S.
+        self._router_s = None
+        if separate_boundaries:
+            self._router_s = per_emb(
+                lambda: DualStreamRouter(d_a, d_s, d_router=d_router,
+                                         router_core=router_core,
+                                         router_pre_layout=router_pre_layout,
+                                         router_pre_detach=router_pre_detach,
+                                         n_layers=router_mixer_n_layers,
+                                         fusion=router_fusion,
+                                         hidden_mult=router_hidden_mult,
+                                         router_temp=router_temp,
+                                         router_sample=router_sample,
+                                         route_on="s"),
+                self._embs)
         self.chunk_layer = ChunkLayer()
         self.dechunk_A = DeChunkLayer(d_a)
         self.dechunk_S = DeChunkLayer(d_s)
@@ -274,6 +527,12 @@ class DualChunkerLevel(Stage):
                                  nn.Linear(2 * d_in, d_out))
 
         def _res_proj(d):
+            if self.residual_rank and 0 < self.residual_rank < d:
+                k = int(self.residual_rank)
+                m = nn.Sequential(nn.Linear(d, k), nn.Linear(k, d))
+                nn.init.zeros_(m[1].weight); nn.init.zeros_(m[1].bias)  # start closed
+                m[0].weight._no_reinit = True; m[1].weight._no_reinit = True
+                return m
             rp = nn.Linear(d, d)
             nn.init.zeros_(rp.weight); nn.init.zeros_(rp.bias)
             rp.weight._no_reinit = True
@@ -289,7 +548,11 @@ class DualChunkerLevel(Stage):
         self.proj_out_A = nn.Linear(self.apex_a, d_a) if self.apex_a != d_a else None
 
         # S path (per-emb)
-        s_target = self.apex_s if self.dual_inner else d_s
+        # S goes DEEP when it enters the shared inner (dual_inner) OR when it has
+        # its own apex (inner_s). Either way it is widened to apex_s and projected
+        # back on the way out.
+        _s_deep = bool(dual_inner) or (inner_s is not None)
+        s_target = self.apex_s if _s_deep else d_s
         if self.grab_prev_end:
             self.prev_end_combine_S = per_emb(lambda: _combine(d_s, s_target), self._embs)
             self.no_prev_S = per_emb(lambda: nn.Parameter(torch.randn(d_s) * 0.02), self._embs)
@@ -298,7 +561,16 @@ class DualChunkerLevel(Stage):
             self.proj_in_S = (per_emb(lambda: nn.Linear(d_s, s_target), self._embs)
                               if d_s != s_target else None)
         self.proj_out_S = (per_emb(lambda: nn.Linear(self.apex_s, d_s), self._embs)
-                           if (self.dual_inner and self.apex_s != d_s) else None)
+                           if (_s_deep and self.apex_s != d_s) else None)
+
+        # --- S-APEX: S's OWN deep stack, per-embodiment ------------------------
+        # Hydra instantiates ONE stage from the config; we deep-copy it per
+        # embodiment so each specific stream gets its own weights (S is specific).
+        # None => legacy behaviour (S bypasses the apex at the seam).
+        self.inner_s = None
+        if inner_s is not None:
+            import copy as _copy
+            self.inner_s = per_emb(lambda: _copy.deepcopy(inner_s), self._embs)
 
         self.residual_proj_A = _res_proj(d_a)
         self.residual_proj_S = per_emb(lambda: _res_proj(d_s), self._embs)
@@ -313,14 +585,118 @@ class DualChunkerLevel(Stage):
         prev_end = torch.where(is_start.unsqueeze(-1), no_prev.to(prev_end.dtype), prev_end)
         return combine_mlp(torch.cat([chunked, prev_end], -1).float()).to(chunked.dtype)
 
+    def _forward_flat_s(self, batch: dict, A, S, cu, emb) -> dict:
+        """A takes the full hierarchy; S is left untouched at frame rate."""
+        _cu_s = batch.get("cu_seqlens_s")
+        cu_s_in = (_cu_s.to(device=S.device, dtype=torch.long)
+                   if _cu_s is not None else cu)
+
+        bpred = pick(self._router, emb)(A, S, cu_seqlens=cu,
+                                        max_seqlen=batch["max_seq_len"],
+                                        cu_seqlens_s=cu_s_in)
+        bmask, bprob, sprob = (bpred.boundary_mask, bpred.boundary_prob,
+                               bpred.selected_probs)
+
+        resA = A
+        if self.res_scale is not None:
+            resA = resA * self.res_scale
+
+        A_ch, next_cu, next_max, _ = self.chunk_layer(A, bmask, cu_seqlens=cu)
+        if self.grab_prev_end:
+            A_in = self._combine_prev_end(A_ch, A, bmask, cu,
+                                          self.prev_end_combine_A, self.no_prev_A)
+        else:
+            A_in = self.proj_in_A(A_ch) if self.proj_in_A is not None else A_ch
+
+        S_out = S
+        if self.inner is not None:
+            ctp = _within_episode_time_pos(next_cu, A_in.shape[0], A.device)
+            if self.dual_inner:
+                # A enters chunked as "A"; S rides along UNCHUNKED as "S" with
+                # its own grid, so an inner stream level (trunk or StreamMLP)
+                # can process it at frame rate. No S projection exists on this
+                # path -- flat_s means S's width is untouched here.
+                ms_s = int(batch.get("max_seq_len_s", batch["max_seq_len"]))
+                ib = sub_batch(batch, A=A_in, S=S, cu_seqlens=next_cu,
+                               max_seq_len=int(next_max), time_pos=ctp,
+                               cu_seqlens_s=cu_s_in, max_seq_len_s=ms_s,
+                               time_pos_s=_within_episode_time_pos(
+                                   cu_s_in, S.shape[0], S.device))
+                ib = self.inner(ib)
+                A_inner = self.proj_out_A(ib["A"]) if self.proj_out_A is not None else ib["A"]
+                S_out = ib["S"]
+            else:  # AGNOSTIC SEAM: only A enters the shared apex
+                ib = sub_batch(batch, x=A_in, cu_seqlens=next_cu,
+                               max_seq_len=int(next_max), time_pos=ctp)
+                ib = self.inner(ib)
+                A_inner = self.proj_out_A(ib["x"]) if self.proj_out_A is not None else ib["x"]
+        else:
+            A_inner = A_in
+
+        A_dech = self.dechunk_A(A_inner, bmask, bprob, cu_seqlens=next_cu)
+        batch["A"] = self.residual_mixer_A(
+            A_dech.float() * _ste_scaled(sprob, self.ste_gain), resA).to(A.dtype)
+        # S never passed through a chunker here; its grid is explicitly carried
+        # so downstream levels do not mistake A's chunk grid for S's.
+        batch["S"] = S_out
+        batch["cu_seqlens_s"] = cu_s_in
+        batch["max_seq_len_s"] = int(batch["max_seq_len"]) if _cu_s is None else int(
+            batch.get("max_seq_len_s", batch["max_seq_len"]))
+        # cu_seqlens/max_seq_len stay at the INPUT token space: A was dechunked
+        # back to it just above (resA is the input A), exactly like the non-flat
+        # path, which also leaves them untouched. Advertising the CHUNK grid here
+        # made every downstream consumer index a frame-rate tensor with
+        # chunk-space offsets -> CUDA index-out-of-bounds in the head.
+
+        batch["aux/chunker"].append({
+            "boundary_mask": bmask,
+            "boundary_prob": bprob,
+            "selected_probs": sprob,
+            "cu_seqlens": cu,
+            "chunk_cu_seqlens": next_cu,
+            # TODO(remove-chunker-target): the compression TARGET is loss policy and now lives on
+            # stages_io.RatioLoss(target_ratio=...). This record field is a
+            # DEPRECATED fallback kept only so existing model yamls (which all
+            # set target_compression_ratio here) keep working. Delete this line
+            # and the constructor arg once every yaml sets it on RatioLoss.
+            "target_ratio": self.target_compression_ratio,
+            "ratio_weight": self.ratio_loss_weight,
+            "flat_s": True,          # no S boundary terms exist at this level
+            "separate_boundaries": False,
+            "tokens": A_ch,
+        })
+        return batch
+
+
     def forward(self, batch: dict) -> dict:
         A, S = batch["A"], batch["S"]
         cu = batch["cu_seqlens"].to(device=A.device, dtype=torch.long)
         emb = batch["embodiment"]
+        if getattr(self, "flat_s", False):
+            # ---- FLAT S: chunk A only; S passes straight through ------------
+            # S keeps the incoming (frame-rate) grid, so downstream trunk levels
+            # build S's mask/rope from cu_seqlens_s while A uses its chunk grid.
+            return self._forward_flat_s(batch, A, S, cu, emb)
+        # S's INPUT grid: its own when an earlier chunker split the streams,
+        # otherwise identical to A's (legacy).
+        _cu_s = batch.get("cu_seqlens_s")
+        cu_s_in = (_cu_s.to(device=S.device, dtype=torch.long)
+                   if _cu_s is not None else cu)
 
         bpred = pick(self._router, emb)(A, S, cu_seqlens=cu,
-                                        max_seqlen=batch["max_seq_len"])
+                                        max_seqlen=batch["max_seq_len"],
+                                        cu_seqlens_s=cu_s_in)
+        if self.separate_boundaries:
+            # SHARED agnostic router (above) + PER-EMBODIMENT specific router.
+            bpred_s = pick(self._router_s, emb)(A, S, cu_seqlens=cu,
+                                                max_seqlen=batch["max_seq_len"],
+                                                cu_seqlens_s=cu_s_in)
+        else:
+            bpred_s = bpred                     # same object => identical grids
         bmask, bprob, sprob = bpred.boundary_mask, bpred.boundary_prob, bpred.selected_probs
+        bmask_s = bpred_s.boundary_mask
+        bprob_s = bpred_s.boundary_prob
+        sprob_s = bpred_s.selected_probs
 
         # Consistency-under-noise (see __init__): agreement between this pass
         # and a second pass on input-noised streams. Forced starts are 1.0 in
@@ -338,13 +714,41 @@ class DualChunkerLevel(Stage):
 
         resA = self.residual_proj_A(A.float())
         resS = pick(self.residual_proj_S, emb)(S.float())
+        if self.res_grad_scale != 1.0:
+            _b = self.res_grad_scale
+            resA = _b * resA + (1.0 - _b) * resA.detach()
+            resS = _b * resS + (1.0 - _b) * resS.detach()
+        rs = self.res_scale
+        if self.res_anneal_epochs > 0:
+            if self.training:
+                self._res_fwd += 1
+            _frac = min(1.0, (float(self._res_fwd) / max(1, self.res_anneal_fwd_per_epoch)) / self.res_anneal_epochs)
+            rs = 1.0 + (self.res_anneal_to - 1.0) * _frac
+        if rs != 1.0:
+            # Bypass narrowing as RES-LANE DROPOUT (panel fix, 2026-07-19): a
+            # multiplicative scale on a learned lane is absorbable (proj/mixer
+            # regrow 1/s — empirically verified). A stochastic blackout is not:
+            # train-time, each token's residual lane survives with prob s ==
+            # res_scale (NO inverted rescale — absence is the point), so the
+            # chunk path MUST carry the output on (1-s) of steps. Eval scales
+            # by s to match the train-time expectation deterministically.
+            if self.training and self.res_dropout:
+                keep = (torch.rand(resA.shape[0], 1, device=resA.device)
+                        < rs).float()
+                resA = resA * keep
+                resS = resS * keep
+            else:
+                resA = resA * rs
+                resS = resS * rs
 
         A_ch, next_cu, next_max, _ = self.chunk_layer(A, bmask, cu_seqlens=cu)
-        S_ch, _, _, _ = self.chunk_layer(S, bmask, cu_seqlens=cu)
+        # S chunks on ITS OWN boundary when separate_boundaries; otherwise bmask_s
+        # IS bmask, so this is the same call as before and next_cu_s == next_cu.
+        S_ch, next_cu_s, next_max_s, _ = self.chunk_layer(S, bmask_s, cu_seqlens=cu_s_in)
 
         if self.grab_prev_end:
             A_in = self._combine_prev_end(A_ch, A, bmask, cu, self.prev_end_combine_A, self.no_prev_A)
-            S_in = self._combine_prev_end(S_ch, S, bmask, cu,
+            S_in = self._combine_prev_end(S_ch, S, bmask_s, cu_s_in,
                                           pick(self.prev_end_combine_S, emb),
                                           pick(self.no_prev_S, emb))
         else:
@@ -357,24 +761,76 @@ class DualChunkerLevel(Stage):
             N = A_in.shape[0]
             ctp = _within_episode_time_pos(next_cu, N, A.device)
             if self.dual_inner:
+                extra = {}
+                if self.separate_boundaries:
+                    # S travels on its own grid; the inner trunk builds a second
+                    # mask/rope from these. Streams stay INDEPENDENT while chunked
+                    # (requires adjacency=[[], []]) and rejoin after dechunk.
+                    extra = dict(
+                        cu_seqlens_s=next_cu_s,
+                        max_seq_len_s=int(next_max_s),
+                        time_pos_s=_within_episode_time_pos(
+                            next_cu_s, S_in.shape[0], S.device),
+                    )
                 ib = sub_batch(batch, A=A_in, S=S_in, cu_seqlens=next_cu,
-                               max_seq_len=int(next_max), time_pos=ctp)
+                               max_seq_len=int(next_max), time_pos=ctp, **extra)
                 ib = self.inner(ib)
                 A_inner = self.proj_out_A(ib["A"]) if self.proj_out_A is not None else ib["A"]
                 pOutS = pick(self.proj_out_S, emb) if self.proj_out_S is not None else None
                 S_inner = pOutS(ib["S"]) if pOutS is not None else ib["S"]
-            else:  # AGNOSTIC SEAM: only A enters (apex); S bypasses
+            else:  # AGNOSTIC SEAM: only A enters the shared apex
                 ib = sub_batch(batch, x=A_in, cu_seqlens=next_cu,
                                max_seq_len=int(next_max), time_pos=ctp)
                 ib = self.inner(ib)
                 A_inner = self.proj_out_A(ib["x"]) if self.proj_out_A is not None else ib["x"]
-                S_inner = S_in
+                if self.inner_s is not None:
+                    # S runs its OWN apex on ITS OWN grid -> a genuinely parallel
+                    # hierarchy, instead of a compress/decompress round trip.
+                    ctp_s = _within_episode_time_pos(next_cu_s, S_in.shape[0], S.device)
+                    ib_s = sub_batch(batch, x=S_in, cu_seqlens=next_cu_s,
+                                     max_seq_len=int(next_max_s), time_pos=ctp_s)
+                    ib_s = pick(self.inner_s, emb)(ib_s)
+                    _poS = pick(self.proj_out_S, emb) if self.proj_out_S is not None else None
+                    S_inner = _poS(ib_s["x"]) if _poS is not None else ib_s["x"]
+                else:
+                    S_inner = S_in
         else:
             A_inner, S_inner = A_in, S_in
 
         A_dech = self.dechunk_A(A_inner, bmask, bprob, cu_seqlens=next_cu)
-        S_dech = self.dechunk_S(S_inner if self.dual_inner else S_in, bmask, bprob,
-                                cu_seqlens=next_cu)
+        # S dechunks on its OWN grid -> lands back at level-0 resolution, where the
+        # two streams REJOIN in the residual mixer below. This is why per-stream
+        # boundaries need no realignment machinery downstream.
+        S_dech = self.dechunk_S(S_inner, bmask_s, bprob_s,
+                                cu_seqlens=next_cu_s)
+        confidence_weighted_A = (
+            A_dech.float() * _ste_scaled(sprob, self.ste_gain)
+        )
+
+        confidence_ssl_losses = None
+        confidence_ssl = getattr(self, "confidence_ssl", None)
+        if confidence_ssl is not None:
+            ssl_input = confidence_weighted_A
+            if getattr(self, "confidence_ssl_router_only", False):
+                # Recompute p from detached level inputs, then use the original
+                # hard assignment for the signed selected confidence. This
+                # freezes the encoder path while preserving router gradients.
+                ssl_bpred = pick(self._router, emb)(
+                    A.detach(), S.detach(), cu_seqlens=cu,
+                    max_seqlen=batch["max_seq_len"])
+                ssl_p = ssl_bpred.boundary_prob[..., -1]
+                ssl_selected = torch.where(bmask, ssl_p, 1.0 - ssl_p).unsqueeze(-1)
+                ssl_input = (
+                    A_dech.detach().float()
+                    * _ste_scaled(ssl_selected, self.ste_gain)
+                )
+            confidence_ssl_losses = confidence_ssl(
+                confidence_frames=ssl_input,
+                latent_frames=A_dech,
+                raw_frames=A,
+                boundary_mask=bmask,
+                chunk_cu_seqlens=next_cu,
+            )
 
         # Deep supervision (see __init__): reconstruct the level INPUT from the
         # RAW chunked tokens dechunked back to the input grid. Uses the same
@@ -388,18 +844,39 @@ class DualChunkerLevel(Stage):
                 self.recon_head(_rec.float()), A.float().detach())
 
         batch["A"] = self.residual_mixer_A(
-            A_dech.float() * _ste_scaled(sprob, self.ste_gain), resA).to(A.dtype)
+            confidence_weighted_A, resA).to(A.dtype)
         batch["S"] = pick(self.residual_mixer_S, emb)(
-            S_dech.float() * _ste_scaled(sprob, self.ste_gain), resS).to(S.dtype)
+            S_dech.float() * _ste_scaled(sprob_s, self.ste_gain), resS).to(S.dtype)
 
-        batch["aux/chunker"].append({
+        aux_rec = {
             "boundary_mask": bmask,
             "boundary_prob": bprob,
             "selected_probs": sprob,
             "cu_seqlens": cu,            # THIS level's input token space
             "chunk_cu_seqlens": next_cu,  # chunk space
+            # TODO(remove-chunker-target): the compression TARGET is loss policy and now lives on
+            # stages_io.RatioLoss(target_ratio=...). This record field is a
+            # DEPRECATED fallback kept only so existing model yamls (which all
+            # set target_compression_ratio here) keep working. Delete this line
+            # and the constructor arg once every yaml sets it on RatioLoss.
             "target_ratio": self.target_compression_ratio,
             "ratio_weight": self.ratio_loss_weight,
+            # --- per-stream boundaries: S's own boundary + its own ratio target.
+            # When separate_boundaries is off these mirror the A entries exactly,
+            # and separate_boundaries=False tells consumers to ignore them.
+            "separate_boundaries": self.separate_boundaries,
+            "boundary_mask_s": bmask_s,
+            "boundary_prob_s": bprob_s,
+            "selected_probs_s": sprob_s,
+            "chunk_cu_seqlens_s": next_cu_s,
+            # S's OWN input grid (differs from cu once separate_boundaries has
+            # split the streams upstream). RatioLoss must mask S entries with
+            # THIS, not A's cu -- A's indices can exceed the S tensor length
+            # (crash, job 3622575) or silently mask wrong positions.
+            "cu_seqlens_s": cu_s_in,
+            # TODO(remove-chunker-target): same deprecation as target_ratio above (S stream).
+            "target_ratio_s": self.target_compression_ratio_s,
+            "ratio_weight_s": self.ratio_loss_weight_s,
             "dec_weight": self.decisiveness_loss_weight,
             "spread_weight": self.spread_loss_weight,
             "spread_alpha": self.spread_alpha,
@@ -422,7 +899,11 @@ class DualChunkerLevel(Stage):
             "indecision_weight": self.indecision_weight,
             "indecision_deadzone": self.indecision_deadzone,
             "tokens": A_ch,               # chunkviz PCA reads A tokens ONLY
-        })
+        }
+        if confidence_ssl_losses is not None:
+            aux_rec["confidence_ssl_losses"] = confidence_ssl_losses
+            aux_rec["confidence_ssl_weights"] = self.confidence_ssl_weights
+        batch["aux/chunker"].append(aux_rec)
         return batch
 
     def _init_weights(self, rng: float, parent_residuals: int) -> int:
@@ -457,18 +938,123 @@ class DualChunkerLevel(Stage):
 class ApexLevel(Stage):
     """Agnostic-only apex: one Isotropic stack on the bare A tokens ("x").
     Publishes the apex tokens as "apex/tokens" — the DTW eval / probes read
-    the key; the forward-hook machinery is dead."""
+    the key; the forward-hook machinery is dead.
+
+    ``self_only=True`` removes every temporal edge at the apex by presenting
+    each packed token to the unchanged Isotropic stack as its own length-one
+    sequence. ``attn_window=N`` instead gives every Transformer layer a causal
+    sliding window of N apex tokens, including the current token. The default
+    is the original full within-episode history path.
+    """
 
     reads = ["x", "cu_seqlens", "max_seq_len"]
     writes = ["x", "apex/tokens"]
 
-    def __init__(self, main_network: dict, causal: bool = True):
+    def __init__(
+        self,
+        main_network: dict,
+        causal: bool = True,
+        self_only: bool = False,
+        attn_window: Optional[int] = None,
+    ):
         super().__init__()
-        self.main_network = build_isotropic(dict(main_network), d_cond=0, causal=causal)
+        if self_only and attn_window is not None:
+            raise ValueError(
+                "ApexLevel self_only and attn_window are mutually exclusive"
+            )
+        if attn_window is not None and int(attn_window) < 1:
+            raise ValueError("ApexLevel attn_window must be >= 1")
+        if attn_window is not None and not causal:
+            raise ValueError("ApexLevel attn_window requires causal=True")
+        self.causal = bool(causal)
+        self.self_only = False
+        self.attn_window: Optional[int] = None
+        self.main_network = build_isotropic(
+            dict(main_network),
+            d_cond=0,
+            causal=causal,
+        )
+        initial_mode = (
+            "self" if self_only else "windowed" if attn_window is not None else "full"
+        )
+        self.set_attention_mode(initial_mode, window=attn_window)
+
+    @property
+    def attention_mode(self) -> str:
+        if self.self_only:
+            return "self"
+        if self.attn_window is not None:
+            return "windowed"
+        return "full"
+
+    def set_attention_mode(
+        self,
+        mode: str,
+        *,
+        window: Optional[int] = None,
+    ) -> None:
+        """Switch apex context without changing parameters or state-dict keys.
+
+        ``full`` uses the complete causal history, ``self`` presents every
+        token as a length-one packed sequence, and ``windowed`` gives each
+        Transformer layer the current token plus ``window - 1`` predecessors.
+        The method is deliberately runtime-safe so the same checkpoint can
+        switch regimes per training step and at rollout.
+        """
+        mode = str(mode).lower().replace("-", "_")
+        if mode in {"self_only", "token_local"}:
+            mode = "self"
+        if mode in {"window", "local"}:
+            mode = "windowed"
+        if mode not in {"full", "self", "windowed"}:
+            raise ValueError(
+                f"unknown apex attention mode {mode!r}; "
+                "expected full, self, or windowed"
+            )
+        if mode == "windowed":
+            if window is None or int(window) < 1:
+                raise ValueError("windowed apex attention requires window >= 1")
+            if not self.causal:
+                raise ValueError("windowed apex attention requires causal=True")
+            resolved_window = int(window)
+        else:
+            if window is not None:
+                raise ValueError(f"{mode} apex attention does not accept a window")
+            resolved_window = None
+
+        for block in self.main_network.layers:
+            mixer = getattr(block, "mixer", None)
+            if mixer is None or not hasattr(mixer, "attn_window"):
+                if mode == "windowed":
+                    raise ValueError(
+                        "windowed apex attention requires a transformer-only "
+                        "main_network"
+                    )
+                continue
+            mixer.attn_window = resolved_window
+
+        self.self_only = mode == "self"
+        self.attn_window = resolved_window
 
     def forward(self, batch: dict) -> dict:
-        y = self.main_network(batch["x"], cu_seqlens=batch["cu_seqlens"],
-                              max_seqlen=batch["max_seq_len"])
+        x = batch["x"]
+        cu_seqlens = batch["cu_seqlens"]
+        max_seqlen = batch["max_seq_len"]
+        if self.self_only:
+            # One token per packed subsequence makes attention (or any other
+            # sequence mixer) strictly token-local while leaving the apex
+            # weights, residual blocks, FFNs, and output shape unchanged.
+            cu_seqlens = torch.arange(
+                x.shape[0] + 1,
+                device=x.device,
+                dtype=cu_seqlens.dtype,
+            )
+            max_seqlen = 1
+        y = self.main_network(
+            x,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
         batch["x"] = y
         batch["apex/tokens"] = y
         if "aux/apex" in batch:
@@ -484,6 +1070,133 @@ class ApexLevel(Stage):
 # --------------------------------------------------------------------------- #
 # The pipeline stage: owns the level chain (intrinsic hierarchy stays inside).
 # --------------------------------------------------------------------------- #
+
+class StreamMLP(Stage):
+    """Per-timestep MLP on ONE stream -- a pyramid level with NO temporal mixing.
+
+    Written for the "history through S hurts" hypothesis: the S stream should
+    carry the current frame's embodiment-specific content and nothing else, so
+    the policy cannot lean on S to smuggle in history. This stage is
+    structurally incapable of it -- it never reads ``cu_seqlens`` or
+    ``time_pos``, so no token can reach another token's information. Contrast
+    with a transformer level pinned to ``attn_window=1``: that reaches the same
+    function class through a degenerate one-element attention (qkv projections
+    and a softmax over a single logit), i.e. identical semantics at the cost of
+    the qkv/out parameters and the mask bookkeeping.
+
+    Structure mirrors ``DualTrunkLevel`` so the two compose in one ``levels``
+    chain: ``n_layers`` encoder blocks -> ``self.inner(batch)`` (the rest of the
+    pyramid) -> ``decoder_layers`` decoder blocks. Each block is pre-norm
+    residual ``x <- x + fc2(act(fc1(norm(x))))``.
+
+    Per-embodiment when ``embodiments`` is given (the S stream is the SPECIFIC
+    stream, so this is the normal case); a bare instantiation shares one MLP.
+
+    Args:
+        d_model: stream width. Unchanged across the level (this stage never
+            projects) -- so the chunker above it must leave S's width alone
+            (``flat_s: true`` / no ``apex_s``).
+        n_layers: encoder-side blocks.
+        decoder_layers: decoder-side blocks, applied after ``inner``. None or 0
+            puts every block on the encoder side.
+        d_hidden: block hidden width. Default 4*d_model, matching the
+            ``d_intermediate`` a transformer level of this width would use --
+            note the resulting level is still CHEAPER than that transformer,
+            which also pays qkv+out (~ d_model^2 * 4 per block).
+        stream: which batch key to transform ("S" by default).
+    """
+
+    def __init__(self, d_model: int, n_layers: int = 4,
+                 decoder_layers: Optional[int] = None,
+                 d_hidden: Optional[int] = None,
+                 stream: str = "S",
+                 embodiments: Optional[List[str]] = None,
+                 activation: str = "gelu",
+                 dropout: float = 0.0,
+                 final_norm: bool = True):
+        super().__init__()
+        self.stream = str(stream)
+        self.reads = [self.stream, "embodiment"]
+        self.writes = [self.stream]
+        d_model = int(d_model)
+        d_hidden = int(d_hidden) if d_hidden else 4 * d_model
+        n_enc = int(n_layers)
+        n_dec = int(decoder_layers) if decoder_layers else 0
+        if n_enc < 0 or n_dec < 0:
+            raise ValueError("StreamMLP layer counts must be >= 0")
+        if n_enc + n_dec == 0:
+            raise ValueError("StreamMLP needs at least one block")
+        acts = {"gelu": nn.GELU, "silu": nn.SiLU, "relu": nn.ReLU}
+        if activation not in acts:
+            raise ValueError("StreamMLP activation %r not in %s"
+                             % (activation, sorted(acts)))
+        act = acts[activation]
+
+        def _stack(n):
+            if n == 0:
+                return None
+            return per_emb(lambda: _MLPBlocks(d_model, d_hidden, n, act,
+                                              dropout, final_norm),
+                           embodiments)
+
+        self.encoder = _stack(n_enc)
+        self.decoder = _stack(n_dec)
+        self.n_blocks = n_enc + n_dec
+        object.__setattr__(self, "inner", None)  # wired by DualstreamTrunk
+
+    def forward(self, batch: dict) -> dict:
+        emb = batch["embodiment"]
+        x = batch[self.stream]
+        if self.encoder is not None:
+            x = pick(self.encoder, emb)(x)
+        batch[self.stream] = x
+        if self.inner is not None:
+            batch = self.inner(batch)
+        if self.decoder is not None:
+            batch[self.stream] = pick(self.decoder, emb)(batch[self.stream])
+        return batch
+
+    def _init_weights(self, rng: float, parent_residuals: int) -> int:
+        n = parent_residuals + self.n_blocks
+        scaled = rng / max(n, 1) ** 0.5
+        for name, m in self.named_modules():
+            if not isinstance(m, nn.Linear) or getattr(m.weight, "_no_reinit", False):
+                continue
+            # down-projection of each block gets the depth-scaled std, matching
+            # DualTrunkLevel._init_weights ("fc2" is the block's output linear).
+            std = scaled if "fc2" in name else rng
+            nn.init.normal_(m.weight, mean=0.0, std=std)
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)
+        if self.inner is not None:
+            n = self.inner._init_weights(rng, n)
+        return n
+
+
+class _MLPBlocks(nn.Module):
+    """n pre-norm residual MLP blocks at constant width. Purely per-timestep."""
+
+    def __init__(self, d_model, d_hidden, n, act, dropout, final_norm):
+        super().__init__()
+        def block():
+            return nn.ModuleDict({
+                "norm": nn.LayerNorm(d_model),
+                "fc1": nn.Linear(d_model, d_hidden),
+                "act": act(),
+                "fc2": nn.Linear(d_hidden, d_model),
+            })
+        self.blocks = nn.ModuleList([block() for _ in range(n)])
+        self.drop = nn.Dropout(dropout) if dropout else None
+        self.final = nn.LayerNorm(d_model) if final_norm else None
+
+    def forward(self, x):
+        for b in self.blocks:
+            h = b["fc2"](b["act"](b["fc1"](b["norm"](x))))
+            if self.drop is not None:
+                h = self.drop(h)
+            x = x + h
+        return self.final(x) if self.final is not None else x
+
 class DualstreamTrunk(Stage):
     """The H-Net dual-stream pyramid as ONE pipeline stage.
 
@@ -503,6 +1216,8 @@ class DualstreamTrunk(Stage):
             # every level's params under levels.{i}.inner.* (the old code's
             # nested double-registration pathology — kill it for real).
             object.__setattr__(levels[i], "inner", levels[i + 1])
+        for i, _lv in enumerate(levels):
+            object.__setattr__(_lv, "viz_level_idx", i)
         object.__setattr__(self, "root", levels[0])  # non-registered ref (levels owns them)
         if init_range:
             self.root._init_weights(float(init_range), 0)

--- a/egomimic/pipeline/stages_io.py
+++ b/egomimic/pipeline/stages_io.py
@@ -11,7 +11,7 @@ old raw-params + head.decode() indirection is gone.
 """
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
@@ -70,6 +70,155 @@ class ObsEncoders(Stage):
         batch["A"] = self.agnostic.forward_packed(**kw)
         batch["S"] = S
         batch["time_pos"] = packed.frame_idx(cu)
+        return batch
+
+
+class SharedObsEncoders(Stage):
+    """ONE shared obs encoder feeding BOTH streams (vs ``ObsEncoders``, which
+    builds two fully independent encoders each with its own VisualCore).
+
+    Layout::
+
+        shared encoder (images only, 1 copy)
+              |
+              +-- proj_a   (SHARED)     -> A
+              +-- proj_s   (per-emb)  \\
+              +-- proprio  (per-emb)  /  + -> S
+
+    A is vision-only and embodiment-agnostic. S stays embodiment-specific
+    through a per-embodiment projection of the shared feature PLUS a per-
+    embodiment proprio encoder; the two are summed at width ``d_s``.
+
+    Args:
+        shared:   InputModule (ObsToken) over IMAGES ONLY, width d_shared.
+        proj_a:   Module d_shared -> d_a, shared across embodiments.
+        proj_s:   dict[emb_name -> Module d_shared -> d_s], per embodiment.
+        proprio:  optional InputModule (ObsToken wrapping a
+                  MultiEmbodimentCondEncoder) over PROPRIO ONLY at width d_s.
+                  None disables the proprio path (S = projected vision only).
+
+    Writes the same keys as ``ObsEncoders`` so every downstream stage is
+    unchanged and the two are drop-in swappable in YAML.
+    """
+
+    reads = ["obs/*", "cu_seqlens", "embodiment"]   # actions NOT required (rollout)
+    writes = ["A", "S", "time_pos"]
+
+    def __init__(
+        self,
+        shared: nn.Module,
+        proj_a: nn.Module,
+        proj_s: Dict[str, nn.Module],
+        proprio: Optional[nn.Module] = None,
+    ):
+        super().__init__()
+        if not proj_s:
+            raise ValueError("SharedObsEncoders needs a non-empty proj_s dict "
+                             "(one entry per embodiment).")
+        self.shared = shared
+        self.proj_a = proj_a
+        self.proj_s = nn.ModuleDict(proj_s)
+        self.proprio = proprio
+
+    def forward(self, batch: dict) -> dict:
+        obs_packed = {k.split("/", 1)[1]: v for k, v in batch.items()
+                      if k.startswith("obs/")}
+        ref = next(v for v in obs_packed.values() if torch.is_tensor(v))
+        T, dev = ref.shape[0], ref.device
+        dt = torch.float32 if not ref.is_floating_point() else ref.dtype
+        actions = batch.get("actions")
+        if actions is None:
+            actions = torch.zeros((T, 1), device=dev, dtype=dt)
+        cu = batch["cu_seqlens"].to(device=dev, dtype=torch.long)
+        emb = batch["embodiment"]
+        # episode-consistent crop support (identical to ObsEncoders)
+        for m in self.modules():
+            if getattr(m, "crop_scope", None) == "episode":
+                m._episode_cu = cu
+        kw = dict(actions_packed=actions, obs_packed=obs_packed, cu_seqlens=cu,
+                  T_total=T, device=dev, dtype=actions.dtype,
+                  embodiment_id=emb)
+
+        feat = self.shared.forward_packed(**kw)          # (T, d_shared)
+
+        if emb not in self.proj_s:
+            raise KeyError(
+                f"SharedObsEncoders has no proj_s entry for embodiment {emb!r}; "
+                f"available: {list(self.proj_s.keys())}."
+            )
+        A = self.proj_a(feat)                            # (T, d_a)
+        S = self.proj_s[emb](feat)                       # (T, d_s)
+        if self.proprio is not None:
+            p = self.proprio.forward_packed(**kw)        # (T, d_s)
+            if p.shape != S.shape:
+                raise ValueError(
+                    f"SharedObsEncoders: proprio output {tuple(p.shape)} does not "
+                    f"match projected-vision S {tuple(S.shape)}; set the proprio "
+                    f"encoder's d_cond equal to proj_s out_features."
+                )
+            S = S + p
+
+        batch["A"] = A
+        batch["S"] = S
+        batch["time_pos"] = packed.frame_idx(cu)
+        return batch
+
+
+class DeriveVelocity(Stage):
+    """Finite-difference velocity as a DERIVED obs key (velocity-ablation arm 2).
+
+    v[t] = x[t] - x[t-1] within an episode, v[0] = 0. Written as a new
+    ``obs/<out_key>`` so the obs encoders can consume it like any other proprio
+    input.
+
+    WHY derived instead of a new zarr key: ``state_agent_obj`` is already
+    emitted by BOTH the training keymap and the eval env->zarr converters
+    (``_env_to_zarr_pushshapes`` / ``_usocket``), so deriving from it means
+    train and eval cannot disagree about the key -- the failure mode the
+    handoff doc warns about. It also needs no norm-stats recompute: this stage
+    runs AFTER normalization, so v is a difference of normalized coordinates
+    and is already on a sane scale.
+
+    Place it AFTER ``TargetBuilder`` so the difference is taken between
+    consecutive TOKENS (stride-decimated), which is the same grid the L0
+    attention window sees -- a w=2 window and this key then carry the same
+    information, which is the whole point of the ablation.
+
+    Args:
+        source:  obs key to difference (default ``state_agent_obj``).
+        out_key: obs key to write (default ``agent_vel``).
+        dims:    how many leading components of ``source`` to difference
+                 (2 = pusher xy; 3 = u_socket pusher x,y,theta).
+    """
+
+    reads = ["obs/*", "cu_seqlens"]
+    writes = []          # obs/<out_key>; declared dynamically in __init__
+
+    def __init__(self, source: str = "state_agent_obj",
+                 out_key: str = "agent_vel", dims: int = 2):
+        super().__init__()
+        self.source = str(source)
+        self.out_key = str(out_key)
+        self.dims = int(dims)
+        self.reads = [f"obs/{self.source}", "cu_seqlens"]
+        self.writes = [f"obs/{self.out_key}"]
+
+    def forward(self, batch: dict) -> dict:
+        src = batch.get(f"obs/{self.source}")
+        if src is None:
+            raise KeyError(
+                f"DeriveVelocity: obs/{self.source} not in batch (have "
+                f"{[k for k in batch if k.startswith('obs/')]})")
+        x = src[..., : self.dims]
+        cu = batch["cu_seqlens"].to(device=x.device, dtype=torch.long)
+        v = torch.zeros_like(x)
+        # packed layout: episodes are contiguous spans [cu[i], cu[i+1]).
+        # Difference INSIDE each span so the first token of an episode is 0
+        # and no velocity leaks across an episode boundary.
+        v[1:] = x[1:] - x[:-1]
+        starts = cu[:-1].clamp(min=0, max=max(x.shape[0] - 1, 0))
+        v[starts] = 0.0
+        batch[f"obs/{self.out_key}"] = v
         return batch
 
 
@@ -466,22 +615,108 @@ class CVAEHead(Stage):
 # --------------------------------------------------------------------------- #
 # Regularizer stage
 # --------------------------------------------------------------------------- #
+#: emb id (Embodiment enum) <-> config-friendly name, for per-emb loss targets
+_EMB_ALIAS = {"eva_bimanual": "8", "human_bimanual": "18"}
+
+
 class RatioLoss(Stage):
-    """H-Net chunker ratio loss from the accumulated aux/chunker records."""
+    """H-Net chunker ratio loss from the accumulated aux/chunker records.
+
+    The compression TARGET is loss policy and lives HERE, not on the chunker:
+    the chunker only routes and publishes b_t/p_t. ``target_ratio`` accepts
+
+      * ``None``  -- use the value the chunker recorded (legacy default, exactly
+        reproduces every pre-existing run),
+      * a float   -- one override for all levels,
+      * a dict    -- per embodiment, keyed by id ("8"/"18") or name
+        ("eva_bimanual"/"human_bimanual"), falling back to the recorded value
+        for any embodiment not listed.
+
+    Per-emb targets exist because the streams run at very different speeds: a
+    human fold is 156 frames (5.2 s) and the same robot fold is 1151 frames
+    (38.4 s) at a shared 30 fps, so one ratio gives 17 apex tokens for human and
+    128 for eva -- a 7.4x mismatch on the axis DTW alignment compares.
+    """
 
     reads = ["aux/chunker"]
     writes = ["loss/ratio", "loss/dec", "loss/seam_recon", "loss/cons",
-              "loss/topk", "loss/softrate", "log/*"]
+              "loss/topk", "loss/softrate", "loss/confidence", "log/*"]
+
+    def __init__(self, target_ratio=None, target_ratio_s=None):
+        super().__init__()
+        self.target_ratio = target_ratio
+        self.target_ratio_s = target_ratio_s
+
+    @staticmethod
+    def _is_seq(x):
+        """list / tuple / omegaconf ListConfig -- NOT str, NOT a scalar.
+
+        hydra passes ListConfig and DictConfig, for which isinstance against the
+        native types is False; duck-type instead of enumerating classes."""
+        return (not isinstance(x, (str, bytes, int, float))
+                and hasattr(x, "__len__") and hasattr(x, "__getitem__")
+                and not hasattr(x, "keys"))
+
+    @classmethod
+    def _pick_level(cls, val, level, recorded):
+        """A per-emb entry may be a scalar (all levels) or a per-level sequence."""
+        if cls._is_seq(val):
+            if level is None or level >= len(val):
+                return recorded
+            return float(val[level])
+        return float(val)
+
+    def _target(self, cfg, recorded, batch, level=None):
+        """Resolve the target for this record: loss config wins, else the value
+        the chunker recorded (so an unconfigured stage is byte-identical).
+
+        ``level`` is the chunker's index in aux/chunker (0 = first stage). It
+        matters because the two stages COMPOUND -- 3.0 twice is 9x, not 3x."""
+        if cfg is None:
+            # TODO(remove-chunker-target): DEPRECATED fallback to the chunker-recorded target. Once
+            # every model yaml sets RatioLoss(target_ratio=...), drop this
+            # branch and make the argument required -- a silent fallback is how
+            # a config that MEANT to set a per-emb target but mistyped the key
+            # would quietly train on the old shared 3.0 instead.
+            return recorded
+        if isinstance(cfg, (int, float)):
+            return float(cfg)
+        if self._is_seq(cfg):
+            return self._pick_level(cfg, level, recorded)
+        key = str(batch.get("embodiment", ""))
+        if key in cfg:
+            return self._pick_level(cfg[key], level, recorded)
+        for name, idx in _EMB_ALIAS.items():
+            if idx == key and name in cfg:
+                return self._pick_level(cfg[name], level, recorded)
+        return recorded
 
     def forward(self, batch: dict) -> dict:
-        aux = [{"bpred": _B(rec), "target_ratio": rec["target_ratio"],
+        aux = [{"bpred": _B(rec),
+                "target_ratio": self._target(self.target_ratio,
+                                             rec["target_ratio"], batch, _i),
                 "weight": rec["ratio_weight"], "cu_seqlens": rec["cu_seqlens"]}
-               for rec in batch.get("aux/chunker", [])]
+               for _i, rec in enumerate(batch.get("aux/chunker", []))]
         dev = None
         for rec in batch.get("aux/chunker", []):
             dev = rec["boundary_prob"].device
             break
         batch["loss/ratio"] = ratio_loss_from_aux(aux, device=dev)
+        # PER-STREAM BOUNDARIES: the SPECIFIC stream has its own boundary, so it
+        # needs its own compression regulariser. Only levels that actually enabled
+        # separate_boundaries contribute; otherwise this key is never written and
+        # the loss dict is byte-identical to before.
+        aux_s = [{"bpred": _BS(rec),
+                  "target_ratio": self._target(self.target_ratio_s,
+                                               rec["target_ratio_s"], batch, _i),
+                  # S boundaries live on S's grid; fall back to A's cu for old
+                  # records (pre-fix) where the streams were never split.
+                  "weight": rec["ratio_weight_s"],
+                  "cu_seqlens": rec.get("cu_seqlens_s", rec["cu_seqlens"])}
+                 for rec in batch.get("aux/chunker", [])
+                 if rec.get("separate_boundaries", False)]
+        if aux_s:
+            batch["loss/ratio_s"] = ratio_loss_from_aux(aux_s, device=dev)
         # Decisiveness term: L_dec = mean(1-(2p-1)^2) is 1.0 at p=0.5, 0 at
         # p in {0,1}. Closes the ratio loss's threshold-riding loophole (a
         # point-mass at p=0.5 scores 0.75 < the honest optimum 1.0); with
@@ -491,6 +726,7 @@ class RatioLoss(Stage):
         cons_total = None
         tk_total = None
         srate_total = None
+        confidence_total = None
         _rates = []
         for i, rec in enumerate(batch.get("aux/chunker", [])):
             # Deep-supervision recon term (computed inside DualChunkerLevel —
@@ -514,6 +750,29 @@ class RatioLoss(Stage):
                 batch[f"log/L{i}_cons"] = float(rl_cons)
                 cons_total = (w_cons * rl_cons if cons_total is None
                               else cons_total + w_cons * rl_cons)
+            # Confidence-side predictive supervision is computed inside the
+            # chunker so its graph remains attached to the selected-confidence
+            # STE. Assemble it before the empty-valid continue, as short
+            # episodes can have no unforced tokens while still producing a
+            # well-defined auxiliary result.
+            confidence_losses = rec.get("confidence_ssl_losses")
+            confidence_weights = rec.get("confidence_ssl_weights", {})
+            if confidence_losses is not None:
+                batch[f"log/L{i}_conf_chunks"] = float(
+                    confidence_losses["n_chunks"])
+                batch[f"log/L{i}_conf_pairs"] = float(
+                    confidence_losses["n_pairs"])
+                for name in ("pred", "id", "vic"):
+                    value = confidence_losses[name]
+                    weight = float(confidence_weights.get(name, 0.0))
+                    if weight <= 0:
+                        continue
+                    batch[f"log/L{i}_conf_{name}"] = float(value)
+                    weighted = weight * value
+                    confidence_total = (
+                        weighted if confidence_total is None
+                        else confidence_total + weighted
+                    )
             p_b = rec["boundary_prob"][..., -1]
             valid = torch.ones_like(p_b, dtype=torch.bool)
             valid[rec["cu_seqlens"][:-1]] = False  # exclude forced subseq starts
@@ -531,6 +790,53 @@ class RatioLoss(Stage):
             batch[f"log/L{i}_boundary_rate"] = f_hard
             batch[f"log/L{i}_avg_chunk_len"] = n_tok / max(n_b, 1)
             _rates.append(f_hard)
+            # --- FENCING diagnostics (prob distribution, not the rate) ------
+            # A fenced router and an honest one have the SAME boundary rate;
+            # only the spread of p distinguishes them. Cheap to log, and the
+            # failure is otherwise invisible until a run is wasted.
+            if pv.numel() > 1:
+                # PRIMARY fencing signal (user, 2026-08-01): mean |p - 0.5|.
+                # Distance from the fence, not spread and not a thresholded
+                # count -- a router pinned at 0.5 has absdev ~0 no matter what
+                # boundary RATE it produces, and rate alone cannot see it.
+                batch[f"log/L{i}_prob_absdev"] = float((pv - 0.5).abs().mean())
+                batch[f"log/L{i}_prob_mean"] = float(pv.mean())
+                batch[f"log/L{i}_prob_std"] = float(pv.std())
+                batch[f"log/L{i}_prob_range"] = float(pv.max() - pv.min())
+                batch[f"log/L{i}_fenced_frac"] = float(
+                    ((pv - 0.5).abs() < 0.02).float().mean())
+            # --- SPECIFIC stream: same semantics, own grid ---------------
+            # With separate_boundaries the S router chunks on its OWN grid, so
+            # the A stats above say nothing about it. Without these, a
+            # collapsed or runaway S router is silent until it crashes (the
+            # ratio-loss index OOB) or quietly wastes the run.
+            p_bs = rec.get("boundary_prob_s")
+            if p_bs is not None:
+                p_bs = p_bs[..., -1]
+                cu_s = rec.get("cu_seqlens_s")
+                if cu_s is None:
+                    cu_s = rec["cu_seqlens"]
+                bms = (p_bs > 0.5).clone()
+                if int(cu_s[:-1].max()) < bms.numel():
+                    bms[cu_s[:-1]] = True
+                n_tok_s = max(bms.numel(), 1)
+                n_b_s = int(bms.sum().item())
+                batch[f"log/L{i}_boundary_rate_s"] = n_b_s / n_tok_s
+                batch[f"log/L{i}_avg_chunk_len_s"] = n_tok_s / max(n_b_s, 1)
+                valid_s = torch.ones_like(p_bs, dtype=torch.bool)
+                if int(cu_s[:-1].max()) < valid_s.numel():
+                    valid_s[cu_s[:-1]] = False
+                pvs = p_bs[valid_s]
+                if pvs.numel() > 1:
+                    batch[f"log/L{i}_prob_absdev_s"] = float((pvs - 0.5).abs().mean())
+                    batch[f"log/L{i}_prob_mean_s"] = float(pvs.mean())
+                    batch[f"log/L{i}_prob_std_s"] = float(pvs.std())
+                    batch[f"log/L{i}_fenced_frac_s"] = float(
+                        ((pvs - 0.5).abs() < 0.02).float().mean())
+                # 1.0 => S boundaries identical to A's (streams not independent)
+                if bms.shape == bm.shape:
+                    batch[f"log/L{i}_as_overlap"] = float(
+                        (bms == bm).float().mean())
             w = float(rec.get("dec_weight", 0.0))
             if w > 0:
                 dec_i = (1.0 - (2.0 * pv - 1.0).pow(2)).mean()
@@ -684,6 +990,8 @@ class RatioLoss(Stage):
             batch["loss/topk"] = tk_total
         if srate_total is not None:
             batch["loss/softrate"] = srate_total
+        if confidence_total is not None:
+            batch["loss/confidence"] = confidence_total
         return batch
 
 
@@ -694,3 +1002,12 @@ class _B:
         self.boundary_mask = rec["boundary_mask"]
         self.boundary_prob = rec["boundary_prob"]
         self.selected_probs = rec["selected_probs"]
+
+
+class _BS:
+    """Same adapter for the SPECIFIC stream's own boundary (separate_boundaries)."""
+
+    def __init__(self, rec):
+        self.boundary_mask = rec["boundary_mask_s"]
+        self.boundary_prob = rec["boundary_prob_s"]
+        self.selected_probs = rec["selected_probs_s"]

--- a/egomimic/pipeline/stages_seq.py
+++ b/egomimic/pipeline/stages_seq.py
@@ -1,0 +1,874 @@
+"""Sequential (flat) pipeline stages -- the un-nested form of the H-Net pyramid.
+
+``stages_hnet.py`` expresses the pyramid as a NESTED chain: ``DualstreamTrunk``
+wires level *i*'s ``.inner`` to level *i+1*, and ``DualChunkerLevel`` calls
+``self.inner(...)`` in the middle of its own forward (chunk -> recurse ->
+dechunk). That nesting is the only reason a container stage exists at all --
+``PipelineAlgo`` already runs a flat list.
+
+Here the same computation is a FLAT list. Two changes make that possible:
+
+1. The chunker is split into :class:`Chunk` (router + compress, publishes a
+   route record) and :class:`Dechunk` (expand + residual mix, consumes it), so
+   what used to be the return half of one forward is now its own stage.
+2. Every stage names the batch keys it reads and writes (``A_L0``, ``S_L0``,
+   ``A_L1``, ...), instead of mutating fixed ``"A"``/``"S"`` slots.
+
+Consequences worth stating, because they remove three flags:
+
+* ``stream_keys`` is gone -- a stage operates on exactly the keys it is given,
+  so "A only" is expressed by naming one key.
+* ``flat_s`` is gone -- "S votes in the router but is not chunked" is just
+  ``Chunk`` reading ``s_key`` and not writing an S output.
+* ``dual_inner`` is gone -- there is no inner; the next stage in the list is
+  whatever you put there.
+
+The trunk's encoder/decoder split (``decoder_layout``) also becomes explicit:
+an encoder :class:`StreamTrunk` before the ``Chunk`` and a decoder one after
+the matching ``Dechunk``.
+
+Model components are REUSED UNCHANGED from ``egomimic.models.hnet``
+(``MultiStreamTrunk``, ``ChunkLayer``/``DeChunkLayer``, ``DualStreamRouter``,
+``build_residual_mixer``, ``build_isotropic``). This module is wiring, not new
+math.
+
+NOT carried over from ``DualChunkerLevel`` (deliberately -- these stay
+available on the nested path, and none is used by the yolo arms):
+``separate_boundaries``, ``confidence_ssl``, ``recon_head`` deep supervision,
+``cons_loss``/``topk``/``softrate``/``indecision`` regularizers, residual
+annealing and res-lane dropout, ``inner_s`` (S running its own apex).
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+
+from egomimic.models.hnet.isotropic_builder import build_isotropic
+from egomimic.models.hnet.multi_stream_trunk import MultiStreamTrunk
+from egomimic.models.hnet.per_emb import per_emb, pick
+from egomimic.models.hnet.residual_mixer import build_residual_mixer
+from egomimic.models.hnet.routing import ChunkLayer, DeChunkLayer
+from egomimic.models.hnet.stages import _init_isotropic_linears
+from egomimic.models.hnet.stream_bundle import build_same_episode_causal_mask
+from egomimic.models.hnet.dual_stream_chunker import DualStreamRouter
+from egomimic.pipeline.core import Stage
+from egomimic.pipeline.stages_io import RatioLoss as _RatioLoss
+from egomimic.pipeline.stages_hnet import (
+    _within_episode_time_pos,
+    _ste_scaled,
+    _masks_for,
+    _norm_window,
+    _MLPBlocks,
+)
+
+
+def _grid_keys(key: str):
+    """Per-level grid key names carried alongside a stream key.
+
+    ``A_L1`` -> ``("cu_seqlens@A_L1", "max_seq_len@A_L1", "time_pos@A_L1")``.
+    Grids belong to a RESOLUTION, not a stream, but keying them off the stream
+    name keeps every stage self-describing from its config alone.
+    """
+    return f"cu_seqlens@{key}", f"max_seq_len@{key}", f"time_pos@{key}"
+
+
+def _read_grid(batch: dict, key: str, ref: torch.Tensor):
+    """Grid for ``key``, falling back to the batch-level grid (level 0)."""
+    ck, mk, tk = _grid_keys(key)
+    cu = batch.get(ck, batch.get("cu_seqlens"))
+    mx = batch.get(mk, batch.get("max_seq_len"))
+    tp = batch.get(tk, batch.get("time_pos"))
+    cu = cu.to(device=ref.device, dtype=torch.long)
+    return cu, int(mx), tp
+
+
+def _write_grid(batch: dict, key: str, cu, mx, tp):
+    ck, mk, tk = _grid_keys(key)
+    batch[ck], batch[mk], batch[tk] = cu, int(mx), tp
+
+
+def per_emb_module(factory_or_mod, use_per_emb: bool, embodiments):
+    """per_emb=True -> one copy per embodiment (PerEmb); else a single shared one.
+    Accepts either a factory or an already-instantiated module (hydra gives the
+    latter for nested _target_ blocks, which cannot be duplicated per emb)."""
+    if not use_per_emb or not embodiments:
+        return factory_or_mod() if callable(factory_or_mod) and not isinstance(
+            factory_or_mod, nn.Module) else factory_or_mod
+    if isinstance(factory_or_mod, nn.Module):
+        raise ValueError(
+            "per_emb=True needs a factory, not an instantiated module: give each "
+            "embodiment its own stage, or pass a _partial_ target.")
+    return per_emb(factory_or_mod, embodiments)   # module-level helper, NOT the flag
+
+
+class StreamTrunk(Stage):
+    """MultiStreamTrunk over one or more named stream keys, at one resolution.
+
+    Replaces ``DualTrunkLevel`` with explicit keys. ``in_keys``/``out_keys``
+    are positionally matched to ``streams_cfg``; a single key is the A-only
+    case that used to need ``stream_keys: [A]``.
+    """
+
+    def __init__(self, in_keys: List[str], streams_cfg: List[dict],
+                 out_keys: Optional[List[str]] = None,
+                 adjacency=None, n_layers: int = 4, rotary_emb_dim: int = 0,
+                 attn_window=None, causal: bool = True,
+                 mask_mode: str = "sym", embodiments: Optional[List[str]] = None,
+                 allow_agnostic_cross: bool = False,
+                 dropout: float = 0.0, ffn_dropout: float = 0.0,
+                 adaln_cond: Optional[str] = None,
+                 adaln_dim: Optional[int] = None):
+        super().__init__()
+        streams_cfg = [dict(s) for s in streams_cfg]
+        N = len(streams_cfg)
+        self.in_keys = [str(k) for k in in_keys]
+        self.out_keys = [str(k) for k in (out_keys or in_keys)]
+        if len(self.in_keys) != N:
+            raise ValueError(
+                f"StreamTrunk: {len(self.in_keys)} in_keys but "
+                f"{N} streams_cfg entries -- one key per stream.")
+        if len(self.out_keys) != len(self.in_keys):
+            raise ValueError("StreamTrunk: out_keys must match in_keys in length.")
+        # _read_grid consumes the level grid; declare it so the routing graph
+        # and the lint see the real dependency.
+        self.reads = list(self.in_keys) + ["embodiment", "cu_seqlens", "max_seq_len", "time_pos"]
+        self.writes = list(self.out_keys)
+        # Same derivation as DualTrunkLevel: "sym" = every stream sees every
+        # other; "asym" = specific streams read the agnostic one, not vice versa.
+        if adjacency is None:
+            adjacency = ([[j for j in range(N) if j != i] for i in range(N)]
+                         if mask_mode == "sym"
+                         else [[] if i == 0 else [0] for i in range(N)])
+        self.causal = bool(causal)
+        self._n_layers = int(n_layers)
+        self.attn_window = _norm_window(attn_window, None, n_layers)
+        self.adaln_cond = str(adaln_cond) if adaln_cond else None
+        ad = int(adaln_dim) if (adaln_cond and adaln_dim) else None
+        self.trunk = MultiStreamTrunk(
+            streams_cfg, adjacency, int(n_layers), int(rotary_emb_dim),
+            float(dropout), ffn_dropout=float(ffn_dropout),
+            embodiments=embodiments,
+            allow_agnostic_cross=bool(allow_agnostic_cross), adaln_dim=ad)
+
+    def forward(self, batch: dict) -> dict:
+        xs = [batch[k] for k in self.in_keys]
+        ref = xs[0]
+        cu, mx, tp = _read_grid(batch, self.in_keys[0], ref)
+        mask, lmasks = _masks_for(self.attn_window, ref.shape[0], cu, tp,
+                                  self.causal, ref.device, self._n_layers)
+        rope = tp.to(device=ref.device, dtype=torch.long)
+        cond = batch.get(self.adaln_cond) if self.adaln_cond else None
+        outs = self.trunk(xs, mask, rope, batch["embodiment"],
+                          cond=cond, layer_masks=lmasks)
+        for k, v in zip(self.out_keys, outs):
+            batch[k] = v
+            _write_grid(batch, k, cu, mx, tp)
+        return batch
+
+    def _init_weights(self, rng: float, parent_residuals: int) -> int:
+        return _init_isotropic_linears(self.trunk, rng, parent_residuals)
+
+
+class Framewise(Stage):
+    """Per-frame MLP on one or more streams -- NO temporal mixing.
+
+    Generalises ``StreamMLP`` to several streams at once. Like it, this stage
+    never reads ``cu_seqlens`` or ``time_pos``, so it is *structurally*
+    incapable of moving information between timesteps -- that is the point,
+    not an optimisation.
+
+    Streams listed in ``per_emb_keys`` get one MLP per embodiment (the usual
+    choice for the specific stream); the rest share one.
+    """
+
+    def __init__(self, in_keys: List[str], dims: List[int],
+                 out_keys: Optional[List[str]] = None,
+                 n_layers: int = 4, d_hidden: Optional[List[int]] = None,
+                 per_emb_keys: Optional[List[str]] = None,
+                 embodiments: Optional[List[str]] = None,
+                 activation: str = "gelu", dropout: float = 0.0,
+                 final_norm: bool = True):
+        super().__init__()
+        self.in_keys = [str(k) for k in in_keys]
+        self.out_keys = [str(k) for k in (out_keys or in_keys)]
+        if len(self.in_keys) != len(dims):
+            raise ValueError("Framewise: one dim per in_key.")
+        self.reads = list(self.in_keys) + ["embodiment"]
+        self.writes = list(self.out_keys)
+        acts = {"gelu": nn.GELU, "silu": nn.SiLU, "relu": nn.ReLU}
+        if activation not in acts:
+            raise ValueError("Framewise activation %r not in %s"
+                             % (activation, sorted(acts)))
+        act = acts[activation]
+        pe = set(per_emb_keys or [])
+        hid = list(d_hidden) if d_hidden else [4 * int(d) for d in dims]
+        blocks = {}
+        for k, d, h in zip(self.in_keys, dims, hid):
+            mk = lambda d=d, h=h: _MLPBlocks(int(d), int(h), int(n_layers),
+                                             act, float(dropout),
+                                             bool(final_norm))
+            blocks[k] = per_emb(mk, embodiments) if k in pe else mk()
+        self.blocks = nn.ModuleDict(
+            {k.replace(".", "_"): v for k, v in blocks.items()})
+        self._key_map = {k: k.replace(".", "_") for k in self.in_keys}
+
+    def forward(self, batch: dict) -> dict:
+        emb = batch["embodiment"]
+        for ik, ok in zip(self.in_keys, self.out_keys):
+            # pick() passes shared (non-PerEmb) modules through unchanged.
+            mod = pick(self.blocks[self._key_map[ik]], emb)
+            batch[ok] = mod(batch[ik])
+            if ok != ik:
+                ck, mk, tk = _grid_keys(ik)
+                if ck in batch:
+                    _write_grid(batch, ok, batch[ck], batch[mk], batch[tk])
+        return batch
+
+
+class Chunk(Stage):
+    """Router + compress, over a LIST of streams sharing one boundary.
+
+    ``in_keys[0]`` is the AGNOSTIC stream; it always drives the compression.
+    Which streams are listed decides the behaviour that used to need flags:
+
+    * ``in_keys: [A_L0, S_L0] -> out_keys: [A_L1, S_L1]`` -- both streams
+      compressed on the shared boundary (the old dual chunker).
+    * ``in_keys: [A_L0] -> out_keys: [A_L1]`` with ``route_on: a`` -- only A is
+      compressed and the router scores A alone; S is simply not named here, so
+      it stays on the frame grid (the old ``flat_s``).
+
+    ``route_on`` picks what enters the router's cossim core: ``"fused"`` (A+S),
+    ``"a"``, or ``"s"``. A single-stream ``in_keys`` requires ``"a"`` -- there
+    is no S to fuse.
+    """
+
+    def __init__(self, in_keys: List[str], out_keys: List[str], route_key: str,
+                 dims: List[int], apex_dims: Optional[List[int]] = None,
+                 route_on: str = "fused", level: Optional[int] = None,
+                 target_compression_ratio: float = 8.0,
+                 ratio_loss_weight: float = 0.03,
+                 ratio_loss_weight_s: float = 0.0,
+                 grab_prev_end: bool = True,
+                 embodiments: Optional[List[str]] = None,
+                 per_emb_keys: Optional[List[str]] = None,
+                 router_per_emb: bool = True,
+                 router_fusion: str = "residual_mlp",
+                 router_core: str = "cossim",
+                 d_router: Optional[int] = None,
+                 router_mixer_n_layers: int = 4,
+                 router_hidden_mult: float = 4.0,
+                 router_temp: float = 1.0, router_sample: bool = False,
+                 res_scale: Optional[float] = None):
+        super().__init__()
+        self.in_keys = [str(k) for k in in_keys]
+        self.out_keys = [str(k) for k in out_keys]
+        self.route_key = str(route_key)
+        self.dims = [int(d) for d in dims]
+        self.apex_dims = [int(d) for d in (apex_dims or dims)]
+        n = len(self.in_keys)
+        if not (len(self.out_keys) == len(self.dims) == len(self.apex_dims) == n):
+            raise ValueError(
+                "Chunk: in_keys/out_keys/dims/apex_dims must be the same length.")
+        self.route_on = str(route_on)
+        # Explicit pyramid level. The NESTED form appends aux/chunker records
+        # innermost-first (each chunker appends after self.inner returns),
+        # while a flat list appends in execution order -- so list POSITION
+        # means opposite things in the two forms. RatioLoss indexes per-level
+        # target_ratio by position, so stamping the level makes per-level
+        # targets/schedules unambiguous instead of order-dependent.
+        self.level = None if level is None else int(level)
+        if n == 1 and self.route_on != "a":
+            raise ValueError(
+                "Chunk: a single-stream in_keys has no S to fuse; "
+                "set route_on='a'.")
+        self.reads = list(self.in_keys) + ["embodiment", "cu_seqlens", "max_seq_len", "time_pos"]
+        self.writes = (list(self.out_keys) + [f"{k}@res" for k in self.in_keys]
+                       + [self.route_key, "aux/chunker"])
+        self.target_compression_ratio = float(target_compression_ratio)
+        self.ratio_loss_weight = float(ratio_loss_weight)
+        # MATCHES DualChunkerLevel (stages_hnet.py:471): an unset `_s` weight
+        # falls back to the A weight. With one shared boundary that applies the
+        # ratio term TWICE on the same b_t -- i.e. the effective weight is 2x
+        # the configured value. That looks accidental upstream, but every
+        # existing baseline trained under it, so reproducing it is required for
+        # the sequential baseline to be comparable. Pass ratio_loss_weight_s=0
+        # explicitly to opt out.
+        self.ratio_loss_weight_s = (float(ratio_loss_weight_s)
+                                    if ratio_loss_weight_s
+                                    else float(ratio_loss_weight))
+        self.grab_prev_end = bool(grab_prev_end)
+        self.res_scale = res_scale
+        self._embs = list(embodiments) if embodiments else None
+        pe = set(per_emb_keys or [])
+        self._per_emb = [k in pe for k in self.in_keys]
+
+        d_a = self.dims[0]
+        d_s = self.dims[1] if n > 1 else d_a
+        mk_router = lambda: DualStreamRouter(
+            d_a, d_s, d_router=d_router, router_core=str(router_core),
+            n_layers=int(router_mixer_n_layers), fusion=str(router_fusion),
+            hidden_mult=float(router_hidden_mult),
+            router_temp=float(router_temp),
+            router_sample=bool(router_sample), route_on=self.route_on)
+        self._router = per_emb(mk_router, self._embs) if router_per_emb else mk_router()
+
+        self.chunk_layer = ChunkLayer()
+
+        def _mk(fac, i):
+            return per_emb(fac, self._embs) if self._per_emb[i] else fac()
+
+        self.residual_proj = nn.ModuleList([
+            _mk((lambda d=d: nn.Identity() if a == d else nn.Linear(d, d)), i)
+            for i, (d, a) in enumerate(zip(self.dims, self.apex_dims))])
+        if self.grab_prev_end:
+            self.prev_end_combine = nn.ModuleList([
+                _mk((lambda d=d, a=a: nn.Linear(2 * d, a)), i)
+                for i, (d, a) in enumerate(zip(self.dims, self.apex_dims))])
+            # no_prev must be PER-EMBODIMENT for specific streams, matching
+            # DualChunkerLevel's per_emb no_prev_S. A bare Parameter and a
+            # PerEmb (which wraps a ParameterDict) cannot share one container,
+            # so per-emb entries live in a ModuleList and shared ones are
+            # registered directly; _no_prev() resolves either.
+            self.no_prev_pe = nn.ModuleList()
+            self._no_prev_ref = []
+            for i, d in enumerate(self.dims):
+                if self._per_emb[i] and self._embs:
+                    self.no_prev_pe.append(
+                        per_emb(lambda d=d: nn.Parameter(torch.zeros(d)), self._embs))
+                    self._no_prev_ref.append(("pe", len(self.no_prev_pe) - 1))
+                else:
+                    self.register_parameter(f"no_prev_{i}",
+                                            nn.Parameter(torch.zeros(d)))
+                    self._no_prev_ref.append(("p", i))
+            self.proj_in = None
+        else:
+            self.prev_end_combine = None
+            self.no_prev_pe = None
+            self._no_prev_ref = []
+            self.proj_in = nn.ModuleList([
+                _mk((lambda d=d, a=a: nn.Identity() if a == d else nn.Linear(d, a)), i)
+                for i, (d, a) in enumerate(zip(self.dims, self.apex_dims))])
+
+    def _no_prev(self, i: int, emb):
+        kind, j = self._no_prev_ref[i]
+        return (pick(self.no_prev_pe[j], emb) if kind == "pe"
+                else getattr(self, f"no_prev_{j}"))
+
+    def _combine_prev_end(self, chunked, x, bmask, cu, combine, no_prev, d):
+        prev = torch.zeros_like(chunked[:, :d]) + no_prev
+        idx = torch.nonzero(bmask, as_tuple=False).flatten()
+        if idx.numel():
+            first = torch.isin(idx, cu[:-1])
+            taken = x[(idx - 1).clamp(min=0)]
+            prev = torch.where(first.unsqueeze(-1), prev, taken)
+        return combine(torch.cat([chunked, prev], -1).float()).to(chunked.dtype)
+
+    def forward(self, batch: dict) -> dict:
+        emb = batch["embodiment"]
+        xs = [batch[k] for k in self.in_keys]
+        A = xs[0]
+        cu, mx, tp = _read_grid(batch, self.in_keys[0], A)
+        S = xs[1] if len(xs) > 1 else A
+        cu_s = (_read_grid(batch, self.in_keys[1], S)[0] if len(xs) > 1 else cu)
+
+        bpred = pick(self._router, emb)(A, S, cu_seqlens=cu, max_seqlen=mx,
+                                        cu_seqlens_s=cu_s)
+        bmask, bprob, sprob = (bpred.boundary_mask, bpred.boundary_prob,
+                               bpred.selected_probs)
+
+        residuals, next_cu, next_max = [], None, None
+        for i, (ik, ok, d) in enumerate(zip(self.in_keys, self.out_keys, self.dims)):
+            x = xs[i]
+            res = pick(self.residual_proj[i], emb)(x.float())
+            if self.res_scale is not None:
+                res = res * float(self.res_scale)
+            residuals.append(res)
+            x_ch, ncu, nmx, _ = self.chunk_layer(x, bmask, cu_seqlens=cu)
+            if self.grab_prev_end:
+                x_in = self._combine_prev_end(
+                    x_ch, x, bmask, cu, pick(self.prev_end_combine[i], emb),
+                    self._no_prev(i, emb), d)
+            else:
+                x_in = pick(self.proj_in[i], emb)(x_ch)
+            next_cu, next_max = ncu, nmx
+            batch[ok] = x_in
+
+        ctp = _within_episode_time_pos(next_cu, batch[self.out_keys[0]].shape[0],
+                                       A.device)
+        for ok in self.out_keys:
+            _write_grid(batch, ok, next_cu, int(next_max), ctp)
+        # The residual (this level's input, projected) is the U-net SKIP. Kept
+        # inside the route dict it is invisible to any consumer that reasons
+        # about dataflow -- the routing graph drew Chunk->Dechunk as a single
+        # "route_LN" edge with no sign that the pre-chunk activations flow
+        # across too. Publishing it as a named key makes the skip a real edge
+        # and leaves `route` as pure metadata.
+        for ik, res in zip(self.in_keys, residuals):
+            batch[f"{ik}@res"] = res
+        route = {
+            "boundary_mask": bmask,
+            "boundary_prob": bprob,
+            "selected_probs": sprob,
+            "cu_seqlens": cu,               # this level's INPUT grid
+            "chunk_cu_seqlens": next_cu,    # chunk grid
+            "residual_keys": [f"{k}@res" for k in self.in_keys],
+            "in_keys": list(self.in_keys),
+            "target_ratio": self.target_compression_ratio,
+            "ratio_weight": self.ratio_loss_weight,
+        }
+        batch[self.route_key] = route
+        # Also publish in the legacy aux/chunker shape so stages_io.RatioLoss
+        # works UNCHANGED -- it reads that list, and its loss math is exactly
+        # what we want. Optional-regularizer fields are emitted inert (0/None)
+        # because this stage deliberately does not implement them; see the
+        # module docstring for the full list.
+        if "aux/chunker" in batch and len(self.in_keys) == 1:
+            # A-ONLY chunker: mirrors DualChunkerLevel._forward_flat_s, which
+            # emits a MINIMAL record with NO _s keys -- there is no S boundary
+            # at this level, so an S ratio term would double-count the SAME
+            # boundary and silently double the effective ratio weight.
+            batch["aux/chunker"].append({
+                "boundary_mask": bmask,
+                "boundary_prob": bprob,
+                "selected_probs": sprob,
+                "cu_seqlens": cu,
+                "chunk_cu_seqlens": next_cu,
+                "target_ratio": self.target_compression_ratio,
+                "ratio_weight": self.ratio_loss_weight,
+                "flat_s": True,
+                "level": self.level,
+                "separate_boundaries": False,
+                "tokens": batch[self.out_keys[0]],
+            })
+        elif "aux/chunker" in batch:
+            batch["aux/chunker"].append({
+                **{k: route[k] for k in
+                   ("boundary_mask", "boundary_prob", "selected_probs",
+                    "cu_seqlens", "chunk_cu_seqlens", "target_ratio",
+                    "ratio_weight")},
+                # no separate per-stream boundaries here: S (when chunked) rides
+                # A's mask, so the S entries mirror A and carry zero weight.
+                "level": self.level,
+                "separate_boundaries": False,
+                "boundary_mask_s": bmask,
+                "boundary_prob_s": bprob,
+                "selected_probs_s": sprob,
+                "chunk_cu_seqlens_s": next_cu,
+                "cu_seqlens_s": cu,
+                "target_ratio_s": self.target_compression_ratio,
+                "ratio_weight_s": float(self.ratio_loss_weight_s),
+                "dec_weight": 0.0, "spread_weight": 0.0, "spread_alpha": 0.5,
+                "hb_weight": 0.0, "hb_lo": 0.25, "hb_hi": 0.45, "hb_window": 12,
+                "recon_loss": None, "recon_weight": 0.0,
+                "cons_loss": None, "cons_weight": 0.0,
+                "topk_weight": 0.0, "topk_margin": 0.1,
+                "softrate_weight": 0.0, "softrate_vote": "sigmoid",
+                "softrate_tau": 0.15, "softrate_center": 0.5,
+                "softrate2_weight": 0.0, "softrate2_center": 0.3,
+                "indecision_weight": 0.0, "indecision_deadzone": 0.21,
+                "tokens": batch[self.out_keys[0]],   # chunkviz reads A tokens
+            })
+        return batch
+
+    def _init_weights(self, rng: float, parent_residuals: int) -> int:
+        return parent_residuals
+
+
+class Dechunk(Stage):
+    """Expand back to the route's input grid and residual-mix.
+
+    The second half of what ``DualChunkerLevel.forward`` used to do after its
+    ``self.inner(...)`` call.
+    """
+
+    def __init__(self, in_keys: List[str], route_key: str, out_keys: List[str],
+                 dims: List[int], apex_dims: Optional[List[int]] = None,
+                 residual_keys: Optional[List[str]] = None,
+                 residual_mixer: str = "mlp",
+                 residual_mixer_kwargs: Optional[dict] = None,
+                 per_emb_keys: Optional[List[str]] = None,
+                 embodiments: Optional[List[str]] = None,
+                 ste_gain: float = 1.0):
+        super().__init__()
+        self.in_keys = [str(k) for k in in_keys]
+        self.out_keys = [str(k) for k in out_keys]
+        self.route_key = str(route_key)
+        self.dims = [int(d) for d in dims]
+        self.apex_dims = [int(d) for d in (apex_dims or dims)]
+        n = len(self.in_keys)
+        if not (len(self.out_keys) == len(self.dims) == len(self.apex_dims) == n):
+            raise ValueError(
+                "Dechunk: in_keys/out_keys/dims/apex_dims must be the same length.")
+        # Which residual each stream mixes with -- name them so the skip shows
+        # up in the routing graph. Falls back to the route record's list.
+        self.residual_keys = ([str(k) for k in residual_keys] if residual_keys
+                              else None)
+        self.reads = (list(self.in_keys) + [self.route_key, "embodiment"]
+                      + (self.residual_keys or []))
+        self.writes = list(self.out_keys)
+        self.ste_gain = float(ste_gain)
+        pe = set(per_emb_keys or [])
+        self._per_emb = [k in pe for k in self.out_keys]
+        embs = list(embodiments) if embodiments else None
+
+        def _mk(fac, i):
+            return per_emb(fac, embs) if self._per_emb[i] else fac()
+
+        self.proj_out = nn.ModuleList([
+            _mk((lambda d=d, a=a: nn.Identity() if a == d else nn.Linear(a, d)), i)
+            for i, (d, a) in enumerate(zip(self.dims, self.apex_dims))])
+        self.dechunk = nn.ModuleList([DeChunkLayer(d) for d in self.dims])
+        self.mixers = nn.ModuleList([
+            _mk((lambda d=d: build_residual_mixer(
+                residual_mixer, d, **(residual_mixer_kwargs or {}))), i)
+            for i, d in enumerate(self.dims)])
+
+    def forward(self, batch: dict) -> dict:
+        r = batch[self.route_key]
+        emb = batch["embodiment"]
+        res_keys = self.residual_keys or r["residual_keys"]
+        for i, (ik, ok) in enumerate(zip(self.in_keys, self.out_keys)):
+            x = pick(self.proj_out[i], emb)(batch[ik])
+            dech = self.dechunk[i](x, r["boundary_mask"], r["boundary_prob"],
+                                   cu_seqlens=r["chunk_cu_seqlens"])
+            gated = dech.float() * _ste_scaled(r["selected_probs"], self.ste_gain)
+            rk = res_keys[i]
+            if rk not in batch:
+                raise KeyError(f"Dechunk: residual {rk!r} not in batch -- the "
+                               f"matching Chunk must run first and publish it.")
+            out = pick(self.mixers[i], emb)(gated, batch[rk])
+            batch[ok] = out.to(dech.dtype)
+            _write_grid(batch, ok, r["cu_seqlens"],
+                        int(batch.get("max_seq_len", 0)),
+                        _within_episode_time_pos(r["cu_seqlens"],
+                                                 out.shape[0], out.device))
+        return batch
+
+    def _init_weights(self, rng: float, parent_residuals: int) -> int:
+        return parent_residuals + 1
+
+
+class Apex(Stage):
+    """Isotropic stack on ONE stream key (the old ``ApexLevel``, un-nested)."""
+
+    def __init__(self, in_key: str, main_network: dict,
+                 out_key: Optional[str] = None, causal: bool = True):
+        super().__init__()
+        self.in_key = str(in_key)
+        self.out_key = str(out_key or in_key)
+        self.reads = [self.in_key, "cu_seqlens", "max_seq_len", "time_pos"]
+        self.writes = [self.out_key, "apex/tokens"]
+        self.causal = bool(causal)
+        self.net = build_isotropic(dict(main_network), d_cond=0, causal=causal)
+
+    def forward(self, batch: dict) -> dict:
+        x = batch[self.in_key]
+        cu, mx, tp = _read_grid(batch, self.in_key, x)
+        out = self.net(x, cu_seqlens=cu, max_seqlen=mx)
+        batch[self.out_key] = out
+        batch["apex/tokens"] = out
+        _write_grid(batch, self.out_key, cu, mx, tp)
+        return batch
+
+    def _init_weights(self, rng: float, parent_residuals: int) -> int:
+        return _init_isotropic_linears(self.net, rng, parent_residuals)
+
+
+class Mix(Stage):
+    """Recombine two same-resolution streams through a residual mixer.
+
+    Used for ``A_agn = mixer(A_from_pyramid, A_framewise)`` -- the per-frame
+    branch rejoining the chunked path.
+    """
+
+    def __init__(self, in_keys: List[str], out_key: str, dim: int,
+                 mixer: str = "mlp", mixer_kwargs: Optional[dict] = None):
+        super().__init__()
+        if len(in_keys) != 2:
+            raise ValueError("Mix takes exactly two in_keys (main, residual).")
+        self.in_keys = [str(k) for k in in_keys]
+        self.out_key = str(out_key)
+        self.reads = list(self.in_keys)
+        self.writes = [self.out_key]
+        self.mixer = build_residual_mixer(mixer, int(dim), **(mixer_kwargs or {}))
+
+    def forward(self, batch: dict) -> dict:
+        main, res = batch[self.in_keys[0]], batch[self.in_keys[1]]
+        out = self.mixer(main.float(), res.float()).to(main.dtype)
+        batch[self.out_key] = out
+        ck, mk, tk = _grid_keys(self.in_keys[0])
+        if ck in batch:
+            _write_grid(batch, self.out_key, batch[ck], batch[mk], batch[tk])
+        return batch
+
+    def _init_weights(self, rng: float, parent_residuals: int) -> int:
+        return parent_residuals + 1
+
+
+class Rename(Stage):
+    """Alias batch keys (e.g. ``S_out -> s``) so heads keep their own names."""
+
+    def __init__(self, mapping: dict):
+        super().__init__()
+        self.mapping = {str(k): str(v) for k, v in dict(mapping).items()}
+        self.reads = list(self.mapping)
+        self.writes = list(self.mapping.values())
+
+    def forward(self, batch: dict) -> dict:
+        for src, dst in self.mapping.items():
+            batch[dst] = batch[src]
+            ck, mk, tk = _grid_keys(src)
+            if ck in batch:
+                _write_grid(batch, dst, batch[ck], batch[mk], batch[tk])
+        return batch
+
+
+class ScheduledRatioLoss(_RatioLoss):
+    """:class:`stages_io.RatioLoss` with a SCHEDULABLE compression target.
+
+    The base class resolves ``target_ratio`` as a scalar / per-level list /
+    per-embodiment dict, all constant in time. Curriculum on the chunker's
+    target (e.g. start loose at 8x and tighten to 3x) needs it to vary with
+    training progress, so this subclass accepts two extra forms:
+
+      * a CALLABLE ``f(progress) -> value`` (hydra ``_partial_: true``), or
+      * a spec dict ``{start, end, over_steps, shape: linear|cosine}``.
+
+    ``progress`` is in [0, 1]. It is read from ``batch["global_step"]`` when the
+    wrapper supplies it; otherwise this stage counts its own TRAIN forwards --
+    the same fallback ``DualChunkerLevel`` uses for its residual anneal, since
+    Lightning's ``global_step`` is not currently placed in the batch.
+
+    Everything the base class does is unchanged: only the resolved target is
+    swapped before ``forward``. ``ratio_weight`` still comes from the Chunk
+    stage (the base class has no weight argument).
+    """
+
+    def __init__(self, *args, schedule=None, over_steps: int = 0,
+                 log_key: str = "log/ratio_target", **kw):
+        super().__init__(*args, **kw)
+        self.schedule = schedule
+        self.over_steps = int(over_steps)
+        self.log_key = str(log_key)
+        self._fwd = 0
+
+    def _progress(self, batch: dict) -> float:
+        step = batch.get("global_step")
+        if step is None:
+            if self.training:
+                self._fwd += 1
+            step = self._fwd
+        if self.over_steps <= 0:
+            return 0.0
+        return max(0.0, min(1.0, float(step) / float(self.over_steps)))
+
+    def _resolve(self, p: float):
+        s = self.schedule
+        if callable(s):
+            return float(s(p))
+        lo, hi = float(s["start"]), float(s["end"])
+        if str(s.get("shape", "linear")) == "cosine":
+            import math
+            p = 0.5 * (1.0 - math.cos(math.pi * p))
+        return lo + (hi - lo) * p
+
+    def forward(self, batch: dict) -> dict:
+        recs = batch.get("aux/chunker")
+        if recs and all(r.get("level") is not None for r in recs):
+            # index by CONFIG level, not append order (see Chunk.level)
+            batch["aux/chunker"] = sorted(recs, key=lambda r: r["level"])
+        if self.schedule is not None:
+            p = self._progress(batch)
+            tgt = self._resolve(p)
+            self.target_ratio = tgt          # base _target() picks this up
+            batch[self.log_key] = float(tgt)
+        return super().forward(batch)
+
+
+class ObsNoise(Stage):
+    """Observation augmentation as an explicit STAGE.
+
+    DESIGN RULE for this module: every stage computes the SAME function in
+    training and inference. That keeps a rollout faithful to what was trained
+    and means no stage silently changes behaviour when you switch to eval.
+
+    This stage is the ONE deliberate exception, and it is declared rather than
+    hidden: with ``train_only: true`` (the default) it is an exact pass-through
+    at eval/rollout and only perturbs during training. Previously this lived on
+    ``PipelineAlgo.train_obs_transforms``, where both the placement and the
+    train-only gate were invisible from the stage list.
+
+    Reuses the existing ``egomimic.pipeline.obs_transforms`` callables (e.g.
+    ``GaussianImageNoise``) -- they are ``dict -> dict`` over the un-prefixed
+    obs names, so this stage strips/restores the ``obs/`` prefix around them.
+
+    Place it BEFORE the obs encoders. Because it is a stage you can now put it
+    anywhere in the list -- e.g. perturb the image but not the proprio, or
+    inject on one stream's input only.
+    """
+
+    def __init__(self, transforms: List[object], keys: Optional[List[str]] = None,
+                 prefix: str = "obs/", train_only: bool = True):
+        super().__init__()
+        self.transforms = list(transforms)
+        self.keys = [str(k) for k in keys] if keys else None
+        self.prefix = str(prefix)
+        self.train_only = bool(train_only)
+        self.reads = [f"{self.prefix}*"]
+        self.writes = [f"{self.prefix}*"]
+
+    def forward(self, batch: dict) -> dict:
+        if self.train_only and not self.training:
+            return batch                      # exact identity at inference
+        sel = (self.keys if self.keys is not None
+               else [k[len(self.prefix):] for k in batch
+                     if k.startswith(self.prefix)])
+        obs = {k: batch[self.prefix + k] for k in sel if self.prefix + k in batch}
+        if not obs:
+            return batch
+        for t in self.transforms:
+            obs = t(obs)
+        for k, v in obs.items():
+            batch[self.prefix + k] = v
+        return batch
+
+
+# --------------------------------------------------------------------------- #
+# OBS stages -- the encoder path, un-nested
+#
+# SharedObsEncoders / ObsEncoders hid the A/S routing INSIDE the class: what
+# reached which stream depended on which class you picked and where a key was
+# declared, not on anything visible in the config. That cost several silent
+# bugs (a key that never arrived, an object pose that reached both streams).
+# These three stages make every hop explicit and named, so "shared encoder"
+# vs "separate encoders" is just how many VisualEncode stages you list.
+# --------------------------------------------------------------------------- #
+
+
+class VisualEncode(Stage):
+    """One image key -> one named feature. Share it by pointing two Fuse
+    stages at the same out_key; separate it by listing two of these."""
+
+    def __init__(self, in_key: str, out_key: str, encoder,
+                 per_emb: bool = False, embodiments: Optional[List[str]] = None):
+        super().__init__()
+        self.in_key, self.out_key = str(in_key), str(out_key)
+        self.reads, self.writes = [self.in_key, "embodiment"], [self.out_key]
+        self.enc = per_emb_module(encoder, per_emb, embodiments)
+
+    def forward(self, batch: dict) -> dict:
+        x = batch.get(self.in_key)
+        if x is None:
+            raise KeyError(f"VisualEncode: {self.in_key!r} not in batch "
+                           f"(have: {sorted(k for k in batch if k.startswith('obs/'))}).")
+        batch[self.out_key] = pick(self.enc, batch["embodiment"])(x)
+        return batch
+
+
+class ObsEmbed(Stage):
+    """One proprio key -> one named embedding (Linear, optionally per-emb).
+
+    Raises on a missing key: a silently-dropped proprio trains the model on
+    vision alone with no error, which is exactly how object_x once ended up
+    standing in for a rotation channel.
+    """
+
+    def __init__(self, in_key: str, out_key: str, input_dim, embed_dim: int,
+                 per_emb: bool = False, embodiments: Optional[List[str]] = None):
+        super().__init__()
+        self.in_key, self.out_key = str(in_key), str(out_key)
+        self.reads, self.writes = [self.in_key, "embodiment"], [self.out_key]
+        # input_dim may be a scalar OR a per-embodiment mapping: pusher_pose is
+        # 2-D for a circle pusher and 4-D for a rotvec u_socket, so one width
+        # cannot serve a cotrain run.
+        if hasattr(input_dim, "items"):
+            if not embodiments:
+                raise ValueError("ObsEmbed: per-emb input_dim needs embodiments.")
+            self.input_dim = {str(e): int(d) for e, d in dict(input_dim).items()}
+            self.emb = nn.ModuleDict({
+                e: nn.Linear(self.input_dim[e], int(embed_dim)) for e in self.input_dim})
+            self._per_emb_in = True
+        else:
+            self.input_dim = int(input_dim)
+            self._per_emb_in = False
+            mk = lambda: nn.Linear(int(input_dim), int(embed_dim))
+            self.emb = per_emb_module(mk, per_emb, embodiments)
+
+    def forward(self, batch: dict) -> dict:
+        x = batch.get(self.in_key)
+        if x is None:
+            raise KeyError(f"ObsEmbed: {self.in_key!r} not in batch "
+                           f"(have: {sorted(k for k in batch if k.startswith('obs/'))}). "
+                           f"Transforms/encoders see KEY_MAP ALIASES, not zarr paths.")
+        emb = str(batch["embodiment"])
+        if self._per_emb_in:
+            if emb not in self.emb:
+                raise KeyError(f"ObsEmbed: no entry for embodiment {emb!r} "
+                               f"(have {list(self.emb)}).")
+            want, mod = self.input_dim[emb], self.emb[emb]
+        else:
+            want, mod = self.input_dim, pick(self.emb, emb)
+        if x.shape[-1] != want:
+            raise ValueError(f"ObsEmbed: {self.in_key!r} width {x.shape[-1]} != "
+                             f"declared input_dim {want} for embodiment {emb!r}.")
+        batch[self.out_key] = mod(x.float())
+        return batch
+
+
+class Fuse(Stage):
+    """Concat named features -> MLP -> one stream key at width ``d_out``.
+
+    This is where a stream is actually composed, so what reaches A vs S is
+    readable from the config instead of implied by an encoder class.
+    """
+
+    def __init__(self, in_keys: List[str], out_key: str, dims: List[int],
+                 d_out: int, widths: Optional[List[int]] = None,
+                 per_emb: bool = False, embodiments: Optional[List[str]] = None):
+        super().__init__()
+        self.in_keys = [str(k) for k in in_keys]
+        self.out_key = str(out_key)
+        self.reads = list(self.in_keys) + ["embodiment"]
+        self.writes = [self.out_key]
+        fused = int(sum(dims))
+        ws = list(widths) if widths else [max(int(d_out), fused)]
+        def mk():
+            layers, prev = [], fused
+            for w in ws:
+                layers += [nn.Linear(prev, int(w)), nn.GELU()]
+                prev = int(w)
+            layers.append(nn.Linear(prev, int(d_out)))
+            return nn.Sequential(*layers)
+        self.proj = per_emb_module(mk, per_emb, embodiments)
+
+    def forward(self, batch: dict) -> dict:
+        feats = []
+        for k in self.in_keys:
+            if k not in batch:
+                raise KeyError(f"Fuse: {k!r} not in batch (have: {sorted(batch)[:12]}).")
+            feats.append(batch[k].float())
+        out = pick(self.proj, batch["embodiment"])(torch.cat(feats, dim=-1))
+        batch[self.out_key] = out
+        return batch
+
+
+class TimePos(Stage):
+    """Publish ``time_pos`` -- the within-episode frame index from cu_seqlens.
+
+    ``ObsEncoders``/``SharedObsEncoders`` used to emit this as a side effect of
+    encoding. Splitting the encoder into explicit stages made that implicit
+    write disappear, and the trunk's mask/RoPE need it -- so it becomes its own
+    one-line stage rather than a hidden effect of something else.
+    """
+
+    reads = ["cu_seqlens"]
+    writes = ["time_pos"]
+
+    def forward(self, batch: dict) -> dict:
+        from egomimic.pipeline import packed
+        cu = batch["cu_seqlens"]
+        batch["time_pos"] = packed.frame_idx(
+            cu.to(dtype=torch.long) if torch.is_tensor(cu) else cu)
+        return batch

--- a/egomimic/rldb/embodiment/pushshapes.py
+++ b/egomimic/rldb/embodiment/pushshapes.py
@@ -50,7 +50,9 @@ def _draw_chunk(
 ) -> np.ndarray:
     """Draw an action chunk as palette-graded dots on ``frame``.
 
-    ``actions`` is (N, 2) in world (0–512) coords; ``scale`` maps world→pixel.
+    ``actions`` is (N, D) with world xy in the first two coordinates; optional
+    extra coordinates (for example U-socket theta) are ignored by this xy
+    trajectory overlay. ``scale`` maps world→pixel.
     Uses ``draw_dot_on_frame`` (main-branch pattern) so consecutive dots are
     colored along a perceptual gradient — viewer can see chunk ordering at a
     glance. Returns the modified frame (draw_dot_on_frame returns a copy).
@@ -306,10 +308,14 @@ def get_rotvec_transform_list():
     :func:`get_rotvec_revert_transform_list` (wired into SimEval 2026-08-04).
     """
     from egomimic.rldb.zarr.action_chunk_transforms import ThetaToRotVec
-    return [ThetaToRotVec(keys=["actions",
-                                "pusher_cmd_pose",
-                                "observations.pusher_cmd_pose"],
-                          angle_col=2)]
+    return [
+        # actions ALWAYS exist -> strict
+        ThetaToRotVec(keys=["actions"], angle_col=2),
+        # pusher_cmd_pose exists only under get_keymap_with_pusher_cmd -> optional.
+        # ("observations.pusher_cmd_pose" was a ZARR PATH and could never match:
+        #  transforms see key_map ALIASES.)
+        ThetaToRotVec(keys=["pusher_cmd_pose"], angle_col=2, strict=False),
+    ]
 
 
 def get_rotvec_revert_transform_list(keys=None, angle_col: int = 2):
@@ -324,3 +330,99 @@ def get_rotvec_revert_transform_list(keys=None, angle_col: int = 2):
     if keys is None:
         keys = ["actions", "pusher_cmd_pose", "observations.pusher_cmd_pose"]
     return [RotVecToTheta(keys=list(keys), angle_col=int(angle_col))]
+
+def get_split_rotvec_transform_list(pusher_dim: int, pusher_has_angle: bool):
+    """SPLIT state into named pusher/object poses, then ROTVEC every angle.
+
+    The A/S split PushShapes actually wants:
+        S <- pusher_pose   embodiment-specific  (circle 2, u_socket 3->4)
+        A <- object_pose   the task object      (3 -> 4 for BOTH)
+    so A takes a genuinely uniform 4-D object pose and never sees a stream
+    whose width depends on the embodiment.
+
+    Every angle becomes (cos, sin) so no consumer receives a wrapping angle:
+      circle    pusher (x,y)          object (x,y,ot)  -> object 4-D
+      u_socket  pusher (x,y,pt) -> 4  object (x,y,ot)  -> object 4-D
+
+    Angle columns AFTER the split are local to each key, which is the point of
+    splitting first: no offset arithmetic that shifts with pusher arity.
+    """
+    from egomimic.rldb.zarr.action_chunk_transforms import (
+        SplitPusherObject, ThetaToRotVec)
+    tl = [SplitPusherObject(pusher_dim=int(pusher_dim))]
+    if pusher_has_angle:
+        # pusher_pose = (x, y, theta) -> angle at col 2
+        tl.append(ThetaToRotVec(keys=["pusher_pose"], angle_col=2))
+    # object_pose = (x, y, theta) -> angle at col 2, for BOTH embodiments
+    tl.append(ThetaToRotVec(keys=["object_pose"], angle_col=2))
+    return tl
+
+
+def get_circle_split_transform_list():
+    """circle: pusher (x,y) has no angle; object angle -> (cos,sin)."""
+    return get_split_rotvec_transform_list(pusher_dim=2, pusher_has_angle=False)
+
+
+def get_usocket_split_transform_list():
+    """u_socket: BOTH pusher and object angles -> (cos,sin); actions too."""
+    from egomimic.rldb.zarr.action_chunk_transforms import ThetaToRotVec
+    tl = get_split_rotvec_transform_list(pusher_dim=3, pusher_has_angle=True)
+    # actions / commanded pose are (x, y, theta) -> 4-D, matching action_dims 4
+    tl.append(ThetaToRotVec(keys=["actions"], angle_col=2))
+    tl.append(ThetaToRotVec(keys=["pusher_cmd_pose"], angle_col=2, strict=False))
+    return tl
+
+
+def get_keymap_split(action_horizon: int = 32, **kwargs) -> dict:
+    """Keymap for the pusher/object split.
+
+    Two constraints pull in opposite directions:
+      * the READER fetches ``spec["zarr_key"]`` for every entry BEFORE any
+        transform runs -- naming a transform-produced path raises KeyError;
+      * ``Algo._build_obs`` only forwards keys listed in ``proprio_keys`` /
+        ``camera_keys``, so a key that is merely added by a transform never
+        reaches the stages at all (it is silently dropped from ``obs/``).
+
+    Both are satisfied by pointing the new names at a path that DOES exist --
+    ``observations.state`` -- so the reader loads the full state as a
+    placeholder under each name, and :class:`SplitPusherObject` then overwrites
+    ``pusher_pose`` / ``object_pose`` with their slices. The entries exist for
+    CLASSIFICATION; their loaded contents are always replaced.
+    """
+    key_map = get_keymap(action_horizon=action_horizon, **kwargs)
+    for name in ("pusher_pose", "object_pose"):
+        key_map[name] = {"key_type": "proprio_keys",
+                         "zarr_key": "observations.state",
+                         "horizon": int(action_horizon)}
+    return key_map
+
+
+def get_rotvec_transform_list_with_proprio():
+    """u_socket theta -> (cos, sin) on actions AND PROPRIO (user, 2026-08-11).
+
+    ``get_rotvec_transform_list`` covers actions / pusher_cmd_pose only, so a
+    model trained with it PREDICTS (x, y, cos, sin) while OBSERVING a raw
+    wrapping angle in ``state_agent_obj`` -- the +/-pi discontinuity stays in
+    the input. This variant transforms the proprio too, so both sides of the
+    policy use the same rotation encoding.
+
+    Pair with: action_dims {pushshapes_sim: 2, pushshapes_sim_u_socket: 4},
+    latent_dim >= 4, u_socket obs_specs input_dim 4 / input_slice [0, 4], and
+    FRESH 4-dim action norm stats (the 2-D circle json does NOT apply).
+    """
+    # NOTE the key is observations.state, NOT observations.state_agent_obj:
+    # state_agent_obj is the KEYMAP alias, the zarr array is observations.state.
+    # ThetaToRotVec skips unknown keys silently, so a wrong name here is a
+    # NO-OP that leaves proprio un-rotvec'd while the config still slices 4
+    # columns -- pulling object_x in as a phantom 'sin'.
+    #   u_socket observations.state (T,6) = [px, py, ptheta | ox, oy, otheta]
+    #   -> angle_col=2 is pusher theta -> (T,7) [px, py, cos, sin | ox, oy, otheta]
+    #   -> input_slice [0,4] = (px, py, cos, sin).  CIRCLE MUST NOT GET THIS
+    #   transform: its col 2 is object_x, not an angle.
+    from egomimic.rldb.zarr.action_chunk_transforms import ThetaToRotVec
+    return [ThetaToRotVec(keys=["actions",
+                                "pusher_cmd_pose",
+                                "observations.pusher_cmd_pose",
+                                "observations.state"],
+                          angle_col=2)]
+

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -615,13 +615,22 @@ class ThetaToRotVec(Transform):
     list both spellings where unsure).
     """
 
-    def __init__(self, keys, angle_col: int = 2):
+    def __init__(self, keys, angle_col: int = 2, strict: bool = True):
         self.keys = list(keys)
         self.angle_col = int(angle_col)
+        self.strict = bool(strict)
 
     def transform(self, batch: dict) -> dict:
         for k in self.keys:
             if k not in batch:
+                if self.strict:
+                    raise KeyError(
+                        f"{type(self).__name__}: key {k!r} not in batch "
+                        f"(have: {sorted(batch)[:12]}). A wrong key here is "
+                        f"a NO-OP that leaves the angle un-encoded while "
+                        f"downstream still slices for (cos, sin). Transforms "
+                        f"see KEY_MAP ALIASES, not zarr paths. Pass "
+                        f"strict=False for genuinely optional keys.")
                 continue
             a = np.asarray(batch[k])
             if a.ndim != 2 or a.shape[1] <= self.angle_col:
@@ -647,14 +656,23 @@ class RotVecToTheta(Transform):
     renormalisation is required.
     """
 
-    def __init__(self, keys, angle_col: int = 2):
+    def __init__(self, keys, angle_col: int = 2, strict: bool = True):
         self.keys = list(keys)
         self.angle_col = int(angle_col)
+        self.strict = bool(strict)
 
     def transform(self, batch: dict) -> dict:
         c = self.angle_col
         for k in self.keys:
             if k not in batch:
+                if self.strict:
+                    raise KeyError(
+                        f"{type(self).__name__}: key {k!r} not in batch "
+                        f"(have: {sorted(batch)[:12]}). A wrong key here is "
+                        f"a NO-OP that leaves the angle un-encoded while "
+                        f"downstream still slices for (cos, sin). Transforms "
+                        f"see KEY_MAP ALIASES, not zarr paths. Pass "
+                        f"strict=False for genuinely optional keys.")
                 continue
             a = np.asarray(batch[k])
             if a.ndim != 2 or a.shape[1] <= c + 1:
@@ -662,4 +680,58 @@ class RotVecToTheta(Transform):
             th = np.arctan2(a[:, c + 1], a[:, c])
             batch[k] = np.concatenate(
                 [a[:, :c], th[:, None].astype(a.dtype), a[:, c + 2:]], axis=1)
+        return batch
+
+class SplitPusherObject(Transform):
+    """Split PushShapes ``state_agent_obj`` into NAMED pusher / object poses.
+
+    PushShapes packs both bodies into one array whose LAYOUT DIFFERS by
+    embodiment::
+
+        circle    (T, 5) = [px, py     | ox, oy, otheta]
+        u_socket  (T, 6) = [px, py, pt | ox, oy, otheta]
+
+    Consumers previously had to slice this by offset, which is how object_x
+    once ended up inside the proprio: the offset of the object block moves
+    with the pusher's arity, so one ``input_slice`` cannot be right for both.
+    Emitting explicit keys removes the guess entirely --
+
+        ``pusher_pose``   the EMBODIMENT-specific body  -> the S stream
+        ``object_pose``   the task object, 3-D for BOTH -> the A stream
+
+    Angles are NOT touched here: chain :class:`ThetaToRotVec` afterwards on
+    whichever keys need it. Splitting and rotation-encoding are separate
+    concerns, and rotvec has several other call sites (actions, cmd pose).
+
+    Args:
+        pusher_dim: columns belonging to the pusher (2 circle, 3 u_socket).
+            Everything after them is the object block.
+        src: source key. NOTE this is the KEY_MAP ALIAS as it appears in the
+            loaded dict (``state_agent_obj``), not the zarr path
+            (``observations.state``) -- transforms run AFTER the key_map has
+            already renamed things.
+    """
+
+    def __init__(self, pusher_dim: int, src: str = "state_agent_obj",
+                 pusher_key: str = "pusher_pose",
+                 object_key: str = "object_pose"):
+        self.pusher_dim = int(pusher_dim)
+        self.src = str(src)
+        self.pusher_key = str(pusher_key)
+        self.object_key = str(object_key)
+
+    def transform(self, batch: dict) -> dict:
+        a = batch.get(self.src)
+        if a is None:
+            raise KeyError(
+                f"SplitPusherObject: {self.src!r} not in batch (have: "
+                f"{sorted(batch)[:12]}). Transforms see KEY_MAP aliases, not "
+                f"zarr paths.")
+        a = np.asarray(a)
+        if a.ndim != 2 or a.shape[1] <= self.pusher_dim:
+            raise ValueError(
+                f"SplitPusherObject: {self.src!r} has shape {a.shape}, expected "
+                f"2-D with more than pusher_dim={self.pusher_dim} columns.")
+        batch[self.pusher_key] = a[:, :self.pusher_dim]
+        batch[self.object_key] = a[:, self.pusher_dim:]
         return batch

--- a/tools/config_graph.py
+++ b/tools/config_graph.py
@@ -1,0 +1,240 @@
+"""Build a routing graph from a pipeline config, for inspection and validation.
+
+WHY INSTANTIATE RATHER THAN PARSE
+---------------------------------
+Every ``Stage`` declares ``self.reads`` / ``self.writes`` in its constructor,
+and several stages *derive* those from defaults -- ``StreamTrunk`` and ``Apex``
+both fall back to writing their input key when no output is named. A parser
+that reads only the literal yaml fields therefore reports them as writing
+nothing, which is exactly the bug this module replaced. Instantiating the
+stages and reading the declared keys is ground truth and cannot drift from the
+code.
+
+The cost is that this needs the real environment (torch + egomimic importable);
+that is the right trade for a tool whose job is to tell you whether a config is
+wired correctly.
+
+USAGE
+    python config_graph.py graph.json  path/to/model/*.yaml
+    python config_graph.py --html viz.html --template tpl.html graph.json  *.yaml
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, Iterable, List, Sequence
+
+# Stage-name -> section of the pipeline. Sections are the coarse reading order
+# of a config (obs -> trunk -> head); anything unlisted lands in OTHER so a new
+# stage shows up as unclassified rather than being silently grouped wrong.
+SECTIONS: Dict[str, str] = {}
+for _sec, _names in (
+    ("OBS", ("TargetBuilder", "ObsNoise", "TimePos", "VisualEncode", "ObsEmbed",
+             "Fuse", "ObsEncoders", "SharedObsEncoders")),
+    ("MAIN TRUNK", ("StreamTrunk", "Framewise", "Chunk", "Dechunk", "Apex", "Mix",
+                    "Rename", "DualstreamTrunk")),
+    ("ACTION PREDICTION", ("SDPHead", "FlowHead", "DiffusionHead", "GMMHead",
+                           "RegressionHead", "RatioLoss", "ScheduledRatioLoss")),
+):
+    for _n in _names:
+        SECTIONS[_n] = _sec
+
+# Which stream a batch key belongs to. Order matters: the agnostic/specific
+# prefixes are checked before the generic fallbacks.
+_STREAM_RULES = (
+    ("route", (r"^route",)),
+    ("A", (r"^A(_|$)", r"^a_top$", r"^emb_object$", r"^feat_img_a$", r"^apex/")),
+    ("S", (r"^S(_|$)", r"^s$", r"^emb_pusher$", r"^feat_img_s$")),
+)
+
+
+def stream_of(key: str) -> str:
+    """Classify a batch key into A / S / route / shared."""
+    for name, pats in _STREAM_RULES:
+        if any(re.search(p, key) for p in pats):
+            return name
+    return "shared"
+
+
+def depth_of(key: str) -> int:
+    """Pyramid level encoded in the key name (``A_L1`` -> 1). 0 when absent."""
+    m = re.search(r"_L(\d+)", key)
+    return int(m.group(1)) if m else 0
+
+
+def _expand(keys: Iterable[str], batch_keys: Iterable[str]) -> List[str]:
+    """Resolve glob declarations like ``obs/*`` against keys seen so far.
+
+    ``ObsNoise`` declares ``obs/*`` because it operates on whatever image keys
+    the config gave it. Left unexpanded, such a node would connect to nothing.
+    """
+    out, pool = [], list(batch_keys)
+    for k in keys:
+        if k.endswith("*"):
+            pre = k[:-1]
+            out.extend(sorted(b for b in pool if b.startswith(pre)))
+        else:
+            out.append(k)
+    seen, uniq = set(), []
+    for k in out:
+        if k not in seen:
+            seen.add(k)
+            uniq.append(k)
+    return uniq
+
+
+# Constructor arguments that are large nested blocks: keep them, but as compact
+# JSON so the hover panel stays readable instead of dumping a whole sub-tree.
+_NESTED = ("encoder", "main_network", "streams_cfg", "residual_mixer_kwargs",
+           "mixer_kwargs", "transforms", "obs_specs", "img_encoders", "mapping")
+
+
+def hyperparams(cfg_stage: Any, limit: int = 400) -> Dict[str, Any]:
+    """Config-declared arguments for one stage, flattened for display."""
+    out: Dict[str, Any] = {}
+    for k, v in dict(cfg_stage).items():
+        if k == "_target_":
+            continue
+        if isinstance(v, (str, int, float, bool)) or v is None:
+            out[k] = v
+        else:
+            out[k] = json.dumps(_plain(v), separators=(",", ":"))[:limit]
+    return out
+
+
+def _plain(v: Any) -> Any:
+    """OmegaConf containers -> plain python, so json can serialise them."""
+    try:
+        from omegaconf import OmegaConf
+        if OmegaConf.is_config(v):
+            return OmegaConf.to_container(v, resolve=False)
+    except Exception:
+        pass
+    if isinstance(v, dict):
+        return {k: _plain(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_plain(x) for x in v]
+    return v
+
+
+def build_graph(path: str) -> Dict[str, Any]:
+    """Instantiate a config's stages and return its routing graph.
+
+    Nodes carry the stage's DECLARED reads/writes (not the yaml literals), its
+    section, stream, pyramid depth and hyperparameters. Edges connect the
+    most recent writer of a key to each subsequent reader -- i.e. the actual
+    dataflow order, so a key read before anything writes it produces no edge
+    and shows up as a dangling input.
+    """
+    import yaml
+    from hydra.utils import instantiate
+    from omegaconf import OmegaConf
+
+    raw = yaml.safe_load(open(path))
+    cfg = OmegaConf.create(raw)
+    cfg_stages = list(cfg.robomimic_model.stages)
+
+    nodes: List[Dict[str, Any]] = []
+    edges: List[Dict[str, Any]] = []
+    producer: Dict[str, int] = {}
+    seen_keys: List[str] = ["cu_seqlens", "max_seq_len", "embodiment", "actions",
+                            "obs/front_img_1", "obs/object_pose", "obs/pusher_pose",
+                            "obs/state_agent_obj", "aux/chunker"]
+
+    for i, cs in enumerate(cfg_stages):
+        stage = instantiate(cs)
+        name = str(cs["_target_"]).split(".")[-1]
+        reads = _expand(list(getattr(stage, "reads", []) or []), seen_keys)
+        writes = _expand(list(getattr(stage, "writes", []) or []), seen_keys)
+        streams = {stream_of(k) for k in (writes or reads)} or {"shared"}
+        stream = streams.pop() if len(streams) == 1 else "both"
+        depth = max([depth_of(k) for k in (writes or reads)] or [0])
+
+        nodes.append({
+            "i": i, "t": name, "sec": SECTIONS.get(name, "OTHER"),
+            "stream": stream, "depth": depth,
+            "in": reads, "out": writes, "p": hyperparams(cs),
+        })
+        for k in reads:
+            if k in producer:
+                edges.append({"a": producer[k], "b": i, "k": k, "s": stream_of(k)})
+        for k in writes:
+            producer[k] = i
+            if k not in seen_keys:
+                seen_keys.append(k)
+
+    return {"nodes": nodes, "edges": edges,
+            "domains": _plain(cfg.robomimic_model.get("domains", [])),
+            "source": os.path.basename(path)}
+
+
+def lint(graph: Dict[str, Any]) -> List[str]:
+    """Structural problems worth failing a config review over."""
+    problems: List[str] = []
+    written = {k for n in graph["nodes"] for k in n["out"]}
+    ambient = {"cu_seqlens", "max_seq_len", "embodiment", "actions", "target",
+               "aux/chunker", "time_pos"}
+    for n in graph["nodes"]:
+        if not n["out"]:
+            problems.append(f"stage {n['i']} {n['t']}: declares no writes")
+        for k in n["in"]:
+            if k not in written and not k.startswith("obs/") and k not in ambient:
+                problems.append(f"stage {n['i']} {n['t']}: reads {k!r}, never written")
+    # Terminal outputs are consumed OUTSIDE the stage list -- by the lightning
+    # module, the loss aggregator or an eval hook -- so an unread write here is
+    # only suspicious for intermediate keys.
+    TERMINAL = ("apex/", "log/", "loss/", "aux/", "chunk/")
+    TERMINAL_EXACT = {"pred_action", "target", "frame_idx", "max_seq_len",
+                      "time_pos", "cu_seqlens"}
+    consumed = {e["k"] for e in graph["edges"]}
+    for n in graph["nodes"]:
+        for k in n["out"]:
+            if (k not in consumed and not k.startswith(TERMINAL)
+                    and k not in TERMINAL_EXACT and not k.startswith("obs/")):
+                problems.append(f"stage {n['i']} {n['t']}: writes {k!r}, never read")
+    return problems
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("out_json")
+    ap.add_argument("configs", nargs="+")
+    ap.add_argument("--html", help="also render this standalone viz file")
+    ap.add_argument("--template", help="HTML template containing __DATA__")
+    ap.add_argument("--lint", action="store_true", help="print structural problems")
+    a = ap.parse_args(argv)
+
+    graphs: Dict[str, Any] = {}
+    for path in a.configs:
+        name = os.path.basename(path)[:-5]
+        try:
+            graphs[name] = build_graph(path)
+        except Exception as exc:                      # keep going; report at the end
+            print(f"  {name:40s} FAILED: {type(exc).__name__}: {exc}", file=sys.stderr)
+            continue
+        g = graphs[name]
+        print(f"  {name:40s} {len(g['nodes']):2d} nodes {len(g['edges']):3d} edges")
+        if a.lint:
+            for p in lint(g):
+                print(f"      ! {p}")
+
+    json.dump(graphs, open(a.out_json, "w"), separators=(",", ":"))
+    print(f"wrote {a.out_json} ({os.path.getsize(a.out_json)} bytes)")
+
+    if a.html:
+        if not a.template:
+            ap.error("--html requires --template")
+        tpl = open(a.template).read()
+        if "__DATA__" not in tpl:
+            ap.error("template has no __DATA__ placeholder")
+        open(a.html, "w").write(
+            tpl.replace("__DATA__", json.dumps(graphs, separators=(",", ":"))))
+        print(f"wrote {a.html} ({os.path.getsize(a.html)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Dissolves DualstreamTrunk (which nests level i.inner = level i+1 and recurses
mid-forward) into an explicit, flat stages list. Every stage declares `reads`
and `writes`, so the wiring is inspectable from the config alone rather than
implied by nesting.

  stages_seq.py   StreamTrunk, Framewise, Chunk, Dechunk, Apex, Mix, Rename,
                  ScheduledRatioLoss, ObsNoise, VisualEncode, ObsEmbed, Fuse,
                  TimePos -- the encoder is stages too, so obs routing is
                  visible instead of hidden inside an encoder module.
  config_graph.py builds the routing graph by INSTANTIATING each stage and
                  reading its declared reads/writes (ground truth, not a yaml
                  parse), with a lint for dim/key mismatches and a 3D viewer.

Configs: 7 arms -- a baseline plus shared/separate encoder and attention-window
variants, on circle+small_circle and circle+u_socket.

Also carried over from the working stack, without which the above cannot run:
per-stream trunk options (multi_stream_trunk), route_on / separate_boundaries
on DualStreamRouter, SharedObsEncoders + DeriveVelocity (stages_io), StreamMLP
(stages_hnet), the hetero denoiser and per-embodiment codec (stages_flow), and
confidence_ssl.

Strictness: CondEncoderModule gains strict_keys and Theta/RotVec gain strict,
both default True. A mis-typed key was previously a silent no-op -- an encoder
would train on the remaining inputs (vision with no proprio) with no error, and
a rotvec transform would leave the angle un-encoded while downstream still
sliced for (cos, sin). Transforms and encoders see KEY_MAP ALIASES, not zarr
paths; get_rotvec_transform_list previously passed
"observations.pusher_cmd_pose", a zarr path that could never match.

Verified from this repo (not the working stack): all symbols import including
the pre-existing PadGripperZeros, strict=True raises and strict=False passes
through, and all 7 configs instantiate with a clean lint, producing node/edge
counts identical to the stack that is currently training them.