### PR TITLE
fix(zarr_writer): shard edge must be >=1 for empty annotations

### DIFF
--- a/egomimic/rldb/zarr/zarr_writer.py
+++ b/egomimic/rldb/zarr/zarr_writer.py
@@ -675,12 +675,18 @@ class ZarrWriter:
         )
 
         n_annotations = len(annotations)
+        # Both the chunk and the SHARD edge must be >= 1 even when there are no
+        # annotations: zarr v3 rejects a zero-length chunk grid, so an episode
+        # written with shards=(0,) cannot be enumerated (group.keys() raises
+        # "integer chunk edge length must be >= 1") even though the array itself
+        # reads back fine. shape=(0,) with a >=1 edge is the correct encoding of
+        # "empty" -- no chunk objects are written either way.
         chunk_shape = (max(1, n_annotations),)
         store.create_array(
             annotation_key,
             shape=encoded.shape,
             chunks=chunk_shape,
-            shards=(n_annotations,),
+            shards=(max(1, n_annotations),),
             dtype=VariableLengthBytes(),
         )
         if n_annotations > 0:


### PR DESCRIPTION
An episode with no language annotations was written with shards=(0,), which
zarr v3 rejects (chunk edge must be >= 1). The array still reads back fine, so
training is unaffected (the loader takes its key list from attrs["features"]
and addresses arrays directly), but any group enumeration -- group.keys(),
.members(), tree walks, external tooling speaking the zarr group API -- raises
"Dimension 0: integer chunk edge length must be >= 1, got 0".

chunks= already clamped with max(1, n); shards= was missed. shape=(0,) with a
>=1 edge is the correct encoding of empty and writes no chunk objects either way.

Affects 2,541 already-written episodes (2,538 aria + 3 trace); those are left
as-is (metadata-only defect, no functional impact on our pipeline).