### PR TITLE
jmni/zarr_registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # The locked environment carries the CUDA torch stack (~4 GB of nvidia-*
-      # wheels). The hosted runner fits it only once the preinstalled toolchains
-      # nothing here uses are gone.
+      # Remove unused toolchains before uv installs approximately 4 GB of
+      # NVIDIA wheels.
       - name: Free disk space
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
@@ -27,13 +26,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          # Not cached on purpose: the resolved environment is ~5 GB, which
-          # would consume most of the repository's 10 GB Actions cache quota.
+          # Disable caching. The uv cache is approximately 5 GB, and the
+          # repository has a 10 GB Actions cache quota.
           enable-cache: false
 
-      # `--locked` is the check that keeps this honest: CI runs the environment
-      # `pyproject.toml` + `uv.lock` describe, the same one developers get from
-      # `uv sync`, and fails if the two have drifted.
+      # Install the versions in uv.lock. Fail if pyproject.toml and uv.lock do
+      # not agree.
       - name: Sync the locked environment
         run: uv sync --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The locked environment carries the CUDA torch stack (~4 GB of nvidia-*
+      # wheels). The hosted runner fits it only once the preinstalled toolchains
+      # nothing here uses are gone.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          # Not cached on purpose: the resolved environment is ~5 GB, which
+          # would consume most of the repository's 10 GB Actions cache quota.
+          enable-cache: false
+
+      # `--locked` is the check that keeps this honest: CI runs the environment
+      # `pyproject.toml` + `uv.lock` describe, the same one developers get from
+      # `uv sync`, and fails if the two have drifted.
+      - name: Sync the locked environment
+        run: uv sync --locked
+
+      - name: Collect tests
+        run: uv run --no-sync pytest --collect-only -q
+
+      - name: Run unit tests
+        run: uv run --no-sync pytest -q
+
+      - name: Lint
+        run: uv run --no-sync ruff check egomimic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,17 @@
 # Repo Agent Rules
 
 ## Shell / Command Execution
-to run commands in the interactive shell make sure to source emimic/bin/activate
+The project environment is the uv environment described by `pyproject.toml` +
+`uv.lock`. Create or update it with `uv sync`, and run project Python tooling
+through it — `uv run pytest`, `uv run ruff check egomimic` — or activate it
+(`source .venv/bin/activate`) first. Do not `pip install` into it; add the
+dependency to `pyproject.toml` and re-run `uv sync`, or CI's `uv sync --locked`
+will fail.
 
-Apply this before running project Python tooling (for example: `python`, `pytest`, `pip`).
+If your environment lives under a different name (this machine uses `ev`), set
+`UV_PROJECT_ENVIRONMENT` to it. Point `UV_CACHE_DIR` and `UV_PYTHON_INSTALL_DIR`
+at scratch storage on any machine with a small home quota — the locked
+environment carries the CUDA torch stack and is several GB.
 
 ## Model settings
 use plan mode for anything except extremely simple tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,19 @@
 # Repo Agent Rules
 
 ## Shell / Command Execution
-The project environment is the uv environment described by `pyproject.toml` +
-`uv.lock`. Create or update it with `uv sync`, and run project Python tooling
-through it — `uv run pytest`, `uv run ruff check egomimic` — or activate it
-(`source .venv/bin/activate`) first. Do not `pip install` into it; add the
-dependency to `pyproject.toml` and re-run `uv sync`, or CI's `uv sync --locked`
-will fail.
+Use the uv environment that `pyproject.toml` and `uv.lock` specify. Run
+`uv sync` to create or update the environment. Run Python tools through uv, for
+example, `uv run pytest` or `uv run ruff check egomimic`. You can also run
+`source .venv/bin/activate` before you use the tools.
 
-If your environment lives under a different name (this machine uses `ev`), set
-`UV_PROJECT_ENVIRONMENT` to it. Point `UV_CACHE_DIR` and `UV_PYTHON_INSTALL_DIR`
-at scratch storage on any machine with a small home quota — the locked
-environment carries the CUDA torch stack and is several GB.
+Do not use `pip install`. Add each dependency to `pyproject.toml`, and then run
+`uv sync`. CI uses `uv sync --locked` and fails if the manifest and lock file do
+not agree.
+
+Set `UV_PROJECT_ENVIRONMENT` if the environment directory is not `.venv`. This
+machine uses `ev`. The locked environment includes several gigabytes of CUDA
+packages. If the home directory has a small quota, set `UV_CACHE_DIR` and
+`UV_PYTHON_INSTALL_DIR` to directories on scratch storage.
 
 ## Model settings
 use plan mode for anything except extremely simple tasks

--- a/CONTRIBUTING_DATA.md
+++ b/CONTRIBUTING_DATA.md
@@ -421,8 +421,9 @@ The root group's `.attrs` dictionary is the **episode metadata**. It is written 
     "intrinsics":        dict,  # MANDATORY: {camera_key: 3x4 K matrix} dict (single-camera =
                                 #   one entry, e.g. {"front_1": K}; 3x4 = the 3x3 pinhole K
                                 #   with a zero last column). Projection uses the "front" entry.
-    "extrinsics":  dict | None, # None, or a non-empty dict of 4x4 world<-cam transforms.
-                                #   Robots key per-arm, e.g. {"left": T, "right": T}.
+    "extrinsics":  dict | None, # None, or a non-empty dict of 4x4 ref_T_cam transforms.
+                                #   Robots key per-arm, e.g. {"left": left_base_T_cam,
+                                #   "right": right_base_T_cam}.
                                 #   Egocentric human contributors omit it (None).
     "features": {
         "<key>": {
@@ -445,7 +446,7 @@ The root group's `.attrs` dictionary is the **episode metadata**. It is written 
 - `features` must have one entry per array key present in the store.
 - `embodiment` and `task_name` must exactly match the values in the DB row for this episode.
 - `intrinsics` is **mandatory** and is always a `{camera_key: 3×4 K matrix}` dict in `zarr.attrs` (single-camera = one entry, e.g. `{"front_1": K}`). `ZarrWriter.create_and_write` raises if it is not a non-empty dict.
-- `extrinsics` is **either `None` or a non-empty `dict`** of 4×4 world↔cam transforms (robots key per-arm, e.g. `{"left": T, "right": T}`); egocentric human contributors omit it (`None`). `ZarrWriter.create_and_write` raises if it is anything other than `None` or a non-empty dict.
+- `extrinsics` is **either `None` or a non-empty `dict`** of 4×4 `ref_T_cam` transforms: each value is the camera pose in its reference frame ([coordinate conventions](docs/CONVENTIONS.md)). Robots key it per-arm, e.g. `{"left": base_T_cam, "right": base_T_cam}`; egocentric human contributors omit it (`None`). `ZarrWriter.create_and_write` raises if it is anything other than `None` or a non-empty dict.
 
 ### 6.4 Storage / Chunking
 
@@ -466,7 +467,7 @@ Do **not** hand-write these into `zarr.attrs` yourself. Pass them to `ZarrWriter
 - **`intrinsics` is a REQUIRED `dict`** of the form `{camera_key: 3x4 K matrix}` — `create_and_write` raises a `ValueError` if it is not a non-empty dict. **Single-camera setups still use a dict — just one entry**, e.g. `{"front_1": K}`. (Always a dict, so downstream code has one clear structure to handle.)
 - Each value is a **3×4** K matrix: the standard 3×3 pinhole matrix with an appended **zero column** (i.e. `[K | 0]`). A bare 3×3 is rejected on the projection path — pad it with `np.hstack([K_3x3, np.zeros((3, 1))])`.
 - **Multi-camera rigs:** add one entry per camera, e.g. `{"front_1": K_front, "left_wrist": K_lw, "right_wrist": K_rw}`. The training/viz projection uses the **front-camera** entry (the key containing `front`), so make sure that one is present and correct.
-- **`extrinsics`** is **`None` or a non-empty `dict`** of 4×4 world↔cam transforms — `create_and_write` raises on anything else. **Robots** key it **per-arm**, e.g. `{"left": T_left, "right": T_right}`; egocentric **human** contributors pass `None` (omit it).
+- **`extrinsics`** is **`None` or a non-empty `dict`** of 4×4 `ref_T_cam` transforms — `create_and_write` raises on anything else. Each value is the camera pose in its reference frame ([coordinate conventions](docs/CONVENTIONS.md)). **Robots** key it **per-arm**, e.g. `{"left": left_base_T_cam, "right": right_base_T_cam}`; egocentric **human** contributors pass `None` (omit it).
 
 ```python
 import numpy as np

--- a/CONTRIBUTING_DATA.md
+++ b/CONTRIBUTING_DATA.md
@@ -446,7 +446,13 @@ The root group's `.attrs` dictionary is the **episode metadata**. It is written 
 - `features` must have one entry per array key present in the store.
 - `embodiment` and `task_name` must exactly match the values in the DB row for this episode.
 - `intrinsics` is **mandatory** and is always a `{camera_key: 3×4 K matrix}` dict in `zarr.attrs` (single-camera = one entry, e.g. `{"front_1": K}`). `ZarrWriter.create_and_write` raises if it is not a non-empty dict.
-- `extrinsics` is **either `None` or a non-empty `dict`** of 4×4 `ref_T_cam` transforms: each value is the camera pose in its reference frame ([coordinate conventions](docs/CONVENTIONS.md)). Robots key it per-arm, e.g. `{"left": base_T_cam, "right": base_T_cam}`; egocentric human contributors omit it (`None`). `ZarrWriter.create_and_write` raises if it is anything other than `None` or a non-empty dict.
+- `extrinsics` must be `None` or a non-empty dictionary of 4×4 `ref_T_cam`
+  transforms. Each matrix gives the camera pose in its reference frame. See
+  [Coordinate conventions](docs/CONVENTIONS.md). Robot episodes use the arm
+  names as keys. For example, use
+  `{"left": left_base_T_cam, "right": right_base_T_cam}`. Egocentric human
+  episodes use `None`.
+  `ZarrWriter.create_and_write` rejects all other values.
 
 ### 6.4 Storage / Chunking
 
@@ -467,7 +473,13 @@ Do **not** hand-write these into `zarr.attrs` yourself. Pass them to `ZarrWriter
 - **`intrinsics` is a REQUIRED `dict`** of the form `{camera_key: 3x4 K matrix}` — `create_and_write` raises a `ValueError` if it is not a non-empty dict. **Single-camera setups still use a dict — just one entry**, e.g. `{"front_1": K}`. (Always a dict, so downstream code has one clear structure to handle.)
 - Each value is a **3×4** K matrix: the standard 3×3 pinhole matrix with an appended **zero column** (i.e. `[K | 0]`). A bare 3×3 is rejected on the projection path — pad it with `np.hstack([K_3x3, np.zeros((3, 1))])`.
 - **Multi-camera rigs:** add one entry per camera, e.g. `{"front_1": K_front, "left_wrist": K_lw, "right_wrist": K_rw}`. The training/viz projection uses the **front-camera** entry (the key containing `front`), so make sure that one is present and correct.
-- **`extrinsics`** is **`None` or a non-empty `dict`** of 4×4 `ref_T_cam` transforms — `create_and_write` raises on anything else. Each value is the camera pose in its reference frame ([coordinate conventions](docs/CONVENTIONS.md)). **Robots** key it **per-arm**, e.g. `{"left": left_base_T_cam, "right": right_base_T_cam}`; egocentric **human** contributors pass `None` (omit it).
+- `extrinsics` must be `None` or a non-empty dictionary of 4×4 `ref_T_cam`
+  transforms. Each matrix gives the camera pose in its reference frame. See
+  [Coordinate conventions](docs/CONVENTIONS.md). Robot episodes use the arm
+  names as keys. For example, use
+  `{"left": left_base_T_cam, "right": right_base_T_cam}`. Egocentric human
+  episodes pass `None`.
+  `create_and_write` rejects all other values.
 
 ```python
 import numpy as np

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,21 +1,29 @@
 # Coordinate conventions
 
-A homogeneous transform named `A_T_B` maps points expressed in frame `B` into
-frame `A`:
+## Transform names
+
+A homogeneous transform named `A_T_B` maps coordinates from frame `B` to frame
+`A`.
 
 ```text
 p_A = A_T_B @ p_B
 A_T_C = A_T_B @ B_T_C
 ```
 
-The name therefore describes the destination frame first and the source frame
-second. For example, `base_T_cam` is the camera pose in the robot base frame;
-`inv(base_T_cam)` maps a base-frame point into the camera frame. Use the same
-ordering for rotations (`A_R_B`).
+`A` is the destination frame. `B` is the source frame. For example,
+`base_T_cam` is the camera pose in the robot base frame. Its inverse maps
+coordinates from the robot base frame to the camera frame.
 
-Episode `extrinsics` values follow this convention. Existing EVA episodes store
-one `base_T_cam` per arm. Human head poses are `world_T_head`; for egocentric
-data the head frame is the camera frame.
+Use `A_R_B` for a rotation that maps coordinates from frame `B` to frame `A`.
 
-Pose arrays use metres and `[x, y, z, qw, qx, qy, qz]` unless a key or function
-explicitly says it contains ZYX yaw, pitch, and roll.
+## Episode transforms
+
+EVA episode extrinsics store one `base_T_cam` matrix for each arm. Human
+episodes store the head pose as `world_T_head`. The head frame and the camera
+frame are the same frame for egocentric human data.
+
+## Pose arrays
+
+Pose translations use metres. Quaternion poses use `[x, y, z, qw, qx, qy,
+qz]`. A key or function must identify an Euler pose explicitly. Euler poses
+use ZYX yaw, pitch, and roll.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -22,6 +22,25 @@ EVA episode extrinsics store one `base_T_cam` matrix for each arm. Human
 episodes store the head pose as `world_T_head`. The head frame and the camera
 frame are the same frame for egocentric human data.
 
+### Existing episodes need no migration
+
+The `ref_T_cam` naming records the direction the code already used. It changes
+no stored value.
+
+Two writers have ever set `extrinsics`: `eva_to_zarr.py` and `hdf5_to_zarr.py`.
+Both pass `Eva.EXTRINSICS` to the writer unmodified, and no write path inverts
+it. Every stored EVA episode therefore holds the camera pose in the arm-base
+frame, which is what the loader expects. `ActionChunkCoordinateFrameTransform`
+inverts the matrix at load time to reach the camera frame. Human writers store
+no extrinsics, so only EVA episodes are affected.
+
+To spot-check one episode, read `extrinsics[arm]` from `zarr.attrs` and look at
+the translation column. It is the camera origin in the arm-base frame, so it
+must place the camera above and behind the arm base. A `cam_T_base` matrix
+places the arm base in front of the camera instead. The rotation column for the
+camera optical axis gives the same answer: in `base_T_cam` it points forward
+and downward in the base frame.
+
 ## Pose arrays
 
 Pose translations use metres. Quaternion poses use `[x, y, z, qw, qx, qy,

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,21 @@
+# Coordinate conventions
+
+A homogeneous transform named `A_T_B` maps points expressed in frame `B` into
+frame `A`:
+
+```text
+p_A = A_T_B @ p_B
+A_T_C = A_T_B @ B_T_C
+```
+
+The name therefore describes the destination frame first and the source frame
+second. For example, `base_T_cam` is the camera pose in the robot base frame;
+`inv(base_T_cam)` maps a base-frame point into the camera frame. Use the same
+ordering for rotations (`A_R_B`).
+
+Episode `extrinsics` values follow this convention. Existing EVA episodes store
+one `base_T_cam` per arm. Human head poses are `world_T_head`; for egocentric
+data the head frame is the camera frame.
+
+Pose arrays use metres and `[x, y, z, qw, qx, qy, qz]` unless a key or function
+explicitly says it contains ZYX yaw, pitch, and roll.

--- a/egomimic/algo/hpt.py
+++ b/egomimic/algo/hpt.py
@@ -16,9 +16,8 @@ from tslearn.metrics import SoftDTWLossPyTorch
 from egomimic.algo.algo import Algo
 from egomimic.models.hpt_nets import MultiheadAttention, SimpleTransformer
 from egomimic.rldb.embodiment.embodiment import get_embodiment, get_embodiment_id
-from egomimic.utils.tensor_utils import EinOpsRearrange, get_sinusoid_encoding_table
 from egomimic.utils.hf_utils import download_from_huggingface
-
+from egomimic.utils.tensor_utils import EinOpsRearrange, get_sinusoid_encoding_table
 
 # Init scale for the HPT action tokens (was a shared constant in utils.py;
 # it has exactly one consumer, below).

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -1,14 +1,8 @@
 import logging
-import random
-from typing import Literal
 
-import numpy as np
-import torch
 from lightning import LightningDataModule
 from lightning.pytorch.utilities.combined_loader import CombinedLoader
-from termcolor import cprint
 from torch.utils.data import DataLoader, default_collate
-from transformers import AutoTokenizer
 
 logger = logging.getLogger(__name__)
 

--- a/egomimic/rldb/embodiment/__init__.py
+++ b/egomimic/rldb/embodiment/__init__.py
@@ -1,0 +1,76 @@
+"""Embodiment package — the one place that says which embodiments exist.
+
+``EMBODIMENT_CLASSES`` maps an episode's ``embodiment`` attribute to the class
+that owns its keymap, transform pipeline and overlays. The same six-entry dict
+used to be pasted into ``egomimic/scripts/viz_language.py`` and into
+``egomimic/scripts/data_visualization/inspector_lib/dataset_view.py``, the
+second copy carrying a comment asking a future editor to keep it in sync with
+the first. Both callers now import from here, and the dict itself is *derived*
+from ``registry/platforms.yaml`` rather than typed out: a registry the code does
+not actually read would be a fifth source of truth beside the four it replaces,
+so the registry is the only place an embodiment can be declared.
+"""
+
+from egomimic.rldb.embodiment.embodiment import (
+    EMBODIMENT,
+    EMBODIMENT_ID_TO_KEY,
+    Embodiment,
+    ResolvedEmbodiment,
+    _import_embodiment_class,
+    canonical_embodiment_name,
+    get_embodiment,
+    get_embodiment_id,
+)
+from egomimic.rldb.embodiment.eva import Eva
+from egomimic.rldb.embodiment.human import Human
+from egomimic.rldb.embodiment.registry import load_platforms
+
+
+def _build_embodiment_classes() -> dict[str, type[Embodiment]]:
+    """Embodiment name -> class, from each platform's ``embodiment_class:``.
+
+    A platform that declares none is skipped: it has no hand-written pipeline
+    yet, and `Embodiment.resolve` raises a pointed error rather than handing
+    back a class that does not fit.
+    """
+    classes: dict[str, type[Embodiment]] = {}
+    for platform in load_platforms().values():
+        if platform.embodiment_class is None:
+            continue
+        cls = _import_embodiment_class(platform.embodiment_class)
+        for embodiment in platform.embodiments:
+            classes[embodiment] = cls
+    return classes
+
+
+EMBODIMENT_CLASSES: dict[str, type[Embodiment]] = _build_embodiment_classes()
+
+
+def get_embodiment_class(
+    embodiment_name: str | None, default: type[Embodiment] | None = None
+) -> type[Embodiment] | None:
+    """Resolve an embodiment name to its class, case-insensitively.
+
+    Deprecated names resolve through the alias table, so an episode written
+    before a rename still gets its real overlay rather than the fallback.
+    Returns ``default`` for a missing, empty or unknown name — callers read this
+    name out of an episode's attrs and want a fallback, not a ``KeyError``.
+    """
+    if not embodiment_name:
+        return default
+    return EMBODIMENT_CLASSES.get(canonical_embodiment_name(embodiment_name), default)
+
+
+__all__ = [
+    "EMBODIMENT",
+    "EMBODIMENT_CLASSES",
+    "EMBODIMENT_ID_TO_KEY",
+    "Embodiment",
+    "Eva",
+    "Human",
+    "ResolvedEmbodiment",
+    "canonical_embodiment_name",
+    "get_embodiment",
+    "get_embodiment_class",
+    "get_embodiment_id",
+]

--- a/egomimic/rldb/embodiment/__init__.py
+++ b/egomimic/rldb/embodiment/__init__.py
@@ -1,14 +1,9 @@
-"""Embodiment package — the one place that says which embodiments exist.
+"""Expose embodiment identifiers, classes, and registry lookup functions.
 
-``EMBODIMENT_CLASSES`` maps an episode's ``embodiment`` attribute to the class
-that owns its keymap, transform pipeline and overlays. The same six-entry dict
-used to be pasted into ``egomimic/scripts/viz_language.py`` and into
-``egomimic/scripts/data_visualization/inspector_lib/dataset_view.py``, the
-second copy carrying a comment asking a future editor to keep it in sync with
-the first. Both callers now import from here, and the dict itself is *derived*
-from ``registry/platforms.yaml`` rather than typed out: a registry the code does
-not actually read would be a fifth source of truth beside the four it replaces,
-so the registry is the only place an embodiment can be declared.
+``EMBODIMENT_CLASSES`` maps each canonical embodiment name to its configured
+``Embodiment`` subclass. The module builds this mapping from
+``registry/platforms.yaml``. It omits platforms that do not specify an
+``embodiment_class``.
 """
 
 from egomimic.rldb.embodiment.embodiment import (
@@ -27,11 +22,12 @@ from egomimic.rldb.embodiment.registry import load_platforms
 
 
 def _build_embodiment_classes() -> dict[str, type[Embodiment]]:
-    """Embodiment name -> class, from each platform's ``embodiment_class:``.
+    """Build the embodiment class mapping from the platform registry.
 
-    A platform that declares none is skipped: it has no hand-written pipeline
-    yet, and `Embodiment.resolve` raises a pointed error rather than handing
-    back a class that does not fit.
+    Returns:
+        A mapping from each canonical embodiment name to an ``Embodiment``
+        subclass. The mapping excludes platforms without an
+        ``embodiment_class`` value.
     """
     classes: dict[str, type[Embodiment]] = {}
     for platform in load_platforms().values():
@@ -49,12 +45,16 @@ EMBODIMENT_CLASSES: dict[str, type[Embodiment]] = _build_embodiment_classes()
 def get_embodiment_class(
     embodiment_name: str | None, default: type[Embodiment] | None = None
 ) -> type[Embodiment] | None:
-    """Resolve an embodiment name to its class, case-insensitively.
+    """Return the class for a current or deprecated embodiment name.
 
-    Deprecated names resolve through the alias table, so an episode written
-    before a rename still gets its real overlay rather than the fallback.
-    Returns ``default`` for a missing, empty or unknown name — callers read this
-    name out of an episode's attrs and want a fallback, not a ``KeyError``.
+    Args:
+        embodiment_name: An embodiment name. The lookup ignores letter case and
+            applies aliases from ``registry/aliases.yaml``.
+        default: The value to return if the name is empty or unknown.
+
+    Returns:
+        The configured ``Embodiment`` subclass, or ``default`` if no class
+        matches the name.
     """
     if not embodiment_name:
         return default

--- a/egomimic/rldb/embodiment/embodiment.py
+++ b/egomimic/rldb/embodiment/embodiment.py
@@ -1,10 +1,21 @@
+import importlib
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass
 from enum import Enum
 from typing import Literal
 
 import numpy as np
 import torch
 
+from egomimic.rldb.embodiment.registry import (
+    EndEffectorSpec,
+    PlatformSpec,
+    load_aliases,
+    load_embodiment_platforms,
+    load_end_effectors,
+    load_platforms,
+)
 from egomimic.rldb.zarr.action_chunk_transforms import Transform
 from egomimic.utils.type_utils import _to_numpy
 from egomimic.utils.viz_utils import (
@@ -50,8 +61,104 @@ def get_embodiment(index):
     return EMBODIMENT_ID_TO_KEY.get(index, None)
 
 
+def canonical_embodiment_name(embodiment_name: str) -> str:
+    """Lowercase an embodiment name and resolve it through `aliases.yaml`.
+
+    A name that is already an `EMBODIMENT` member is returned unchanged, so the
+    alias table can never shadow a live name. An unknown name is returned as-is
+    and left to fail at the caller, where the error names the actual input.
+    """
+    name = str(embodiment_name).lower()
+    if name.upper() in EMBODIMENT.__members__:
+        return name
+    return load_aliases().get(name, name)
+
+
 def get_embodiment_id(embodiment_name):
-    return EMBODIMENT[embodiment_name.upper()].value
+    """Map an embodiment name to its stable integer id.
+
+    Deprecated names resolve through `registry/aliases.yaml` first: the name is
+    baked into every episode's `zarr.json`, so without this fallback a rename
+    turns every cached episode into a `KeyError` at load (README, 07/08/2026).
+    """
+    return EMBODIMENT[canonical_embodiment_name(embodiment_name).upper()].value
+
+
+#: The sides an end-effector can be declared for. End-effectors vary per side:
+#: a one-handed rig or two different hands are both legal.
+SIDES = ("left", "right")
+
+
+def _import_embodiment_class(path: str) -> type["Embodiment"]:
+    module_name, _, attr = path.rpartition(".")
+    if not module_name:
+        raise ValueError(f"embodiment_class {path!r} is not a dotted path")
+    return getattr(importlib.import_module(module_name), attr)
+
+
+@dataclass(frozen=True)
+class ResolvedEmbodiment:
+    """One platform plus one end-effector per side, composed from the registry.
+
+    This is the shape that keeps the head count off the platform count: the
+    platform selects the stem and the key widths, the end-effectors select
+    `action_space`, and `action_space` selects the head. A new hand on a known
+    platform changes only `end_effectors`.
+    """
+
+    platform: PlatformSpec
+    end_effectors: Mapping[str, EndEffectorSpec]
+    embodiment_name: str | None = None
+
+    @property
+    def action_space(self) -> str:
+        """The canonical action space, derived from the end-effector classes.
+
+        Mixed sides are refused rather than silently resolved: an episode whose
+        two hands want different heads has no single training interface, and
+        picking one here would hide that.
+        """
+        spaces = {ee.action_space for ee in self.end_effectors.values()}
+        if len(spaces) != 1:
+            raise ValueError(
+                f"{self.describe()}: end-effectors disagree on action_space "
+                f"({sorted(spaces)}); an episode trains through exactly one head"
+            )
+        return spaces.pop()
+
+    @property
+    def embodiment_class(self) -> type["Embodiment"]:
+        """The hand-written `Embodiment` subclass for this platform.
+
+        `Human` and `Eva` encode real subtlety (head-frame vs extrinsics-frame,
+        wrist-frame variants, interpolation strides) and are reached through the
+        registry's `embodiment_class:` escape hatch rather than rewritten. A
+        platform without one has no derived pipeline yet, and says so.
+        """
+        path = self.platform.embodiment_class
+        if path is None:
+            raise NotImplementedError(
+                f"{self.describe()}: platform {self.platform.name!r} declares no "
+                "`embodiment_class:` and there is no derived transform pipeline "
+                "yet — add one to platforms.yaml"
+            )
+        return _import_embodiment_class(path)
+
+    def keypoints(self, side: str):
+        """The end-effector's keypoint spec (topology + validity mask) for a side."""
+        return self.end_effectors[side].keypoints
+
+    def get_keymap(self, *args, **kwargs):
+        return self.embodiment_class.get_keymap(*args, **kwargs)
+
+    def get_transform_list(self, *args, **kwargs):
+        return self.embodiment_class.get_transform_list(*args, **kwargs)
+
+    def describe(self) -> str:
+        sides = ", ".join(
+            f"{s}={self.end_effectors[s].name}" for s in sorted(self.end_effectors)
+        )
+        return f"{self.embodiment_name or self.platform.name} ({sides})"
 
 
 class Embodiment(ABC):
@@ -60,6 +167,89 @@ class Embodiment(ABC):
     INTRINSICS = None
     EXTRINSICS = None
     VIZ_IMAGE_KEY = "observations.images.front_img_1"
+
+    @classmethod
+    def resolve(cls, spec) -> ResolvedEmbodiment:
+        """Compose an embodiment from the registry.
+
+        `spec` is either an embodiment name (`"eva_bimanual"`, aliases included)
+        or a `morphology` block::
+
+            {"platform": "eva_x5",
+             "end_effector": {"left": "eva_parallel_jaw",
+                              "right": "eva_parallel_jaw"}}
+
+        The name form is the backward-compatible path: no episode carries a
+        `morphology` block yet, so the platform's `default_end_effector` fills
+        both sides. `end_effector` may also be a bare string, meaning both sides.
+        """
+        if isinstance(spec, Mapping):
+            return cls._resolve_morphology(spec)
+        if isinstance(spec, str):
+            return cls._resolve_name(spec)
+        raise TypeError(
+            "resolve() takes an embodiment name or a morphology mapping, got "
+            f"{type(spec).__name__}"
+        )
+
+    @classmethod
+    def _resolve_name(cls, embodiment_name: str) -> ResolvedEmbodiment:
+        name = canonical_embodiment_name(embodiment_name)
+        platform = load_embodiment_platforms().get(name)
+        if platform is None:
+            raise ValueError(
+                f"embodiment {embodiment_name!r} is not owned by any platform in "
+                "registry/platforms.yaml; known: "
+                f"{sorted(load_embodiment_platforms())}"
+            )
+        end_effectors = load_end_effectors()
+        default = end_effectors[platform.default_end_effector]
+        return ResolvedEmbodiment(
+            platform=platform,
+            end_effectors={side: default for side in SIDES},
+            embodiment_name=name,
+        )
+
+    @classmethod
+    def _resolve_morphology(cls, morphology: Mapping) -> ResolvedEmbodiment:
+        platforms = load_platforms()
+        platform_name = morphology.get("platform")
+        platform = platforms.get(platform_name)
+        if platform is None:
+            raise ValueError(
+                f"morphology.platform {platform_name!r} is not in "
+                f"registry/platforms.yaml; known: {sorted(platforms)}"
+            )
+
+        end_effectors = load_end_effectors()
+        declared = morphology.get("end_effector", platform.default_end_effector)
+        if isinstance(declared, str):
+            declared = {side: declared for side in SIDES}
+        if not isinstance(declared, Mapping) or not declared:
+            raise ValueError(
+                "morphology.end_effector must be an end-effector name or a "
+                f"{{side: name}} mapping, got {declared!r}"
+            )
+
+        resolved = {}
+        for side, ee_name in declared.items():
+            if side not in SIDES:
+                raise ValueError(
+                    f"morphology.end_effector has unknown side {side!r}; "
+                    f"expected one of {list(SIDES)}"
+                )
+            if ee_name not in end_effectors:
+                raise ValueError(
+                    f"morphology.end_effector[{side!r}] = {ee_name!r} is not in "
+                    f"registry/end_effectors.yaml; known: {sorted(end_effectors)}"
+                )
+            resolved[side] = end_effectors[ee_name]
+
+        return ResolvedEmbodiment(
+            platform=platform,
+            end_effectors=resolved,
+            embodiment_name=morphology.get("embodiment"),
+        )
 
     @staticmethod
     def get_transform_list() -> list[Transform]:

--- a/egomimic/rldb/embodiment/embodiment.py
+++ b/egomimic/rldb/embodiment/embodiment.py
@@ -27,9 +27,8 @@ from egomimic.utils.viz_utils import (
 
 
 class EMBODIMENT(Enum):
-    # All human demonstration data is one embodiment (HUMAN_*); the robot Eva is
-    # the only non-human embodiment. There is NO vendor/source notion at the
-    # embodiment level — the data source is recorded only in the SQL `lab` field.
+    # IDs 1 through 3 identify human data. IDs 4 through 6 identify EVA data.
+    # The SQL `lab` field identifies the data source.
     HUMAN_RIGHT_ARM = 1
     HUMAN_LEFT_ARM = 2
     HUMAN_BIMANUAL = 3
@@ -62,11 +61,14 @@ def get_embodiment(index):
 
 
 def canonical_embodiment_name(embodiment_name: str) -> str:
-    """Lowercase an embodiment name and resolve it through `aliases.yaml`.
+    """Return the lowercase canonical form of an embodiment name.
 
-    A name that is already an `EMBODIMENT` member is returned unchanged, so the
-    alias table can never shadow a live name. An unknown name is returned as-is
-    and left to fail at the caller, where the error names the actual input.
+    Args:
+        embodiment_name: A current, deprecated, or unknown embodiment name.
+
+    Returns:
+        The current name for a configured alias. A current name takes priority
+        over an alias. The function returns an unknown name in lowercase.
     """
     name = str(embodiment_name).lower()
     if name.upper() in EMBODIMENT.__members__:
@@ -75,17 +77,22 @@ def canonical_embodiment_name(embodiment_name: str) -> str:
 
 
 def get_embodiment_id(embodiment_name):
-    """Map an embodiment name to its stable integer id.
+    """Return the stable integer ID for an embodiment name.
 
-    Deprecated names resolve through `registry/aliases.yaml` first: the name is
-    baked into every episode's `zarr.json`, so without this fallback a rename
-    turns every cached episode into a `KeyError` at load (README, 07/08/2026).
+    Args:
+        embodiment_name: A current name or an alias in
+            ``registry/aliases.yaml``. The lookup ignores letter case.
+
+    Returns:
+        The integer value of the matching ``EMBODIMENT`` member.
+
+    Raises:
+        KeyError: If the canonical name is not an ``EMBODIMENT`` member.
     """
     return EMBODIMENT[canonical_embodiment_name(embodiment_name).upper()].value
 
 
-#: The sides an end-effector can be declared for. End-effectors vary per side:
-#: a one-handed rig or two different hands are both legal.
+#: Valid keys for ``ResolvedEmbodiment.end_effectors``.
 SIDES = ("left", "right")
 
 
@@ -98,12 +105,14 @@ def _import_embodiment_class(path: str) -> type["Embodiment"]:
 
 @dataclass(frozen=True)
 class ResolvedEmbodiment:
-    """One platform plus one end-effector per side, composed from the registry.
+    """Store a platform and its selected end-effectors.
 
-    This is the shape that keeps the head count off the platform count: the
-    platform selects the stem and the key widths, the end-effectors select
-    `action_space`, and `action_space` selects the head. A new hand on a known
-    platform changes only `end_effectors`.
+    Attributes:
+        platform: The selected platform specification.
+        end_effectors: A mapping from ``"left"`` or ``"right"`` to the
+            end-effector specification for that side.
+        embodiment_name: The canonical embodiment name, if resolution started
+            from a name.
     """
 
     platform: PlatformSpec
@@ -112,11 +121,11 @@ class ResolvedEmbodiment:
 
     @property
     def action_space(self) -> str:
-        """The canonical action space, derived from the end-effector classes.
+        """Return the action space shared by all selected end-effectors.
 
-        Mixed sides are refused rather than silently resolved: an episode whose
-        two hands want different heads has no single training interface, and
-        picking one here would hide that.
+        Raises:
+            ValueError: If the selected end-effectors specify different action
+                spaces.
         """
         spaces = {ee.action_space for ee in self.end_effectors.values()}
         if len(spaces) != 1:
@@ -128,12 +137,11 @@ class ResolvedEmbodiment:
 
     @property
     def embodiment_class(self) -> type["Embodiment"]:
-        """The hand-written `Embodiment` subclass for this platform.
+        """Import and return the platform's configured ``Embodiment`` class.
 
-        `Human` and `Eva` encode real subtlety (head-frame vs extrinsics-frame,
-        wrist-frame variants, interpolation strides) and are reached through the
-        registry's `embodiment_class:` escape hatch rather than rewritten. A
-        platform without one has no derived pipeline yet, and says so.
+        Raises:
+            NotImplementedError: If the platform does not specify an
+                ``embodiment_class`` value.
         """
         path = self.platform.embodiment_class
         if path is None:
@@ -145,7 +153,14 @@ class ResolvedEmbodiment:
         return _import_embodiment_class(path)
 
     def keypoints(self, side: str):
-        """The end-effector's keypoint spec (topology + validity mask) for a side."""
+        """Return the keypoint topology and valid slots for one side.
+
+        Args:
+            side: The ``"left"`` or ``"right"`` end-effector key.
+
+        Raises:
+            KeyError: If ``side`` is not in ``end_effectors``.
+        """
         return self.end_effectors[side].keypoints
 
     def get_keymap(self, *args, **kwargs):
@@ -162,7 +177,7 @@ class ResolvedEmbodiment:
 
 
 class Embodiment(ABC):
-    """Base embodiment class. An embodiment is responsible for defining the transform pipeline that converts between the raw data in the dataset and the canonical representation used by the model."""
+    """Define dataset transforms and visualization for an embodiment."""
 
     INTRINSICS = None
     EXTRINSICS = None
@@ -170,18 +185,26 @@ class Embodiment(ABC):
 
     @classmethod
     def resolve(cls, spec) -> ResolvedEmbodiment:
-        """Compose an embodiment from the registry.
+        """Resolve an embodiment name or morphology mapping.
 
-        `spec` is either an embodiment name (`"eva_bimanual"`, aliases included)
-        or a `morphology` block::
+        A name selects its platform and the platform's default end-effector for
+        both sides. A morphology mapping has this form::
 
             {"platform": "eva_x5",
              "end_effector": {"left": "eva_parallel_jaw",
                               "right": "eva_parallel_jaw"}}
 
-        The name form is the backward-compatible path: no episode carries a
-        `morphology` block yet, so the platform's `default_end_effector` fills
-        both sides. `end_effector` may also be a bare string, meaning both sides.
+        Args:
+            spec: A current or deprecated embodiment name, or a morphology
+                mapping. In a morphology mapping, ``end_effector`` can be one
+                name for both sides or a mapping of side names to end-effectors.
+
+        Returns:
+            The selected platform and end-effector specifications.
+
+        Raises:
+            TypeError: If ``spec`` is not a string or mapping.
+            ValueError: If a platform, side, or end-effector name is invalid.
         """
         if isinstance(spec, Mapping):
             return cls._resolve_morphology(spec)

--- a/egomimic/rldb/embodiment/eva.py
+++ b/egomimic/rldb/embodiment/eva.py
@@ -224,8 +224,8 @@ def _build_eva_bimanual_revert_eef_frame_transform_list(
 
 def _build_eva_bimanual_eef_frame_transform_list(
     *,
-    left_target_world: str = "left_extrinsics_pose",
-    right_target_world: str = "right_extrinsics_pose",
+    left_base_T_cam_pose_key: str = "left_base_T_cam_pose",
+    right_base_T_cam_pose_key: str = "right_base_T_cam_pose",
     left_cmd_world: str = "left.cmd_ee_pose",
     right_cmd_world: str = "right.cmd_ee_pose",
     left_obs_pose: str = "left.obs_ee_pose",
@@ -249,35 +249,35 @@ def _build_eva_bimanual_eef_frame_transform_list(
     """EVA bimanual transform pipeline with actions expressed relative to the
     current EEF pose (wrist frame), analogous to keypoints relative to wrist pose."""
     extrinsics = Eva.EXTRINSICS
-    left_extrinsics_pose = _matrix_to_xyzwxyz(extrinsics["left"][None, :])[0]
-    right_extrinsics_pose = _matrix_to_xyzwxyz(extrinsics["right"][None, :])[0]
-    left_extra_batch_key = {"left_extrinsics_pose": left_extrinsics_pose}
-    right_extra_batch_key = {"right_extrinsics_pose": right_extrinsics_pose}
+    left_base_T_cam_pose = _matrix_to_xyzwxyz(extrinsics["left"][None, :])[0]
+    right_base_T_cam_pose = _matrix_to_xyzwxyz(extrinsics["right"][None, :])[0]
+    left_extra_batch_key = {left_base_T_cam_pose_key: left_base_T_cam_pose}
+    right_extra_batch_key = {right_base_T_cam_pose_key: right_base_T_cam_pose}
 
     # Step 1: transform cmd and obs into camera frame using extrinsics
     transform_list = [
         ActionChunkCoordinateFrameTransform(
-            target_world=left_target_world,
+            target_world=left_base_T_cam_pose_key,
             chunk_world=left_cmd_world,
             transformed_key_name=left_cmd_camframe,
             extra_batch_key=left_extra_batch_key,
             mode="xyzwxyz",
         ),
         ActionChunkCoordinateFrameTransform(
-            target_world=right_target_world,
+            target_world=right_base_T_cam_pose_key,
             chunk_world=right_cmd_world,
             transformed_key_name=right_cmd_camframe,
             extra_batch_key=right_extra_batch_key,
             mode="xyzwxyz",
         ),
         PoseCoordinateFrameTransform(
-            target_world=left_target_world,
+            target_world=left_base_T_cam_pose_key,
             pose_world=left_obs_pose,
             transformed_key_name=left_obs_camframe,
             mode="xyzwxyz",
         ),
         PoseCoordinateFrameTransform(
-            target_world=right_target_world,
+            target_world=right_base_T_cam_pose_key,
             pose_world=right_obs_pose,
             transformed_key_name=right_obs_camframe,
             mode="xyzwxyz",
@@ -375,8 +375,8 @@ def _build_eva_bimanual_eef_frame_transform_list(
                     right_obs_pose,
                     left_cmd_camframe,
                     right_cmd_camframe,
-                    left_target_world,
-                    right_target_world,
+                    left_base_T_cam_pose_key,
+                    right_base_T_cam_pose_key,
                 ]
             ),
             NumpyToTensor(
@@ -392,8 +392,8 @@ def _build_eva_bimanual_eef_frame_transform_list(
 
 def _build_eva_bimanual_transform_list(
     *,
-    left_target_world: str = "left_extrinsics_pose",
-    right_target_world: str = "right_extrinsics_pose",
+    left_base_T_cam_pose_key: str = "left_base_T_cam_pose",
+    right_base_T_cam_pose_key: str = "right_base_T_cam_pose",
     left_cmd_world: str = "left.cmd_ee_pose",
     right_cmd_world: str = "right.cmd_ee_pose",
     left_obs_pose: str = "left.obs_ee_pose",
@@ -412,35 +412,35 @@ def _build_eva_bimanual_transform_list(
 ) -> list[Transform]:
     """Canonical EVA bimanual transform pipeline used by tests and notebooks."""
     extrinsics = Eva.EXTRINSICS
-    left_extrinsics_pose = _matrix_to_xyzwxyz(extrinsics["left"][None, :])[0]
-    right_extrinsics_pose = _matrix_to_xyzwxyz(extrinsics["right"][None, :])[0]
-    left_extra_batch_key = {"left_extrinsics_pose": left_extrinsics_pose}
-    right_extra_batch_key = {"right_extrinsics_pose": right_extrinsics_pose}
+    left_base_T_cam_pose = _matrix_to_xyzwxyz(extrinsics["left"][None, :])[0]
+    right_base_T_cam_pose = _matrix_to_xyzwxyz(extrinsics["right"][None, :])[0]
+    left_extra_batch_key = {left_base_T_cam_pose_key: left_base_T_cam_pose}
+    right_extra_batch_key = {right_base_T_cam_pose_key: right_base_T_cam_pose}
 
     mode = "xyzwxyz" if is_quat else "xyzypr"
     transform_list = [
         ActionChunkCoordinateFrameTransform(
-            target_world=left_target_world,
+            target_world=left_base_T_cam_pose_key,
             chunk_world=left_cmd_world,
             transformed_key_name=left_cmd_camframe,
             extra_batch_key=left_extra_batch_key,
             mode=mode,
         ),
         ActionChunkCoordinateFrameTransform(
-            target_world=right_target_world,
+            target_world=right_base_T_cam_pose_key,
             chunk_world=right_cmd_world,
             transformed_key_name=right_cmd_camframe,
             extra_batch_key=right_extra_batch_key,
             mode=mode,
         ),
         PoseCoordinateFrameTransform(
-            target_world=left_target_world,
+            target_world=left_base_T_cam_pose_key,
             pose_world=left_obs_pose,
             transformed_key_name=left_obs_pose,
             mode=mode,
         ),
         PoseCoordinateFrameTransform(
-            target_world=right_target_world,
+            target_world=right_base_T_cam_pose_key,
             pose_world=right_obs_pose,
             transformed_key_name=right_obs_pose,
             mode=mode,
@@ -511,8 +511,8 @@ def _build_eva_bimanual_transform_list(
                 keys_to_delete=[
                     left_cmd_world,
                     right_cmd_world,
-                    left_target_world,
-                    right_target_world,
+                    left_base_T_cam_pose_key,
+                    right_base_T_cam_pose_key,
                 ]
             ),
             NumpyToTensor(

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -106,7 +106,7 @@ class Human(Embodiment):
     # Front-image key for Pi/PaliGemma-style naming (any "_pi"-suffixed mode);
     # Pi's _fill_missing_images auto-duplicates the absent wrist keys.
     PI_FRONT_KEY = "base_0_rgb"
-    RGB_T_CPF = ARIA_RGB_T_CPF  # for the opt-in Aria gaze viz
+    RGB_T_CPF = ARIA_RGB_T_CPF  # `viz` uses this matrix for Aria gaze data.
     # Canonical MANO 21-keypoint topology: 0=wrist, 1-4 thumb, 5-8 index, ...
     FINGER_EDGES = [
         (0, 1), (1, 2), (2, 3), (3, 4),         # thumb

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import Literal
 
 import numpy as np
@@ -25,7 +24,6 @@ from egomimic.utils.viz_utils import (
     _viz_gaze,
     _viz_keypoints,
 )
-
 
 ARIA_INTRINSICS = np.array(
     [
@@ -67,7 +65,7 @@ LIGHTWHEEL_INTRINSICS = np.array(
     ]
 )
 
-ARIA_T_RGB_CPF = np.array(
+ARIA_RGB_T_CPF = np.array(
     [
         [-0.99989084, 0.01251132, -0.00786028, 0.05686918],
         [-0.01132842, -0.99067146, -0.13580032, 0.00922798],
@@ -108,7 +106,7 @@ class Human(Embodiment):
     # Front-image key for Pi/PaliGemma-style naming (any "_pi"-suffixed mode);
     # Pi's _fill_missing_images auto-duplicates the absent wrist keys.
     PI_FRONT_KEY = "base_0_rgb"
-    T_RGB_CPF = ARIA_T_RGB_CPF  # for the opt-in aria gaze viz
+    RGB_T_CPF = ARIA_RGB_T_CPF  # for the opt-in Aria gaze viz
     # Canonical MANO 21-keypoint topology: 0=wrist, 1-4 thumb, 5-8 index, ...
     FINGER_EDGES = [
         (0, 1), (1, 2), (2, 3), (3, 4),         # thumb
@@ -152,7 +150,7 @@ class Human(Embodiment):
                 image=image,
                 gaze_data=viz_data,
                 intrinsics=K,
-                t_rgb_cpf=cls.T_RGB_CPF,
+                rgb_T_cpf=cls.RGB_T_CPF,
                 **kwargs,
             )
         if mode == "keypoints":

--- a/egomimic/rldb/embodiment/registry/__init__.py
+++ b/egomimic/rldb/embodiment/registry/__init__.py
@@ -1,0 +1,399 @@
+"""Declarative embodiment registry.
+
+The YAML files beside this module are data, not code: adding an embodiment, a
+platform or an end-effector should be a diffable block here rather than an edit
+spread across an enum, two class dicts and a hydra config.
+
+The registry is factorized along the two axes that are actually combinatorial —
+``platforms.yaml`` (arm chain, aux chain, camera set, reference frame) and
+``end_effectors.yaml`` (DOF, keypoint topology, action space) — so a new hand on
+a known robot is one block in one file. Calibration is deliberately absent: it
+is per-episode data, not a specification, and centralizing it is the failure
+mode the schema exists to avoid.
+
+This module imports nothing from ``egomimic.rldb.embodiment``. It is a leaf, so
+the parent package (and ``embodiment.py`` itself) can read the registry without
+an import cycle. Anything needing the ``EMBODIMENT`` enum belongs one level up.
+"""
+
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+REGISTRY_DIR = Path(__file__).parent
+
+PLATFORM_KINDS = frozenset({"robot", "human"})
+END_EFFECTOR_CLASSES = frozenset({"parallel_jaw", "human_hand", "dexterous_hand"})
+ACTION_SPACES = frozenset({"cartesian", "keypoints"})
+#: Keypoint topology -> number of slots. A topology is a superset; an
+#: end-effector declares which of its slots are valid.
+TOPOLOGY_SLOTS = {"mano21": 21}
+
+_PLATFORM_FIELDS = frozenset(
+    {
+        "kind",
+        "embodiment_prefix",
+        "arity",
+        "arm_dof",
+        "aux",
+        "cameras",
+        "reference_frame",
+        "default_end_effector",
+        "embodiment_class",
+    }
+)
+_END_EFFECTOR_FIELDS = frozenset(
+    {
+        "class",
+        "dof",
+        "action_space",
+        "keypoints",
+        "joint_names",
+        "joint_limits",
+        "urdf",
+        "dead_dims",
+    }
+)
+_AUX_FIELDS = frozenset({"dof", "joint_names"})
+_KEYPOINT_FIELDS = frozenset({"topology", "valid"})
+
+
+class RegistryError(ValueError):
+    """A registry file is malformed.
+
+    Raised at load, not at use: a stale or typo'd registry must break the
+    embodiment that depends on it immediately, otherwise the YAML becomes a
+    fifth place to drift instead of the one place that replaces the other four.
+    """
+
+
+@dataclass(frozen=True)
+class KeypointSpec:
+    """Which slots of a keypoint topology an end-effector actually has."""
+
+    topology: str
+    valid: tuple[int, ...]
+
+    @property
+    def n_slots(self) -> int:
+        """Total slots in the topology, valid or not."""
+        return TOPOLOGY_SLOTS[self.topology]
+
+    @property
+    def is_complete(self) -> bool:
+        return len(self.valid) == self.n_slots
+
+
+@dataclass(frozen=True)
+class AuxChainSpec:
+    """A platform's non-arm joint chain (torso / lift / head)."""
+
+    dof: int
+    joint_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EndEffectorSpec:
+    name: str
+    ee_class: str
+    dof: int | None
+    action_space: str
+    keypoints: KeypointSpec
+    joint_names: tuple[str, ...] = ()
+    joint_limits: tuple[tuple[float, float], ...] = ()
+    urdf: str | None = None
+    dead_dims: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlatformSpec:
+    name: str
+    kind: str
+    embodiment_prefix: str
+    arity: tuple[str, ...]
+    arm_dof: int | None
+    aux: AuxChainSpec | None
+    cameras: tuple[str, ...]
+    reference_frame: str
+    default_end_effector: str
+    embodiment_class: str | None = None
+
+    @property
+    def embodiments(self) -> tuple[str, ...]:
+        """The EMBODIMENT names this platform owns, e.g. ``eva_bimanual``."""
+        return tuple(f"{self.embodiment_prefix}_{a}" for a in self.arity)
+
+
+def _load_yaml(file_name: str) -> dict:
+    with (REGISTRY_DIR / file_name).open("r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _check_fields(block: dict, allowed: frozenset[str], where: str) -> None:
+    """Reject unknown keys — a typo'd field would otherwise be silently ignored."""
+    unknown = sorted(set(block) - allowed)
+    if unknown:
+        raise RegistryError(
+            f"{where}: unknown field(s) {unknown}; expected some of {sorted(allowed)}"
+        )
+
+
+def _require(block: dict, field: str, where: str):
+    if field not in block:
+        raise RegistryError(f"{where}: missing required field {field!r}")
+    return block[field]
+
+
+def _parse_keypoints(raw, where: str) -> KeypointSpec:
+    if not isinstance(raw, dict):
+        raise RegistryError(f"{where}: `keypoints` must be a mapping, got {raw!r}")
+    _check_fields(raw, _KEYPOINT_FIELDS, f"{where}.keypoints")
+    topology = _require(raw, "topology", f"{where}.keypoints")
+    if topology not in TOPOLOGY_SLOTS:
+        raise RegistryError(
+            f"{where}.keypoints: unknown topology {topology!r}; "
+            f"expected one of {sorted(TOPOLOGY_SLOTS)}"
+        )
+    n_slots = TOPOLOGY_SLOTS[topology]
+    valid = _require(raw, "valid", f"{where}.keypoints")
+    if valid == "all":
+        return KeypointSpec(topology=topology, valid=tuple(range(n_slots)))
+    if not isinstance(valid, list) or not valid:
+        raise RegistryError(
+            f"{where}.keypoints: `valid` must be 'all' or a non-empty list of "
+            f"slot indices, got {valid!r}"
+        )
+    out = []
+    for slot in valid:
+        if not isinstance(slot, int) or isinstance(slot, bool):
+            raise RegistryError(f"{where}.keypoints: slot {slot!r} is not an int")
+        if not 0 <= slot < n_slots:
+            raise RegistryError(
+                f"{where}.keypoints: slot {slot} out of range for {topology} "
+                f"(0..{n_slots - 1})"
+            )
+        out.append(slot)
+    if len(set(out)) != len(out):
+        raise RegistryError(f"{where}.keypoints: duplicate slots in {valid!r}")
+    return KeypointSpec(topology=topology, valid=tuple(sorted(out)))
+
+
+def _parse_aux(raw, where: str) -> AuxChainSpec | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise RegistryError(f"{where}: `aux` must be null or a mapping, got {raw!r}")
+    _check_fields(raw, _AUX_FIELDS, f"{where}.aux")
+    dof = _require(raw, "dof", f"{where}.aux")
+    if not isinstance(dof, int) or dof <= 0:
+        raise RegistryError(f"{where}.aux: `dof` must be a positive int, got {dof!r}")
+    joint_names = tuple(raw.get("joint_names") or ())
+    if joint_names and len(joint_names) != dof:
+        raise RegistryError(
+            f"{where}.aux: {len(joint_names)} joint_names for dof {dof}"
+        )
+    return AuxChainSpec(dof=dof, joint_names=joint_names)
+
+
+def _parse_end_effector(name: str, block: dict) -> EndEffectorSpec:
+    where = f"end_effectors.yaml[{name}]"
+    if not isinstance(block, dict):
+        raise RegistryError(f"{where}: must be a mapping, got {block!r}")
+    _check_fields(block, _END_EFFECTOR_FIELDS, where)
+
+    ee_class = _require(block, "class", where)
+    if ee_class not in END_EFFECTOR_CLASSES:
+        raise RegistryError(
+            f"{where}: unknown class {ee_class!r}; "
+            f"expected one of {sorted(END_EFFECTOR_CLASSES)}"
+        )
+    action_space = _require(block, "action_space", where)
+    if action_space not in ACTION_SPACES:
+        raise RegistryError(
+            f"{where}: unknown action_space {action_space!r}; "
+            f"expected one of {sorted(ACTION_SPACES)}"
+        )
+
+    dof = _require(block, "dof", where)
+    if dof is not None and (not isinstance(dof, int) or dof <= 0):
+        raise RegistryError(
+            f"{where}: `dof` must be null or a positive int, got {dof!r}"
+        )
+
+    joint_names = tuple(block.get("joint_names") or ())
+    if joint_names and dof is not None and len(joint_names) != dof:
+        raise RegistryError(f"{where}: {len(joint_names)} joint_names for dof {dof}")
+
+    raw_limits = block.get("joint_limits") or ()
+    limits: list[tuple[float, float]] = []
+    for limit in raw_limits:
+        if not isinstance(limit, (list, tuple)) or len(limit) != 2:
+            raise RegistryError(
+                f"{where}: joint_limits entry {limit!r} is not [lo, hi]"
+            )
+        lo, hi = float(limit[0]), float(limit[1])
+        if lo > hi:
+            raise RegistryError(f"{where}: joint limit [{lo}, {hi}] has lo > hi")
+        limits.append((lo, hi))
+    if limits and dof is not None and len(limits) != dof:
+        raise RegistryError(f"{where}: {len(limits)} joint_limits for dof {dof}")
+
+    dead_dims = tuple(block.get("dead_dims") or ())
+    for dim in dead_dims:
+        if not isinstance(dim, int) or isinstance(dim, bool):
+            raise RegistryError(f"{where}: dead_dims entry {dim!r} is not an int")
+        if dof is None or not 0 <= dim < dof:
+            raise RegistryError(f"{where}: dead dim {dim} out of range for dof {dof!r}")
+
+    return EndEffectorSpec(
+        name=name,
+        ee_class=ee_class,
+        dof=dof,
+        action_space=action_space,
+        keypoints=_parse_keypoints(_require(block, "keypoints", where), where),
+        joint_names=joint_names,
+        joint_limits=tuple(limits),
+        urdf=block.get("urdf"),
+        dead_dims=dead_dims,
+    )
+
+
+def _parse_platform(name: str, block: dict, end_effectors: dict[str, EndEffectorSpec]):
+    where = f"platforms.yaml[{name}]"
+    if not isinstance(block, dict):
+        raise RegistryError(f"{where}: must be a mapping, got {block!r}")
+    _check_fields(block, _PLATFORM_FIELDS, where)
+
+    kind = _require(block, "kind", where)
+    if kind not in PLATFORM_KINDS:
+        raise RegistryError(
+            f"{where}: unknown kind {kind!r}; expected one of {sorted(PLATFORM_KINDS)}"
+        )
+
+    arity = tuple(_require(block, "arity", where) or ())
+    if not arity:
+        raise RegistryError(f"{where}: `arity` must be a non-empty list")
+    if len(set(arity)) != len(arity):
+        raise RegistryError(f"{where}: duplicate entries in arity {list(arity)}")
+
+    arm_dof = _require(block, "arm_dof", where)
+    if arm_dof is not None and (not isinstance(arm_dof, int) or arm_dof <= 0):
+        raise RegistryError(
+            f"{where}: `arm_dof` must be null or a positive int, got {arm_dof!r}"
+        )
+
+    cameras = tuple(_require(block, "cameras", where) or ())
+    if not cameras:
+        raise RegistryError(f"{where}: `cameras` must be a non-empty list")
+    if len(set(cameras)) != len(cameras):
+        raise RegistryError(f"{where}: duplicate entries in cameras {list(cameras)}")
+
+    reference_frame = _require(block, "reference_frame", where)
+    if reference_frame.startswith("camera:"):
+        camera = reference_frame.split(":", 1)[1]
+        if camera not in cameras:
+            raise RegistryError(
+                f"{where}: reference_frame {reference_frame!r} names a camera that "
+                f"is not declared; cameras are {list(cameras)}"
+            )
+    elif reference_frame not in ("robot_base", "slam_world"):
+        raise RegistryError(
+            f"{where}: unknown reference_frame {reference_frame!r}; expected "
+            "'robot_base', 'slam_world' or 'camera:<declared camera>'"
+        )
+
+    default_end_effector = _require(block, "default_end_effector", where)
+    if default_end_effector not in end_effectors:
+        raise RegistryError(
+            f"{where}: default_end_effector {default_end_effector!r} is not in "
+            f"end_effectors.yaml; known: {sorted(end_effectors)}"
+        )
+
+    return PlatformSpec(
+        name=name,
+        kind=kind,
+        embodiment_prefix=_require(block, "embodiment_prefix", where),
+        arity=arity,
+        arm_dof=arm_dof,
+        aux=_parse_aux(block.get("aux"), where),
+        cameras=cameras,
+        reference_frame=reference_frame,
+        default_end_effector=default_end_effector,
+        embodiment_class=block.get("embodiment_class"),
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def load_aliases() -> dict[str, str]:
+    """Deprecated embodiment name -> current name, lowercased both sides.
+
+    See ``aliases.yaml``: the table is append-only, and it is what keeps a
+    rename from being a fleet-wide re-download.
+    """
+    raw = _load_yaml("aliases.yaml")
+    return {str(old).lower(): str(new).lower() for old, new in raw.items()}
+
+
+@functools.lru_cache(maxsize=None)
+def load_end_effectors() -> dict[str, EndEffectorSpec]:
+    """End-effector name -> spec, from ``end_effectors.yaml``."""
+    return {
+        name: _parse_end_effector(name, block)
+        for name, block in _load_yaml("end_effectors.yaml").items()
+    }
+
+
+@functools.lru_cache(maxsize=None)
+def load_platforms() -> dict[str, PlatformSpec]:
+    """Platform name -> spec, from ``platforms.yaml``."""
+    end_effectors = load_end_effectors()
+    platforms = {
+        name: _parse_platform(name, block, end_effectors)
+        for name, block in _load_yaml("platforms.yaml").items()
+    }
+    seen: dict[str, str] = {}
+    for platform in platforms.values():
+        for embodiment in platform.embodiments:
+            if embodiment in seen:
+                raise RegistryError(
+                    f"platforms.yaml: embodiment {embodiment!r} is claimed by both "
+                    f"{seen[embodiment]!r} and {platform.name!r}"
+                )
+            seen[embodiment] = platform.name
+    return platforms
+
+
+@functools.lru_cache(maxsize=None)
+def load_embodiment_platforms() -> dict[str, PlatformSpec]:
+    """Embodiment name -> the platform that owns it, aliases included."""
+    by_embodiment = {
+        embodiment: platform
+        for platform in load_platforms().values()
+        for embodiment in platform.embodiments
+    }
+    for old, new in load_aliases().items():
+        if new in by_embodiment:
+            by_embodiment.setdefault(old, by_embodiment[new])
+    return by_embodiment
+
+
+__all__ = [
+    "ACTION_SPACES",
+    "END_EFFECTOR_CLASSES",
+    "PLATFORM_KINDS",
+    "REGISTRY_DIR",
+    "TOPOLOGY_SLOTS",
+    "AuxChainSpec",
+    "EndEffectorSpec",
+    "KeypointSpec",
+    "PlatformSpec",
+    "RegistryError",
+    "load_aliases",
+    "load_embodiment_platforms",
+    "load_end_effectors",
+    "load_platforms",
+]

--- a/egomimic/rldb/embodiment/registry/__init__.py
+++ b/egomimic/rldb/embodiment/registry/__init__.py
@@ -1,19 +1,10 @@
-"""Declarative embodiment registry.
+"""Load and validate the embodiment registry YAML files.
 
-The YAML files beside this module are data, not code: adding an embodiment, a
-platform or an end-effector should be a diffable block here rather than an edit
-spread across an enum, two class dicts and a hydra config.
-
-The registry is factorized along the two axes that are actually combinatorial —
-``platforms.yaml`` (arm chain, aux chain, camera set, reference frame) and
-``end_effectors.yaml`` (DOF, keypoint topology, action space) — so a new hand on
-a known robot is one block in one file. Calibration is deliberately absent: it
-is per-episode data, not a specification, and centralizing it is the failure
-mode the schema exists to avoid.
-
-This module imports nothing from ``egomimic.rldb.embodiment``. It is a leaf, so
-the parent package (and ``embodiment.py`` itself) can read the registry without
-an import cycle. Anything needing the ``EMBODIMENT`` enum belongs one level up.
+``platforms.yaml`` defines arm chains, auxiliary chains, cameras, and reference
+frames. ``end_effectors.yaml`` defines joints, keypoint slots, and action
+spaces. ``aliases.yaml`` maps deprecated embodiment names to current names.
+Episode metadata stores calibration, so this registry does not define
+calibration values.
 """
 
 from __future__ import annotations
@@ -24,13 +15,14 @@ from pathlib import Path
 
 import yaml
 
+# Do not import the parent embodiment package here. The parent package imports
+# this module when it builds ``EMBODIMENT_CLASSES``.
 REGISTRY_DIR = Path(__file__).parent
 
 PLATFORM_KINDS = frozenset({"robot", "human"})
 END_EFFECTOR_CLASSES = frozenset({"parallel_jaw", "human_hand", "dexterous_hand"})
 ACTION_SPACES = frozenset({"cartesian", "keypoints"})
-#: Keypoint topology -> number of slots. A topology is a superset; an
-#: end-effector declares which of its slots are valid.
+#: Number of keypoint slots in each supported topology.
 TOPOLOGY_SLOTS = {"mano21": 21}
 
 _PLATFORM_FIELDS = frozenset(
@@ -63,24 +55,25 @@ _KEYPOINT_FIELDS = frozenset({"topology", "valid"})
 
 
 class RegistryError(ValueError):
-    """A registry file is malformed.
-
-    Raised at load, not at use: a stale or typo'd registry must break the
-    embodiment that depends on it immediately, otherwise the YAML becomes a
-    fifth place to drift instead of the one place that replaces the other four.
-    """
+    """Report invalid data in a registry YAML file."""
 
 
 @dataclass(frozen=True)
 class KeypointSpec:
-    """Which slots of a keypoint topology an end-effector actually has."""
+    """Identify a keypoint topology and the end-effector's valid slots.
+
+    Attributes:
+        topology: A key in ``TOPOLOGY_SLOTS``.
+        valid: Zero-based indices of valid slots in the topology. The registry
+            loader sorts these indices.
+    """
 
     topology: str
     valid: tuple[int, ...]
 
     @property
     def n_slots(self) -> int:
-        """Total slots in the topology, valid or not."""
+        """Return the total number of slots in the topology."""
         return TOPOLOGY_SLOTS[self.topology]
 
     @property
@@ -90,7 +83,12 @@ class KeypointSpec:
 
 @dataclass(frozen=True)
 class AuxChainSpec:
-    """A platform's non-arm joint chain (torso / lift / head)."""
+    """Describe the non-arm joints of a platform.
+
+    Attributes:
+        dof: The number of joints in the auxiliary chain.
+        joint_names: The joint names in chain order. This tuple can be empty.
+    """
 
     dof: int
     joint_names: tuple[str, ...] = ()
@@ -98,6 +96,13 @@ class AuxChainSpec:
 
 @dataclass(frozen=True)
 class EndEffectorSpec:
+    """Store one validated entry from ``end_effectors.yaml``.
+
+    ``keypoints`` defines the common topology and the slots that this
+    end-effector supports. The optional fields store joint metadata and a URDF
+    path.
+    """
+
     name: str
     ee_class: str
     dof: int | None
@@ -111,6 +116,12 @@ class EndEffectorSpec:
 
 @dataclass(frozen=True)
 class PlatformSpec:
+    """Store one validated entry from ``platforms.yaml``.
+
+    The entry defines the arm configurations, joint counts, image streams,
+    reference frame, and default end-effector for a platform.
+    """
+
     name: str
     kind: str
     embodiment_prefix: str
@@ -124,7 +135,7 @@ class PlatformSpec:
 
     @property
     def embodiments(self) -> tuple[str, ...]:
-        """The EMBODIMENT names this platform owns, e.g. ``eva_bimanual``."""
+        """Return ``<embodiment_prefix>_<arity>`` for each supported arity."""
         return tuple(f"{self.embodiment_prefix}_{a}" for a in self.arity)
 
 
@@ -134,7 +145,7 @@ def _load_yaml(file_name: str) -> dict:
 
 
 def _check_fields(block: dict, allowed: frozenset[str], where: str) -> None:
-    """Reject unknown keys — a typo'd field would otherwise be silently ignored."""
+    """Raise ``RegistryError`` if a mapping contains an unknown field."""
     unknown = sorted(set(block) - allowed)
     if unknown:
         raise RegistryError(
@@ -329,10 +340,11 @@ def _parse_platform(name: str, block: dict, end_effectors: dict[str, EndEffector
 
 @functools.lru_cache(maxsize=None)
 def load_aliases() -> dict[str, str]:
-    """Deprecated embodiment name -> current name, lowercased both sides.
+    """Load the deprecated-to-current embodiment name mapping.
 
-    See ``aliases.yaml``: the table is append-only, and it is what keeps a
-    rename from being a fleet-wide re-download.
+    Returns:
+        A dictionary from lowercase deprecated names to lowercase current
+        names.
     """
     raw = _load_yaml("aliases.yaml")
     return {str(old).lower(): str(new).lower() for old, new in raw.items()}
@@ -340,7 +352,14 @@ def load_aliases() -> dict[str, str]:
 
 @functools.lru_cache(maxsize=None)
 def load_end_effectors() -> dict[str, EndEffectorSpec]:
-    """End-effector name -> spec, from ``end_effectors.yaml``."""
+    """Load and validate ``end_effectors.yaml``.
+
+    Returns:
+        A dictionary from end-effector names to validated specifications.
+
+    Raises:
+        RegistryError: If an entry has an unknown field or an invalid value.
+    """
     return {
         name: _parse_end_effector(name, block)
         for name, block in _load_yaml("end_effectors.yaml").items()
@@ -349,7 +368,15 @@ def load_end_effectors() -> dict[str, EndEffectorSpec]:
 
 @functools.lru_cache(maxsize=None)
 def load_platforms() -> dict[str, PlatformSpec]:
-    """Platform name -> spec, from ``platforms.yaml``."""
+    """Load and validate ``platforms.yaml``.
+
+    Returns:
+        A dictionary from platform names to validated specifications.
+
+    Raises:
+        RegistryError: If an entry is invalid or two platforms produce the
+            same embodiment name.
+    """
     end_effectors = load_end_effectors()
     platforms = {
         name: _parse_platform(name, block, end_effectors)
@@ -369,7 +396,11 @@ def load_platforms() -> dict[str, PlatformSpec]:
 
 @functools.lru_cache(maxsize=None)
 def load_embodiment_platforms() -> dict[str, PlatformSpec]:
-    """Embodiment name -> the platform that owns it, aliases included."""
+    """Map current and deprecated embodiment names to platform specifications.
+
+    The result includes an alias only if its current target identifies a
+    platform.
+    """
     by_embodiment = {
         embodiment: platform
         for platform in load_platforms().values()

--- a/egomimic/rldb/embodiment/registry/aliases.yaml
+++ b/egomimic/rldb/embodiment/registry/aliases.yaml
@@ -1,0 +1,24 @@
+# Deprecated embodiment name -> current name.
+#
+# Append-only. A row here is the promise that an episode written under the old
+# name keeps loading; deleting one re-creates exactly the failure this table
+# exists to prevent. The 07/08/2026 human-embodiment collapse cost a fleet-wide
+# "⚠️ Action required — RE-DOWNLOAD your data" (README) purely because
+# `get_embodiment_id` had no fallback: the name is baked into every episode's
+# `zarr.json`, so the rename hard-crashed with `KeyError: 'ARIA_BIMANUAL'`.
+#
+# Only names that were once real belong here. `eve_*` is deliberately absent:
+# Eve was a different robot, not a renamed one, and silently loading its
+# episodes as some other platform is worse than the KeyError.
+
+# 07/08/2026 — human embodiment collapse: the per-vendor names became `human_*`.
+# The data source now lives only in the SQL `lab` field.
+aria_left_arm: human_left_arm
+aria_right_arm: human_right_arm
+aria_bimanual: human_bimanual
+mecka_left_arm: human_left_arm
+mecka_right_arm: human_right_arm
+mecka_bimanual: human_bimanual
+scale_left_arm: human_left_arm
+scale_right_arm: human_right_arm
+scale_bimanual: human_bimanual

--- a/egomimic/rldb/embodiment/registry/aliases.yaml
+++ b/egomimic/rldb/embodiment/registry/aliases.yaml
@@ -1,18 +1,14 @@
-# Deprecated embodiment name -> current name.
+# Map deprecated embodiment names to current names.
 #
-# Append-only. A row here is the promise that an episode written under the old
-# name keeps loading; deleting one re-creates exactly the failure this table
-# exists to prevent. The 07/08/2026 human-embodiment collapse cost a fleet-wide
-# "⚠️ Action required — RE-DOWNLOAD your data" (README) purely because
-# `get_embodiment_id` had no fallback: the name is baked into every episode's
-# `zarr.json`, so the rename hard-crashed with `KeyError: 'ARIA_BIMANUAL'`.
+# Do not remove an existing mapping. Stored `zarr.json` files can contain a
+# deprecated name. Before this table existed, `get_embodiment_id` raised
+# `KeyError: 'ARIA_BIMANUAL'` for cached episodes after the 2026-07-08 rename.
 #
-# Only names that were once real belong here. `eve_*` is deliberately absent:
-# Eve was a different robot, not a renamed one, and silently loading its
-# episodes as some other platform is worse than the KeyError.
+# Add a mapping only for a name that the project previously stored. Do not map
+# `eve_*`. Eve identifies a different robot, not a deprecated name.
 
-# 07/08/2026 — human embodiment collapse: the per-vendor names became `human_*`.
-# The data source now lives only in the SQL `lab` field.
+# On 2026-07-08, vendor-specific human names changed to `human_*`. The SQL
+# `lab` field now stores the data source.
 aria_left_arm: human_left_arm
 aria_right_arm: human_right_arm
 aria_bimanual: human_bimanual

--- a/egomimic/rldb/embodiment/registry/end_effectors.yaml
+++ b/egomimic/rldb/embodiment/registry/end_effectors.yaml
@@ -1,0 +1,37 @@
+# End-effectors — what is on the end of each arm, declared per side.
+#
+# `action_space` is the load-bearing field: it selects the policy head, and it
+# takes two values, not one per (platform, end-effector) pair.
+#
+#   cartesian  [L xyz ypr g, R xyz ypr g]                            (14)
+#   keypoints  [L wrist_pose, L kp21, R wrist_pose, R kp21]     (138 / 140)
+#
+# `keypoints.valid` is a validity mask over the 21 MANO slots: the topology is a
+# superset, and an end-effector declares which slots it actually has. `all` is
+# the five-finger case. A mask says "this hand has no pinky"; it is not the same
+# thing as the `1e9` sentinel, which says "this frame's estimate failed".
+#
+# Fields
+#   class          parallel_jaw | human_hand | dexterous_hand
+#   dof            actuated joints, or null when there is no joint chain
+#   action_space   cartesian | keypoints
+#   keypoints      {topology, valid}
+#   joint_names    optional, len == dof
+#   joint_limits   optional [[lo, hi], ...], len == dof
+#   urdf           optional, for FK: joints -> keypoints
+#   dead_dims      structurally dead joint indices; declared, never silently zero
+
+eva_parallel_jaw:
+  class: parallel_jaw
+  dof: 1
+  action_space: cartesian
+  # Exactly representable as keypoints (aperture = ||tip_a - tip_b||) so a jaw
+  # episode *can* join a dexterous batch. It is not obliged to: jaws train
+  # through `cartesian`, as they do today.
+  keypoints: {topology: mano21, valid: [0, 4, 8]}
+
+mano_hand:
+  class: human_hand
+  dof: null
+  action_space: keypoints
+  keypoints: {topology: mano21, valid: all}

--- a/egomimic/rldb/embodiment/registry/end_effectors.yaml
+++ b/egomimic/rldb/embodiment/registry/end_effectors.yaml
@@ -1,33 +1,30 @@
-# End-effectors — what is on the end of each arm, declared per side.
+# Define the end-effector types that a platform can use on each arm.
 #
-# `action_space` is the load-bearing field: it selects the policy head, and it
-# takes two values, not one per (platform, end-effector) pair.
+# `action_space` selects the policy output layout.
+#   cartesian: [L xyz ypr gripper, R xyz ypr gripper] (14 values)
+#   keypoints: [L wrist pose, L kp21, R wrist pose, R kp21]
+#              (138 values with YPR or 140 values with quaternions)
 #
-#   cartesian  [L xyz ypr g, R xyz ypr g]                            (14)
-#   keypoints  [L wrist_pose, L kp21, R wrist_pose, R kp21]     (138 / 140)
-#
-# `keypoints.valid` is a validity mask over the 21 MANO slots: the topology is a
-# superset, and an end-effector declares which slots it actually has. `all` is
-# the five-finger case. A mask says "this hand has no pinky"; it is not the same
-# thing as the `1e9` sentinel, which says "this frame's estimate failed".
+# `keypoints.valid` lists the MANO slots that exist on the end-effector. Use
+# `all` to select all 21 slots. This static list is different from the `1e9`
+# value that marks a failed estimate in one frame.
 #
 # Fields
 #   class          parallel_jaw | human_hand | dexterous_hand
-#   dof            actuated joints, or null when there is no joint chain
+#   dof            number of actuated joints, or null for no joint chain
 #   action_space   cartesian | keypoints
 #   keypoints      {topology, valid}
-#   joint_names    optional, len == dof
-#   joint_limits   optional [[lo, hi], ...], len == dof
-#   urdf           optional, for FK: joints -> keypoints
-#   dead_dims      structurally dead joint indices; declared, never silently zero
+#   joint_names    optional names in joint order; length must equal dof
+#   joint_limits   optional [lower, upper] pairs; length must equal dof
+#   urdf           optional URDF path for joint-to-keypoint kinematics
+#   dead_dims      optional indices of joint dimensions that contain no signal
 
 eva_parallel_jaw:
   class: parallel_jaw
   dof: 1
   action_space: cartesian
-  # Exactly representable as keypoints (aperture = ||tip_a - tip_b||) so a jaw
-  # episode *can* join a dexterous batch. It is not obliged to: jaws train
-  # through `cartesian`, as they do today.
+  # Slots 0, 4, and 8 represent the wrist and two jaw tips. The distance
+  # between the tips gives the jaw aperture.
   keypoints: {topology: mano21, valid: [0, 4, 8]}
 
 mano_hand:

--- a/egomimic/rldb/embodiment/registry/platforms.yaml
+++ b/egomimic/rldb/embodiment/registry/platforms.yaml
@@ -1,22 +1,18 @@
-# Platforms — what robot (or human) produced an episode.
+# Define the robot or human platform that produced an episode.
 #
-# A platform fixes the arm chain, the auxiliary chain, the camera set and the
-# frame that calibration is expressed in. It deliberately says nothing about the
-# end-effector: that is a separate axis, declared per side in
-# `end_effectors.yaml`, so a new hand on a known robot costs zero lines here.
+# A platform entry defines its joint chains, cameras, and calibration reference
+# frame. `end_effectors.yaml` defines the end-effector for each side.
 #
 # Fields
 #   kind                 robot | human
-#   embodiment_prefix    with `arity`, derives the EMBODIMENT names this
-#                        platform owns (`eva` + `bimanual` -> `eva_bimanual`)
-#   arity                which arm configurations exist
-#   arm_dof              joints per arm; null when poses are observed directly
-#   aux                  torso / lift / head chain, or null
-#   cameras              the declared `images.*` streams
-#   reference_frame      what calibration is relative to: `robot_base`,
-#                        `slam_world`, or `camera:<one of cameras>`
-#   default_end_effector used when an episode carries no `morphology` block
-#   embodiment_class     escape hatch — a hand-written Embodiment subclass
+#   embodiment_prefix    prefix for names derived from each arity value
+#   arity                supported arm configurations
+#   arm_dof              number of joints per arm, or null for observed poses
+#   aux                  non-arm joint chain, or null
+#   cameras              names of the `images.*` streams
+#   reference_frame      robot_base, slam_world, or camera:<camera-name>
+#   default_end_effector end-effector to use when morphology is not present
+#   embodiment_class     dotted path to an existing Embodiment subclass
 
 eva_x5:
   kind: robot
@@ -25,7 +21,7 @@ eva_x5:
   arm_dof: 6
   aux: null
   cameras: [front_1, left_wrist, right_wrist]
-  # EVA extrinsics are stored per arm as `base_T_cam` against the front camera.
+  # EVA episodes store one `base_T_cam` matrix per arm for the front camera.
   reference_frame: camera:front_1
   default_end_effector: eva_parallel_jaw
   embodiment_class: egomimic.rldb.embodiment.eva.Eva
@@ -34,7 +30,7 @@ human_body:
   kind: human
   embodiment_prefix: human
   arity: [left_arm, right_arm, bimanual]
-  # No joint chain: wrist poses and MANO keypoints are observed, not FK'd.
+  # Human episodes contain observed wrist poses and MANO keypoints.
   arm_dof: null
   aux: null
   cameras: [front_1]

--- a/egomimic/rldb/embodiment/registry/platforms.yaml
+++ b/egomimic/rldb/embodiment/registry/platforms.yaml
@@ -1,0 +1,43 @@
+# Platforms — what robot (or human) produced an episode.
+#
+# A platform fixes the arm chain, the auxiliary chain, the camera set and the
+# frame that calibration is expressed in. It deliberately says nothing about the
+# end-effector: that is a separate axis, declared per side in
+# `end_effectors.yaml`, so a new hand on a known robot costs zero lines here.
+#
+# Fields
+#   kind                 robot | human
+#   embodiment_prefix    with `arity`, derives the EMBODIMENT names this
+#                        platform owns (`eva` + `bimanual` -> `eva_bimanual`)
+#   arity                which arm configurations exist
+#   arm_dof              joints per arm; null when poses are observed directly
+#   aux                  torso / lift / head chain, or null
+#   cameras              the declared `images.*` streams
+#   reference_frame      what calibration is relative to: `robot_base`,
+#                        `slam_world`, or `camera:<one of cameras>`
+#   default_end_effector used when an episode carries no `morphology` block
+#   embodiment_class     escape hatch — a hand-written Embodiment subclass
+
+eva_x5:
+  kind: robot
+  embodiment_prefix: eva
+  arity: [left_arm, right_arm, bimanual]
+  arm_dof: 6
+  aux: null
+  cameras: [front_1, left_wrist, right_wrist]
+  # EVA extrinsics are stored per arm as `base_T_cam` against the front camera.
+  reference_frame: camera:front_1
+  default_end_effector: eva_parallel_jaw
+  embodiment_class: egomimic.rldb.embodiment.eva.Eva
+
+human_body:
+  kind: human
+  embodiment_prefix: human
+  arity: [left_arm, right_arm, bimanual]
+  # No joint chain: wrist poses and MANO keypoints are observed, not FK'd.
+  arm_dof: null
+  aux: null
+  cameras: [front_1]
+  reference_frame: slam_world
+  default_end_effector: mano_hand
+  embodiment_class: egomimic.rldb.embodiment.human.Human

--- a/egomimic/rldb/embodiment/test_embodiment_registry.py
+++ b/egomimic/rldb/embodiment/test_embodiment_registry.py
@@ -1,0 +1,109 @@
+"""Tests for the single embodiment registry (`egomimic.rldb.embodiment`)."""
+
+import pytest
+
+from egomimic.rldb.embodiment import (
+    EMBODIMENT,
+    EMBODIMENT_CLASSES,
+    Embodiment,
+    Human,
+    canonical_embodiment_name,
+    get_embodiment_class,
+    get_embodiment_id,
+)
+from egomimic.rldb.embodiment.registry import load_aliases
+
+
+def test_every_enum_member_has_a_class() -> None:
+    """The registry is the single answer to "what embodiments are there".
+
+    An enum member with no class is the drift the two mirrored dicts used to
+    hide: the name loads, the overlay silently falls back to `Human`.
+    """
+    missing = [
+        m.name.lower() for m in EMBODIMENT if m.name.lower() not in EMBODIMENT_CLASSES
+    ]
+    assert not missing, f"EMBODIMENT members with no class: {missing}"
+
+
+def test_registry_has_no_unknown_names() -> None:
+    known = {m.name.lower() for m in EMBODIMENT}
+    extra = sorted(set(EMBODIMENT_CLASSES) - known)
+    assert not extra, f"EMBODIMENT_CLASSES names not in the EMBODIMENT enum: {extra}"
+
+
+def test_every_class_is_an_embodiment() -> None:
+    for name, cls in EMBODIMENT_CLASSES.items():
+        assert issubclass(cls, Embodiment), f"{name} -> {cls} is not an Embodiment"
+
+
+def test_get_embodiment_class_is_case_insensitive() -> None:
+    assert get_embodiment_class("EVA_BIMANUAL") is EMBODIMENT_CLASSES["eva_bimanual"]
+    assert get_embodiment_class("Human_Bimanual") is Human
+
+
+def test_get_embodiment_class_falls_back_instead_of_raising() -> None:
+    """Readers pull this name out of an episode's attrs; a miss is a fallback."""
+    assert get_embodiment_class("not_an_embodiment") is None
+    assert get_embodiment_class("") is None
+    assert get_embodiment_class(None) is None
+    assert get_embodiment_class("not_an_embodiment", default=Human) is Human
+
+
+def test_aliases_resolve_to_live_ids() -> None:
+    """The 07/08/2026 collapse hard-crashed on cached episodes; it must not now."""
+    for old, new in load_aliases().items():
+        assert get_embodiment_id(old) == get_embodiment_id(new), old
+
+
+def test_alias_targets_are_canonical_names() -> None:
+    known = {m.name.lower() for m in EMBODIMENT}
+    aliases = load_aliases()
+    unknown = sorted(t for t in aliases.values() if t not in known)
+    assert not unknown, f"aliases.yaml points at names that do not exist: {unknown}"
+
+
+def test_no_alias_shadows_a_live_name() -> None:
+    """A live name always wins, so a re-used name can never be silently rerouted."""
+    known = {m.name.lower() for m in EMBODIMENT}
+    shadowing = sorted(set(load_aliases()) & known)
+    assert not shadowing, f"aliases.yaml keys collide with live names: {shadowing}"
+    for name in known:
+        assert canonical_embodiment_name(name) == name
+
+
+def test_aliases_are_not_chained() -> None:
+    """One hop only: an alias target must not itself be an alias."""
+    aliases = load_aliases()
+    chained = sorted(t for t in aliases.values() if t in aliases)
+    assert not chained, f"aliases.yaml has chained entries: {chained}"
+
+
+def test_alias_resolves_to_the_right_class() -> None:
+    assert get_embodiment_class("aria_bimanual") is Human
+    assert get_embodiment_class("MECKA_LEFT_ARM") is Human
+
+
+def test_unknown_name_still_fails_loudly() -> None:
+    """An alias table is a compatibility shim, not a way to swallow typos."""
+    with pytest.raises(KeyError):
+        get_embodiment_id("eva_bimanualll")
+
+
+def test_aliases_are_a_read_shim_only(tmp_path) -> None:
+    """Old episodes load under an alias; new ones may not be *written* under one.
+
+    The table exists so a rename costs nothing at load. Letting a producer write
+    a deprecated name would turn the shim into a second live spelling.
+    """
+    import numpy as np
+
+    from egomimic.rldb.zarr.zarr_writer import ZarrWriter
+
+    with pytest.raises(ValueError, match="embodiment must be one of"):
+        ZarrWriter.create_and_write(
+            episode_path=tmp_path / "aliased.zarr",
+            numeric_data={"left.obs_gripper": np.zeros((4, 1))},
+            embodiment="aria_bimanual",
+            intrinsics={"front_1": np.zeros((3, 4))},
+        )

--- a/egomimic/rldb/embodiment/test_embodiment_registry.py
+++ b/egomimic/rldb/embodiment/test_embodiment_registry.py
@@ -1,4 +1,4 @@
-"""Tests for the single embodiment registry (`egomimic.rldb.embodiment`)."""
+"""Test embodiment class lookup and deprecated-name aliases."""
 
 import pytest
 
@@ -15,11 +15,6 @@ from egomimic.rldb.embodiment.registry import load_aliases
 
 
 def test_every_enum_member_has_a_class() -> None:
-    """The registry is the single answer to "what embodiments are there".
-
-    An enum member with no class is the drift the two mirrored dicts used to
-    hide: the name loads, the overlay silently falls back to `Human`.
-    """
     missing = [
         m.name.lower() for m in EMBODIMENT if m.name.lower() not in EMBODIMENT_CLASSES
     ]
@@ -43,7 +38,6 @@ def test_get_embodiment_class_is_case_insensitive() -> None:
 
 
 def test_get_embodiment_class_falls_back_instead_of_raising() -> None:
-    """Readers pull this name out of an episode's attrs; a miss is a fallback."""
     assert get_embodiment_class("not_an_embodiment") is None
     assert get_embodiment_class("") is None
     assert get_embodiment_class(None) is None
@@ -51,7 +45,6 @@ def test_get_embodiment_class_falls_back_instead_of_raising() -> None:
 
 
 def test_aliases_resolve_to_live_ids() -> None:
-    """The 07/08/2026 collapse hard-crashed on cached episodes; it must not now."""
     for old, new in load_aliases().items():
         assert get_embodiment_id(old) == get_embodiment_id(new), old
 
@@ -64,7 +57,6 @@ def test_alias_targets_are_canonical_names() -> None:
 
 
 def test_no_alias_shadows_a_live_name() -> None:
-    """A live name always wins, so a re-used name can never be silently rerouted."""
     known = {m.name.lower() for m in EMBODIMENT}
     shadowing = sorted(set(load_aliases()) & known)
     assert not shadowing, f"aliases.yaml keys collide with live names: {shadowing}"
@@ -73,7 +65,6 @@ def test_no_alias_shadows_a_live_name() -> None:
 
 
 def test_aliases_are_not_chained() -> None:
-    """One hop only: an alias target must not itself be an alias."""
     aliases = load_aliases()
     chained = sorted(t for t in aliases.values() if t in aliases)
     assert not chained, f"aliases.yaml has chained entries: {chained}"
@@ -85,17 +76,11 @@ def test_alias_resolves_to_the_right_class() -> None:
 
 
 def test_unknown_name_still_fails_loudly() -> None:
-    """An alias table is a compatibility shim, not a way to swallow typos."""
     with pytest.raises(KeyError):
         get_embodiment_id("eva_bimanualll")
 
 
 def test_aliases_are_a_read_shim_only(tmp_path) -> None:
-    """Old episodes load under an alias; new ones may not be *written* under one.
-
-    The table exists so a rename costs nothing at load. Letting a producer write
-    a deprecated name would turn the shim into a second live spelling.
-    """
     import numpy as np
 
     from egomimic.rldb.zarr.zarr_writer import ZarrWriter

--- a/egomimic/rldb/embodiment/test_registry_files.py
+++ b/egomimic/rldb/embodiment/test_registry_files.py
@@ -1,10 +1,4 @@
-"""Tests for the declarative registry (`egomimic/rldb/embodiment/registry/`).
-
-Two things are being defended here. First, that the YAML actually describes the
-embodiments the code has: a registry the code does not agree with is worse than
-the dicts it replaces. Second, that a malformed block fails at load — a typo'd
-field silently ignored is exactly how four sources of truth drifted apart.
-"""
+"""Test registry consistency and reject invalid registry entries."""
 
 import importlib
 
@@ -43,7 +37,6 @@ def test_platforms_claim_no_embodiment_that_does_not_exist() -> None:
 
 
 def test_embodiment_class_escape_hatch_resolves() -> None:
-    """`embodiment_class:` is a dotted path; a typo must not survive to runtime."""
     for platform in load_platforms().values():
         if platform.embodiment_class is None:
             continue
@@ -52,7 +45,6 @@ def test_embodiment_class_escape_hatch_resolves() -> None:
 
 
 def test_registry_agrees_with_the_class_dict() -> None:
-    """Both halves of the registry must name the same class for an embodiment."""
     for embodiment, platform in load_embodiment_platforms().items():
         if embodiment not in EMBODIMENT_CLASSES or platform.embodiment_class is None:
             continue
@@ -70,7 +62,7 @@ def test_default_end_effectors_and_action_spaces_exist() -> None:
 def test_declared_end_effector_masks() -> None:
     end_effectors = load_end_effectors()
     assert end_effectors["mano_hand"].keypoints.is_complete
-    # A jaw is exactly representable: wrist + two tips, aperture = ||tip - tip||.
+    # MANO slots 0, 4, and 8 represent the wrist and the two jaw tips.
     jaw = end_effectors["eva_parallel_jaw"].keypoints
     assert jaw.valid == (0, 4, 8)
     assert not jaw.is_complete

--- a/egomimic/rldb/embodiment/test_registry_files.py
+++ b/egomimic/rldb/embodiment/test_registry_files.py
@@ -1,0 +1,170 @@
+"""Tests for the declarative registry (`egomimic/rldb/embodiment/registry/`).
+
+Two things are being defended here. First, that the YAML actually describes the
+embodiments the code has: a registry the code does not agree with is worse than
+the dicts it replaces. Second, that a malformed block fails at load — a typo'd
+field silently ignored is exactly how four sources of truth drifted apart.
+"""
+
+import importlib
+
+import pytest
+
+from egomimic.rldb.embodiment import EMBODIMENT, EMBODIMENT_CLASSES, Embodiment
+from egomimic.rldb.embodiment.registry import (
+    ACTION_SPACES,
+    RegistryError,
+    _parse_end_effector,
+    _parse_platform,
+    load_embodiment_platforms,
+    load_end_effectors,
+    load_platforms,
+)
+
+
+def _import_path(path: str):
+    module_name, _, attr = path.rpartition(".")
+    return getattr(importlib.import_module(module_name), attr)
+
+
+def test_every_enum_member_is_owned_by_a_platform() -> None:
+    by_embodiment = load_embodiment_platforms()
+    missing = sorted(
+        m.name.lower() for m in EMBODIMENT if m.name.lower() not in by_embodiment
+    )
+    assert not missing, f"EMBODIMENT members no platform claims: {missing}"
+
+
+def test_platforms_claim_no_embodiment_that_does_not_exist() -> None:
+    known = {m.name.lower() for m in EMBODIMENT}
+    for platform in load_platforms().values():
+        extra = sorted(set(platform.embodiments) - known)
+        assert not extra, f"{platform.name} claims non-existent embodiments: {extra}"
+
+
+def test_embodiment_class_escape_hatch_resolves() -> None:
+    """`embodiment_class:` is a dotted path; a typo must not survive to runtime."""
+    for platform in load_platforms().values():
+        if platform.embodiment_class is None:
+            continue
+        cls = _import_path(platform.embodiment_class)
+        assert issubclass(cls, Embodiment), platform.embodiment_class
+
+
+def test_registry_agrees_with_the_class_dict() -> None:
+    """Both halves of the registry must name the same class for an embodiment."""
+    for embodiment, platform in load_embodiment_platforms().items():
+        if embodiment not in EMBODIMENT_CLASSES or platform.embodiment_class is None:
+            continue
+        assert EMBODIMENT_CLASSES[embodiment] is _import_path(platform.embodiment_class)
+
+
+def test_default_end_effectors_and_action_spaces_exist() -> None:
+    end_effectors = load_end_effectors()
+    for platform in load_platforms().values():
+        assert platform.default_end_effector in end_effectors
+    for spec in end_effectors.values():
+        assert spec.action_space in ACTION_SPACES
+
+
+def test_declared_end_effector_masks() -> None:
+    end_effectors = load_end_effectors()
+    assert end_effectors["mano_hand"].keypoints.is_complete
+    # A jaw is exactly representable: wrist + two tips, aperture = ||tip - tip||.
+    jaw = end_effectors["eva_parallel_jaw"].keypoints
+    assert jaw.valid == (0, 4, 8)
+    assert not jaw.is_complete
+    assert jaw.n_slots == 21
+
+
+def test_aliases_reach_the_same_platform_as_their_target() -> None:
+    by_embodiment = load_embodiment_platforms()
+    assert by_embodiment["aria_bimanual"] is by_embodiment["human_bimanual"]
+
+
+def _jaw_block(**overrides):
+    block = {
+        "class": "parallel_jaw",
+        "dof": 1,
+        "action_space": "cartesian",
+        "keypoints": {"topology": "mano21", "valid": [0, 4, 8]},
+    }
+    block.update(overrides)
+    return block
+
+
+def _platform_block(**overrides):
+    block = {
+        "kind": "robot",
+        "embodiment_prefix": "eva",
+        "arity": ["bimanual"],
+        "arm_dof": 6,
+        "aux": None,
+        "cameras": ["front_1"],
+        "reference_frame": "camera:front_1",
+        "default_end_effector": "eva_parallel_jaw",
+    }
+    block.update(overrides)
+    return block
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"actoin_space": "cartesian"}, id="typo'd field"),
+        pytest.param({"action_space": "joints"}, id="unknown action space"),
+        pytest.param({"class": "vacuum_gripper"}, id="unknown class"),
+        pytest.param(
+            {"keypoints": {"topology": "mano21", "valid": [0, 21]}},
+            id="slot out of range",
+        ),
+        pytest.param(
+            {"keypoints": {"topology": "smplx", "valid": "all"}},
+            id="unknown topology",
+        ),
+        pytest.param({"dof": 2, "joint_names": ["a"]}, id="joint_names vs dof"),
+        pytest.param({"dof": 1, "joint_limits": [[1.0, -1.0]]}, id="inverted limit"),
+        pytest.param({"dof": 1, "dead_dims": [3]}, id="dead dim out of range"),
+    ],
+)
+def test_malformed_end_effector_is_rejected(overrides) -> None:
+    with pytest.raises(RegistryError):
+        _parse_end_effector("bad_ee", _jaw_block(**overrides))
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"kind": "cyborg"}, id="unknown kind"),
+        pytest.param({"arity": []}, id="empty arity"),
+        pytest.param({"cameras": []}, id="no cameras"),
+        pytest.param(
+            {"reference_frame": "camera:left_wrist"}, id="frame names absent camera"
+        ),
+        pytest.param({"reference_frame": "table"}, id="unknown reference frame"),
+        pytest.param({"default_end_effector": "no_such_hand"}, id="unknown default ee"),
+        pytest.param({"arm_dof": 0}, id="non-positive arm_dof"),
+        pytest.param({"aux": {"dof": 7, "joint_names": ["a"]}}, id="aux names vs dof"),
+    ],
+)
+def test_malformed_platform_is_rejected(overrides) -> None:
+    with pytest.raises(RegistryError):
+        _parse_platform(
+            "bad_platform", _platform_block(**overrides), load_end_effectors()
+        )
+
+
+def test_valid_all_expands_to_the_whole_topology() -> None:
+    spec = _parse_end_effector(
+        "five_finger",
+        _jaw_block(
+            **{
+                "class": "dexterous_hand",
+                "dof": 20,
+                "action_space": "keypoints",
+                "keypoints": {"topology": "mano21", "valid": "all"},
+            }
+        ),
+    )
+    assert spec.keypoints.valid == tuple(range(21))
+    assert spec.keypoints.is_complete

--- a/egomimic/rldb/embodiment/test_resolve.py
+++ b/egomimic/rldb/embodiment/test_resolve.py
@@ -1,0 +1,143 @@
+"""Tests for `Embodiment.resolve` — the composition path.
+
+The property under test is the design's acceptance test: swapping the
+end-effector must change `action_space` and nothing else, and swapping the
+platform must change the platform and nothing about the hand.
+"""
+
+from dataclasses import replace
+
+import pytest
+
+from egomimic.rldb.embodiment import Embodiment, Eva, Human, ResolvedEmbodiment
+from egomimic.rldb.embodiment.registry import load_end_effectors, load_platforms
+
+
+def test_resolve_by_name_uses_the_platform_default_end_effector() -> None:
+    """No episode carries a `morphology` block yet, so the name must still work."""
+    eva = Embodiment.resolve("eva_bimanual")
+    assert eva.platform is load_platforms()["eva_x5"]
+    assert eva.platform.arm_dof == 6
+    assert set(eva.end_effectors) == {"left", "right"}
+    assert all(ee.name == "eva_parallel_jaw" for ee in eva.end_effectors.values())
+    assert eva.action_space == "cartesian"
+    assert eva.embodiment_class is Eva
+
+
+def test_resolve_human_lands_on_the_keypoints_head() -> None:
+    human = Embodiment.resolve("human_bimanual")
+    assert human.platform is load_platforms()["human_body"]
+    assert human.platform.arm_dof is None
+    assert human.action_space == "keypoints"
+    assert human.embodiment_class is Human
+    assert human.keypoints("left").is_complete
+
+
+def test_resolve_follows_aliases() -> None:
+    assert (
+        Embodiment.resolve("aria_bimanual").platform
+        is Embodiment.resolve("human_bimanual").platform
+    )
+    assert Embodiment.resolve("SCALE_LEFT_ARM").embodiment_class is Human
+
+
+def test_resolve_from_morphology_block() -> None:
+    resolved = Embodiment.resolve(
+        {
+            "platform": "eva_x5",
+            "end_effector": {"left": "eva_parallel_jaw", "right": "eva_parallel_jaw"},
+            "vendor": "rl2",
+        }
+    )
+    assert resolved.platform.name == "eva_x5"
+    assert resolved.action_space == "cartesian"
+    assert resolved.embodiment_class is Eva
+
+
+def test_morphology_end_effector_may_be_a_bare_string() -> None:
+    resolved = Embodiment.resolve(
+        {"platform": "human_body", "end_effector": "mano_hand"}
+    )
+    assert set(resolved.end_effectors) == {"left", "right"}
+    assert resolved.action_space == "keypoints"
+
+
+def test_a_new_hand_on_a_known_platform_costs_no_code() -> None:
+    """The design's acceptance test, run against the registry as it stands.
+
+    Swapping the declared end-effector re-routes the head with no change to the
+    platform, the stem inputs or any Python. Here the jaw is swapped for a
+    five-finger hand on the same EVA arms.
+    """
+    jaws = Embodiment.resolve(
+        {"platform": "eva_x5", "end_effector": "eva_parallel_jaw"}
+    )
+    hands = Embodiment.resolve({"platform": "eva_x5", "end_effector": "mano_hand"})
+
+    assert jaws.platform is hands.platform
+    assert jaws.platform.cameras == hands.platform.cameras
+    assert jaws.platform.arm_dof == hands.platform.arm_dof
+    assert jaws.action_space == "cartesian"
+    assert hands.action_space == "keypoints"
+
+
+def test_mixed_action_spaces_are_refused() -> None:
+    """Two hands wanting different heads has no single training interface."""
+    mixed = Embodiment.resolve(
+        {
+            "platform": "eva_x5",
+            "end_effector": {"left": "eva_parallel_jaw", "right": "mano_hand"},
+        }
+    )
+    with pytest.raises(ValueError, match="disagree on action_space"):
+        mixed.action_space
+
+
+def test_platform_without_a_class_says_so() -> None:
+    platform = replace(load_platforms()["eva_x5"], embodiment_class=None)
+    resolved = ResolvedEmbodiment(
+        platform=platform,
+        end_effectors={"left": load_end_effectors()["eva_parallel_jaw"]},
+    )
+    with pytest.raises(NotImplementedError, match="embodiment_class"):
+        resolved.embodiment_class
+
+
+@pytest.mark.parametrize(
+    "spec, match",
+    [
+        pytest.param("not_an_embodiment", "not owned by any platform", id="bad name"),
+        pytest.param({"platform": "nope"}, "not in", id="bad platform"),
+        pytest.param(
+            {"platform": "eva_x5", "end_effector": {"left": "nope"}},
+            "not in",
+            id="bad end effector",
+        ),
+        pytest.param(
+            {"platform": "eva_x5", "end_effector": {"middle": "mano_hand"}},
+            "unknown side",
+            id="bad side",
+        ),
+        pytest.param(
+            {"platform": "eva_x5", "end_effector": []}, "must be", id="bad ee type"
+        ),
+    ],
+)
+def test_a_bad_identifier_is_a_hard_error(spec, match) -> None:
+    """Identifiers plus a registry: a typo fails at resolve, not silently later."""
+    with pytest.raises(ValueError, match=match):
+        Embodiment.resolve(spec)
+
+
+def test_resolve_rejects_the_wrong_type() -> None:
+    with pytest.raises(TypeError):
+        Embodiment.resolve(3)
+
+
+def test_resolve_delegates_to_the_hand_written_pipeline() -> None:
+    """`Human`/`Eva` are reached through the registry, not rewritten."""
+    eva = Embodiment.resolve("eva_bimanual")
+    assert eva.get_keymap("cartesian") == Eva.get_keymap("cartesian")
+    assert len(eva.get_transform_list("cartesian")) == len(
+        Eva.get_transform_list("cartesian")
+    )

--- a/egomimic/rldb/embodiment/test_resolve.py
+++ b/egomimic/rldb/embodiment/test_resolve.py
@@ -1,9 +1,4 @@
-"""Tests for `Embodiment.resolve` — the composition path.
-
-The property under test is the design's acceptance test: swapping the
-end-effector must change `action_space` and nothing else, and swapping the
-platform must change the platform and nothing about the hand.
-"""
+"""Test name-based and morphology-based ``Embodiment.resolve`` inputs."""
 
 from dataclasses import replace
 
@@ -14,7 +9,6 @@ from egomimic.rldb.embodiment.registry import load_end_effectors, load_platforms
 
 
 def test_resolve_by_name_uses_the_platform_default_end_effector() -> None:
-    """No episode carries a `morphology` block yet, so the name must still work."""
     eva = Embodiment.resolve("eva_bimanual")
     assert eva.platform is load_platforms()["eva_x5"]
     assert eva.platform.arm_dof == 6
@@ -63,12 +57,6 @@ def test_morphology_end_effector_may_be_a_bare_string() -> None:
 
 
 def test_a_new_hand_on_a_known_platform_costs_no_code() -> None:
-    """The design's acceptance test, run against the registry as it stands.
-
-    Swapping the declared end-effector re-routes the head with no change to the
-    platform, the stem inputs or any Python. Here the jaw is swapped for a
-    five-finger hand on the same EVA arms.
-    """
     jaws = Embodiment.resolve(
         {"platform": "eva_x5", "end_effector": "eva_parallel_jaw"}
     )
@@ -82,7 +70,6 @@ def test_a_new_hand_on_a_known_platform_costs_no_code() -> None:
 
 
 def test_mixed_action_spaces_are_refused() -> None:
-    """Two hands wanting different heads has no single training interface."""
     mixed = Embodiment.resolve(
         {
             "platform": "eva_x5",
@@ -124,7 +111,6 @@ def test_platform_without_a_class_says_so() -> None:
     ],
 )
 def test_a_bad_identifier_is_a_hard_error(spec, match) -> None:
-    """Identifiers plus a registry: a typo fails at resolve, not silently later."""
     with pytest.raises(ValueError, match=match):
         Embodiment.resolve(spec)
 
@@ -135,7 +121,6 @@ def test_resolve_rejects_the_wrong_type() -> None:
 
 
 def test_resolve_delegates_to_the_hand_written_pipeline() -> None:
-    """`Human`/`Eva` are reached through the registry, not rewritten."""
     eva = Embodiment.resolve("eva_bimanual")
     assert eva.get_keymap("cartesian") == Eva.get_keymap("cartesian")
     assert len(eva.get_transform_list("cartesian")) == len(

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -79,7 +79,7 @@ class InterpolatePose(Transform):
         if self.mode == "xyzwxyz":
             if actions.ndim != 2 or actions.shape[-1] != 7:
                 raise ValueError(
-                    f"InterpolatePose expects (T, 7) when is_quat=True, got "
+                    f"InterpolatePose expects (T, 7) when mode='xyzwxyz', got "
                     f"{actions.shape} for key '{self.action_key}'"
                 )
             batch[self.output_action_key] = _interpolate_quat_wxyz(

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -154,10 +154,16 @@ class ActionChunkCoordinateFrameTransform(Transform):
     ):
         """
         args:
-            target_world:
-            chunk_world:
-            transformed_key_name:
-            is_quat: if True, inputs are xyz + quat(wxyz); otherwise xyz + ypr.
+            target_world: Batch key for the target-frame pose in the reference
+                frame (`reference_T_target`).
+            chunk_world: Batch key for the pose chunk. With `inverse=True`, the
+                poses are `reference_T_chunk`; otherwise they are
+                `target_T_chunk`.
+            transformed_key_name: Batch key for the transformed pose chunk.
+            mode: Pose representation used by the chunk.
+            inverse: Compute `target_T_chunk = inv(reference_T_target) @
+                reference_T_chunk` when true. When false, compose
+                `reference_T_chunk = reference_T_target @ target_T_chunk`.
         """
         self.target_world = target_world
         self.chunk_world = chunk_world
@@ -170,26 +176,25 @@ class ActionChunkCoordinateFrameTransform(Transform):
         """
         args:
             batch:
-                if is_quat=False, inputs are xyz + ypr.
-                if is_quat=True, inputs are xyz + quat(wxyz).
+                Inputs use the representation selected by `mode`.
                 Input shape validation is delegated to the selected to-matrix helper.
-                transformed_key_name: str, name of the new key to store the transformed chunk world in
+                transformed_key_name: str, name of the new key to store the
+                    transformed pose chunk in.
 
         returns
-            batch with new key containing transformed chunk world in target frame:
-                if is_quat=False: (T, 6) xyz + ypr
-                if is_quat=True: (T, 7) xyz + quat(wxyz)
+            Batch with a new key containing the transformed pose chunk.
         """
-        # flatten to (T, D)
-        # target world is head pose, chunk world is keypoints
+        # Flatten to (T, D).
         batch.update(self.extra_batch_key or {})
-        target_world = np.asarray(batch[self.target_world])
-        chunk_world = np.asarray(batch[self.chunk_world])
-        chunk_world_shape = None
+        target_world_pose = np.asarray(batch[self.target_world])
+        chunk_world_poses = np.asarray(batch[self.chunk_world])
+        chunk_world_poses_shape = None
 
-        if chunk_world.ndim > 2:
-            chunk_world_shape = chunk_world.shape
-            chunk_world = chunk_world.reshape(-1, chunk_world_shape[-1])
+        if chunk_world_poses.ndim > 2:
+            chunk_world_poses_shape = chunk_world_poses.shape
+            chunk_world_poses = chunk_world_poses.reshape(
+                -1, chunk_world_poses_shape[-1]
+            )
 
         to_matrix_fn = None
         if self.mode == "xyzwxyz":
@@ -201,38 +206,45 @@ class ActionChunkCoordinateFrameTransform(Transform):
         else:
             raise ValueError(f"Invalid mode: {self.mode}")
 
-        target_world_to_matrix_fn = (
-            _xyzwxyz_to_matrix if target_world.shape[-1] == 7 else _xyzypr_to_matrix
+        target_pose_to_matrix_fn = (
+            _xyzwxyz_to_matrix
+            if target_world_pose.shape[-1] == 7
+            else _xyzypr_to_matrix
         )
-        # Convert to SE3 for transformation
-        target_se3 = SE3.from_matrix(
-            target_world_to_matrix_fn(target_world[None, :])[0]
+        # Convert to SE3 for transformation. The target pose is
+        # `reference_T_target` under the repository convention.
+        reference_T_target = SE3.from_matrix(
+            target_pose_to_matrix_fn(target_world_pose[None, :])[0]
         )  # (4, 4)
-        chunk_se3 = SE3.from_matrix(to_matrix_fn(chunk_world))  # (T, 4, 4)
+        chunk_pose_transforms = SE3.from_matrix(
+            to_matrix_fn(chunk_world_poses)
+        )  # (T, 4, 4)
 
         # Compute relative transform and apply to chunk
         if self.inverse:
-            chunk_in_target_frame = target_se3.inverse() @ chunk_se3
+            transformed_pose_transforms = (
+                reference_T_target.inverse() @ chunk_pose_transforms
+            )
         else:
-            chunk_in_target_frame = target_se3 @ chunk_se3
-        chunk_mats = chunk_in_target_frame.to_matrix()
-        if chunk_mats.ndim == 2:
-            chunk_mats = chunk_mats[None, ...]
+            transformed_pose_transforms = reference_T_target @ chunk_pose_transforms
+        transformed_matrices = transformed_pose_transforms.to_matrix()
+        if transformed_matrices.ndim == 2:
+            transformed_matrices = transformed_matrices[None, ...]
 
         if self.mode == "xyzwxyz":
-            chunk_in_target_frame = _matrix_to_xyzwxyz(chunk_mats)
+            transformed_poses = _matrix_to_xyzwxyz(transformed_matrices)
         elif self.mode == "xyzypr":
-            chunk_in_target_frame = _matrix_to_xyzypr(chunk_mats)
+            transformed_poses = _matrix_to_xyzypr(transformed_matrices)
         elif self.mode == "xyz":
-            chunk_in_target_frame = _matrix_to_xyz(chunk_mats)
+            transformed_poses = _matrix_to_xyz(transformed_matrices)
         else:
             raise ValueError(f"Invalid mode: {self.mode}")
 
-        if chunk_world_shape is not None:
-            chunk_in_target_frame = chunk_in_target_frame.reshape(*chunk_world_shape)
+        if chunk_world_poses_shape is not None:
+            transformed_poses = transformed_poses.reshape(*chunk_world_poses_shape)
 
         # Store transformed chunk back in batch
-        batch[self.transformed_key_name] = chunk_in_target_frame
+        batch[self.transformed_key_name] = transformed_poses
 
         return batch
 
@@ -443,23 +455,25 @@ class CartesianWithGripperCoordinateTransform(Transform):
         left_pose_world = chunk_world[:, :6]
         right_pose_world = chunk_world[:, 7:13]
 
-        left_target_se3 = SE3.from_matrix(
+        world_T_left_target = SE3.from_matrix(
             _xyzypr_to_matrix(left_target_world[None, :])[0]
         )
-        right_target_se3 = SE3.from_matrix(
+        world_T_right_target = SE3.from_matrix(
             _xyzypr_to_matrix(right_target_world[None, :])[0]
         )
-        left_target_inv = left_target_se3.inverse()
-        right_target_inv = right_target_se3.inverse()
+        left_target_T_world = world_T_left_target.inverse()
+        right_target_T_world = world_T_right_target.inverse()
 
         left_pose_in_target = _matrix_to_xyzypr(
             (
-                left_target_inv @ SE3.from_matrix(_xyzypr_to_matrix(left_pose_world))
+                left_target_T_world
+                @ SE3.from_matrix(_xyzypr_to_matrix(left_pose_world))
             ).to_matrix()
         )
         right_pose_in_target = _matrix_to_xyzypr(
             (
-                right_target_inv @ SE3.from_matrix(_xyzypr_to_matrix(right_pose_world))
+                right_target_T_world
+                @ SE3.from_matrix(_xyzypr_to_matrix(right_pose_world))
             ).to_matrix()
         )
 

--- a/egomimic/rldb/zarr/action_chunk_transforms.py
+++ b/egomimic/rldb/zarr/action_chunk_transforms.py
@@ -152,18 +152,20 @@ class ActionChunkCoordinateFrameTransform(Transform):
         mode: Literal["xyz", "xyzwxyz", "xyzypr"] = "xyzwxyz",
         inverse: bool = True,
     ):
-        """
-        args:
+        """Configure a coordinate transform for a batch of poses.
+
+        Args:
             target_world: Batch key for the target-frame pose in the reference
-                frame (`reference_T_target`).
-            chunk_world: Batch key for the pose chunk. With `inverse=True`, the
-                poses are `reference_T_chunk`; otherwise they are
-                `target_T_chunk`.
-            transformed_key_name: Batch key for the transformed pose chunk.
-            mode: Pose representation used by the chunk.
-            inverse: Compute `target_T_chunk = inv(reference_T_target) @
-                reference_T_chunk` when true. When false, compose
-                `reference_T_chunk = reference_T_target @ target_T_chunk`.
+                frame. This pose represents ``reference_T_target``.
+            chunk_world: Batch key for the input poses.
+            transformed_key_name: Batch key for the output poses.
+            extra_batch_key: Values to add to the batch before the transform.
+            mode: Input and output layout. Use ``"xyz"``, ``"xyzypr"``, or
+                ``"xyzwxyz"``.
+            inverse: If true, compute ``target_T_chunk`` from
+                ``reference_T_target`` and ``reference_T_chunk``. If false,
+                compute ``reference_T_chunk`` from ``reference_T_target`` and
+                ``target_T_chunk``.
         """
         self.target_world = target_world
         self.chunk_world = chunk_world
@@ -173,18 +175,21 @@ class ActionChunkCoordinateFrameTransform(Transform):
         self.inverse = inverse
 
     def transform(self, batch):
-        """
-        args:
-            batch:
-                Inputs use the representation selected by `mode`.
-                Input shape validation is delegated to the selected to-matrix helper.
-                transformed_key_name: str, name of the new key to store the
-                    transformed pose chunk in.
+        """Transform the configured pose chunk and store it in the batch.
 
-        returns
-            Batch with a new key containing the transformed pose chunk.
+        Args:
+            batch: A mutable mapping that contains ``target_world`` and
+                ``chunk_world``. The last input dimension must match ``mode``.
+
+        Returns:
+            The input mapping with ``transformed_key_name`` added. The output
+            has the same shape as the input pose chunk.
+
+        Raises:
+            KeyError: If the batch does not contain a configured input key.
+            ValueError: If ``mode`` is not a supported pose layout.
         """
-        # Flatten to (T, D).
+        # Flatten the leading chunk dimensions into one pose dimension.
         batch.update(self.extra_batch_key or {})
         target_world_pose = np.asarray(batch[self.target_world])
         chunk_world_poses = np.asarray(batch[self.chunk_world])
@@ -211,8 +216,7 @@ class ActionChunkCoordinateFrameTransform(Transform):
             if target_world_pose.shape[-1] == 7
             else _xyzypr_to_matrix
         )
-        # Convert to SE3 for transformation. The target pose is
-        # `reference_T_target` under the repository convention.
+        # Convert the target pose from `reference_T_target` to an SE(3) value.
         reference_T_target = SE3.from_matrix(
             target_pose_to_matrix_fn(target_world_pose[None, :])[0]
         )  # (4, 4)
@@ -220,7 +224,7 @@ class ActionChunkCoordinateFrameTransform(Transform):
             to_matrix_fn(chunk_world_poses)
         )  # (T, 4, 4)
 
-        # Compute relative transform and apply to chunk
+        # Express each chunk pose in the selected output frame.
         if self.inverse:
             transformed_pose_transforms = (
                 reference_T_target.inverse() @ chunk_pose_transforms

--- a/egomimic/rldb/zarr/hdf5_to_zarr.py
+++ b/egomimic/rldb/zarr/hdf5_to_zarr.py
@@ -20,9 +20,9 @@ from pathlib import Path
 
 import numpy as np
 
+from egomimic.rldb.embodiment.eva import Eva
 from egomimic.rldb.zarr import ZarrWriter
 from egomimic.scripts.eva_process.zarr_utils import EvaHD5Extractor
-from egomimic.rldb.embodiment.eva import Eva
 
 
 def is_image_array(arr) -> bool:

--- a/egomimic/rldb/zarr/test_action_chunk_transforms_unit.py
+++ b/egomimic/rldb/zarr/test_action_chunk_transforms_unit.py
@@ -2,15 +2,22 @@ import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation as R
 
+from egomimic.rldb.embodiment.eva import _build_eva_bimanual_transform_list
+from egomimic.rldb.embodiment.human import (
+    _build_human_cartesian_bimanual_transform_list,
+)
 from egomimic.rldb.zarr.action_chunk_transforms import (
     ActionChunkCoordinateFrameTransform,
     ConcatKeys,
     InterpolatePose,
     XYZWXYZ_to_XYZYPR,
-    build_human_bimanual_transform_list,
-    build_eva_bimanual_transform_list,
 )
-from egomimic.utils.pose_utils import _xyzwxyz_to_matrix
+from egomimic.utils.pose_utils import (
+    _xyzwxyz_to_matrix,
+    base_frame_to_cam_frame,
+    cam_frame_to_base_frame,
+    ee_pose_to_cam_frame,
+)
 
 
 def _shape_map(batch: dict) -> dict[str, tuple]:
@@ -78,41 +85,59 @@ def test_xyzwxyz_to_matrix_converts_wxyz_quaternion() -> None:
     np.testing.assert_allclose(mats[1, :3, 3], np.zeros(3), atol=1e-7)
 
 
+def test_base_t_cam_convention_round_trip() -> None:
+    base_T_cam = np.eye(4, dtype=np.float64)
+    base_T_cam[:3, 3] = np.array([1.0, 2.0, 3.0])
+    base_pose = np.array([[1.5, 2.5, 3.5, 0.0, 0.0, 0.0]])
+
+    cam_pose = base_frame_to_cam_frame(base_pose, base_T_cam)
+
+    np.testing.assert_allclose(cam_pose, [[0.5, 0.5, 0.5, 0.0, 0.0, 0.0]])
+    np.testing.assert_allclose(
+        cam_frame_to_base_frame(cam_pose, base_T_cam), base_pose, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        ee_pose_to_cam_frame(base_pose[:, :3], base_T_cam), cam_pose[:, :3]
+    )
+
+
 def test_action_chunk_coordinate_frame_transform_accepts_quat_wxyz_input() -> None:
     yaw = np.pi / 2.0
     qw = np.cos(yaw / 2.0)
     qz = np.sin(yaw / 2.0)
 
     transform = ActionChunkCoordinateFrameTransform(
-        target_world="target_world",
-        chunk_world="chunk_world",
-        transformed_key_name="chunk_target",
-        is_quat=True,
+        target_world="base_T_cam_pose",
+        chunk_world="base_T_ee_poses",
+        transformed_key_name="cam_T_ee_poses",
+        mode="xyzwxyz",
     )
 
     batch = {
-        "target_world": np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], dtype=np.float64),
-        "chunk_world": np.array(
+        "base_T_cam_pose": np.array(
+            [1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0], dtype=np.float64
+        ),
+        "base_T_ee_poses": np.array(
             [
-                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, qw, 0.0, 0.0, qz],
+                [1.5, 2.5, 3.5, 1.0, 0.0, 0.0, 0.0],
+                [1.0, 3.0, 3.0, qw, 0.0, 0.0, qz],
             ],
             dtype=np.float64,
         ),
     }
 
     out = transform.transform(batch)
-    chunk_target = np.asarray(out["chunk_target"])
+    cam_T_ee_poses = np.asarray(out["cam_T_ee_poses"])
 
-    assert chunk_target.shape == (2, 7)
+    assert cam_T_ee_poses.shape == (2, 7)
     expected = np.array(
         [
-            [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.5, 1.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 0.0, qw, 0.0, 0.0, qz],
         ],
         dtype=np.float64,
     )
-    np.testing.assert_allclose(chunk_target, expected, atol=1e-6)
+    np.testing.assert_allclose(cam_T_ee_poses, expected, atol=1e-6)
 
 
 def test_action_chunk_coordinate_frame_transform_ypr_mode_invalid_chunk_shape_raises() -> (
@@ -122,7 +147,7 @@ def test_action_chunk_coordinate_frame_transform_ypr_mode_invalid_chunk_shape_ra
         target_world="target_world",
         chunk_world="chunk_world",
         transformed_key_name="chunk_target",
-        is_quat=False,
+        mode="xyzypr",
     )
     batch = {
         "target_world": np.zeros(6, dtype=np.float64),
@@ -140,7 +165,7 @@ def test_action_chunk_coordinate_frame_transform_quat_mode_invalid_chunk_shape_r
         target_world="target_world",
         chunk_world="chunk_world",
         transformed_key_name="chunk_target",
-        is_quat=True,
+        mode="xyzwxyz",
     )
     batch = {
         "target_world": np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], dtype=np.float64),
@@ -156,7 +181,7 @@ def test_action_chunk_coordinate_frame_transform_invalid_target_shape_raises() -
         target_world="target_world",
         chunk_world="chunk_world",
         transformed_key_name="chunk_target",
-        is_quat=False,
+        mode="xyzypr",
     )
     batch = {
         "target_world": np.zeros((2, 6), dtype=np.float64),
@@ -176,7 +201,7 @@ def test_interpolate_pose_quat_wxyz_slerp_happy_path() -> None:
         new_chunk_length=5,
         action_key="actions",
         output_action_key="actions_out",
-        is_quat=True,
+        mode="xyzwxyz",
     )
     batch = {
         "actions": np.array(
@@ -207,7 +232,7 @@ def test_interpolate_pose_quat_wxyz_invalid_shape_raises() -> None:
         new_chunk_length=4,
         action_key="actions",
         output_action_key="actions_out",
-        is_quat=True,
+        mode="xyzwxyz",
     )
     batch = {"actions": np.zeros((2, 6), dtype=np.float64)}
     with pytest.raises(ValueError, match=r"InterpolatePose expects \(T, 7\)"):
@@ -260,7 +285,7 @@ def test_xyzwxyz_to_xyzypr_strict_shape_raises() -> None:
 
 
 def test_eva_builder_orders_xyzwxyz_to_xyzypr_after_interpolate_before_concat() -> None:
-    transform_list = build_eva_bimanual_transform_list(is_quat=True)
+    transform_list = _build_eva_bimanual_transform_list(is_quat=True)
     converter_indices = [
         i for i, t in enumerate(transform_list) if isinstance(t, XYZWXYZ_to_XYZYPR)
     ]
@@ -286,7 +311,9 @@ def test_eva_builder_orders_xyzwxyz_to_xyzypr_after_interpolate_before_concat() 
 def test_human_builder_orders_xyzwxyz_to_xyzypr_after_interpolate_before_concat() -> (
     None
 ):
-    transform_list = build_human_bimanual_transform_list(target_world_is_quat=True)
+    transform_list = _build_human_cartesian_bimanual_transform_list(
+        target_world_is_quat=True
+    )
     converter_indices = [
         i for i, t in enumerate(transform_list) if isinstance(t, XYZWXYZ_to_XYZYPR)
     ]
@@ -310,7 +337,7 @@ def test_human_builder_orders_xyzwxyz_to_xyzypr_after_interpolate_before_concat(
 
 
 def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
-    transform_list = build_eva_bimanual_transform_list(
+    transform_list = _build_eva_bimanual_transform_list(
         chunk_length=4, stride=1, is_quat=True
     )
     cmd_pose = np.zeros((5, 7), dtype=np.float64)
@@ -318,14 +345,14 @@ def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
     obs_pose = np.zeros((7,), dtype=np.float64)
     obs_pose[3] = 1.0
     batch = {
-        "left_extrinsics_pose": np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
-        "right_extrinsics_pose": np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        "left_base_T_cam_pose": np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        "right_base_T_cam_pose": np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
         "left.cmd_ee_pose": cmd_pose.copy(),
         "right.cmd_ee_pose": cmd_pose.copy(),
         "left.obs_ee_pose": obs_pose.copy(),
         "right.obs_ee_pose": obs_pose.copy(),
-        "left.gripper": np.zeros((5, 1), dtype=np.float64),
-        "right.gripper": np.zeros((5, 1), dtype=np.float64),
+        "left.cmd_gripper": np.zeros((5, 1), dtype=np.float64),
+        "right.cmd_gripper": np.zeros((5, 1), dtype=np.float64),
         "left.obs_gripper": np.zeros((1,), dtype=np.float64),
         "right.obs_gripper": np.zeros((1,), dtype=np.float64),
     }
@@ -344,18 +371,19 @@ def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
         "ConcatKeys",
         "ConcatKeys",
         "DeleteKeys",
+        "NumpyToTensor",
     ]
     assert [name for name, _, _ in snapshots] == expected_names
 
     base_keys = {
-        "left_extrinsics_pose",
-        "right_extrinsics_pose",
+        "left_base_T_cam_pose",
+        "right_base_T_cam_pose",
         "left.cmd_ee_pose",
         "right.cmd_ee_pose",
         "left.obs_ee_pose",
         "right.obs_ee_pose",
-        "left.gripper",
-        "right.gripper",
+        "left.cmd_gripper",
+        "right.cmd_gripper",
         "left.obs_gripper",
         "right.obs_gripper",
     }
@@ -366,14 +394,14 @@ def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
         "ActionChunkCoordinateFrameTransform",
         base_keys | {"left.cmd_ee_pose_camframe"},
         {
-            "left_extrinsics_pose": (7,),
-            "right_extrinsics_pose": (7,),
+            "left_base_T_cam_pose": (7,),
+            "right_base_T_cam_pose": (7,),
             "left.cmd_ee_pose": (5, 7),
             "right.cmd_ee_pose": (5, 7),
             "left.obs_ee_pose": (7,),
             "right.obs_ee_pose": (7,),
-            "left.gripper": (5, 1),
-            "right.gripper": (5, 1),
+            "left.cmd_gripper": (5, 1),
+            "right.cmd_gripper": (5, 1),
             "left.obs_gripper": (1,),
             "right.obs_gripper": (1,),
             "left.cmd_ee_pose_camframe": (5, 7),
@@ -429,8 +457,8 @@ def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
         "ConcatKeys",
         {
             "actions_cartesian",
-            "left_extrinsics_pose",
-            "right_extrinsics_pose",
+            "left_base_T_cam_pose",
+            "right_base_T_cam_pose",
             "left.cmd_ee_pose",
             "right.cmd_ee_pose",
             "left.obs_ee_pose",
@@ -451,8 +479,8 @@ def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
         {
             "actions_cartesian",
             "observations.state.ee_pose",
-            "left_extrinsics_pose",
-            "right_extrinsics_pose",
+            "left_base_T_cam_pose",
+            "right_base_T_cam_pose",
             "left.cmd_ee_pose",
             "right.cmd_ee_pose",
         },
@@ -474,7 +502,7 @@ def test_eva_transform_list_stepwise_keys_and_shapes() -> None:
 
 
 def test_human_transform_list_stepwise_keys_and_shapes() -> None:
-    transform_list = build_human_bimanual_transform_list(
+    transform_list = _build_human_cartesian_bimanual_transform_list(
         chunk_length=4,
         stride=2,
         target_world_is_quat=True,

--- a/egomimic/rldb/zarr/test_zarr.py
+++ b/egomimic/rldb/zarr/test_zarr.py
@@ -1,472 +1,156 @@
-from pathlib import Path
-
 import numpy as np
-import pytest
 import torch
-from scipy.spatial.transform import Rotation as R
 
-from egomimic.rldb.utils import S3RLDBDataset
-from egomimic.rldb.zarr.action_chunk_transforms import (
-    _matrix_to_xyzypr,
-    build_human_bimanual_transform_list,
-    build_eva_bimanual_transform_list,
+from egomimic.rldb.embodiment.embodiment import get_embodiment_id
+from egomimic.rldb.embodiment.eva import Eva, _build_eva_bimanual_transform_list
+from egomimic.rldb.embodiment.human import (
+    _build_human_cartesian_bimanual_transform_list,
 )
 from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset, ZarrDataset
-from egomimic.rldb.embodiment.eva import Eva
-
-ZARR_EPISODE_PATH = Path(
-    "/coc/flash7/rco3/EgoVerse/egomimic/rldb/zarr/zarr/new/1769460905119.zarr"
-)
-LEROBOT_EPISODE_HASH = "2026-01-26-20-55-05-119000"
-LEROBOT_CACHE_ROOT = "/coc/flash7/skareer6/CacheEgoVerse/.cache"
-EMBODIMENT = "eva_bimanual"
-ACTION_HORIZON_REAL = 45
-ACTION_CHUNK_LENGTH = 100
-KEYS_TO_COMPARE = (
-    "observations.images.front_img_1",
-    "observations.images.right_wrist_img",
-    "observations.images.left_wrist_img",
-    "actions_cartesian",
-    "observations.state.ee_pose",
-)
-IMAGE_KEYS = {
-    "observations.images.front_img_1",
-    "observations.images.right_wrist_img",
-    "observations.images.left_wrist_img",
-}
-
-ARIA_ZARR_EPISODE_PATH = Path(
-    "/coc/flash7/scratch/egoverseDebugDatasets/proc_zarr/1764285211791.zarr/"
-)
-ARIA_LEROBOT_EPISODE_HASH = "2025-11-27-23-13-31-791000"
-ARIA_EMBODIMENT = "human_bimanual"
-ARIA_ACTION_HORIZON_REAL = 30
-ARIA_ACTION_CHUNK_LENGTH = 100
-ARIA_ACTION_STRIDE = 3
-ARIA_KEYS_TO_COMPARE = (
-    "observations.images.front_img_1",
-    "actions_cartesian",
-    "observations.state.ee_pose",
-)
-ARIA_IMAGE_KEYS = {"observations.images.front_img_1"}
-
-SCALE_LEROBOT_EPISODE_HASH = "697c1e6c0cac8cd3c4873844"
-SCALE_ZARR_EPISODE_PATH = Path(
-    "/nethome/agao81/flash/EgoVerse/external/scale/scripts/datasets/2026-02-20-18-52-08-062985/697c1e6c0cac8cd3c4873844_episode_000000.zarr"
-)
-SCALE_EMBODIMENT = "human_bimanual"
-SCALE_CACHE_ROOT = "/coc/flash7/scratch/.cache"
-SCALE_ACTION_HORIZON_REAL = 30
-SCALE_ACTION_CHUNK_LENGTH = 100
-SCALE_ACTION_STRIDE = 1
-# zarr_key -> lerobot_key mapping for comparison
-SCALE_KEY_MAP = {
-    "observations.images.front_img_1": "observations.images.front_img_1",
-    "actions_cartesian": "actions_ee_cartesian_cam",
-    "observations.state.ee_pose": "observations.state.ee_pose_cam",
-}
-SCALE_IMAGE_KEYS = {"observations.images.front_img_1"}
-SCALE_KEYPOINT_KEYS = ("left.obs_keypoints", "right.obs_keypoints")
+from egomimic.rldb.zarr.zarr_writer import ZarrWriter
 
 
-def _to_numpy(value):
-    if isinstance(value, torch.Tensor):
-        return value.detach().cpu().numpy()
-    if isinstance(value, np.ndarray):
-        return value
-    return value
+def _pose_sequence(length: int, *, x_offset: float = 0.0) -> np.ndarray:
+    poses = np.zeros((length, 7), dtype=np.float64)
+    poses[:, 0] = x_offset + np.arange(length, dtype=np.float64) * 0.01
+    poses[:, 3] = 1.0
+    return poses
 
 
-def _assert_scale_pose_equivalent(
-    zarr_val: np.ndarray, lerobot_val: np.ndarray, key_name: str
-) -> None:
-    if zarr_val.shape[-1] != 12 or lerobot_val.shape[-1] != 12:
+def _camera_intrinsics() -> dict[str, np.ndarray]:
+    return {
+        "front_1": np.array(
+            [
+                [200.0, 0.0, 160.0, 0.0],
+                [0.0, 200.0, 120.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+            dtype=np.float64,
+        )
+    }
+
+
+def test_eva_zarr_dataset_runs_current_transform_pipeline(tmp_path) -> None:
+    length = 5
+    episode_path = tmp_path / "eva_episode.zarr"
+    left_cmd_gripper = np.linspace(0.0, 1.0, length, dtype=np.float64)[:, None]
+    right_cmd_gripper = np.linspace(1.0, 0.0, length, dtype=np.float64)[:, None]
+
+    ZarrWriter.create_and_write(
+        episode_path=episode_path,
+        numeric_data={
+            "left.obs_ee_pose": _pose_sequence(length),
+            "right.obs_ee_pose": _pose_sequence(length, x_offset=0.2),
+            "left.obs_gripper": np.full((length, 1), 0.25, dtype=np.float64),
+            "right.obs_gripper": np.full((length, 1), 0.75, dtype=np.float64),
+            "left.cmd_ee_pose": _pose_sequence(length, x_offset=0.1),
+            "right.cmd_ee_pose": _pose_sequence(length, x_offset=0.3),
+            "left.cmd_gripper": left_cmd_gripper,
+            "right.cmd_gripper": right_cmd_gripper,
+        },
+        embodiment="eva_bimanual",
+        intrinsics=_camera_intrinsics(),
+        extrinsics=Eva.EXTRINSICS,
+        chunk_timesteps=4,
+    )
+
+    key_map = {
+        "left.obs_ee_pose": {"zarr_key": "left.obs_ee_pose"},
+        "right.obs_ee_pose": {"zarr_key": "right.obs_ee_pose"},
+        "left.obs_gripper": {"zarr_key": "left.obs_gripper"},
+        "right.obs_gripper": {"zarr_key": "right.obs_gripper"},
+        "left.cmd_ee_pose": {"zarr_key": "left.cmd_ee_pose", "horizon": 4},
+        "right.cmd_ee_pose": {"zarr_key": "right.cmd_ee_pose", "horizon": 4},
+        "left.cmd_gripper": {"zarr_key": "left.cmd_gripper", "horizon": 4},
+        "right.cmd_gripper": {"zarr_key": "right.cmd_gripper", "horizon": 4},
+    }
+    leaf = ZarrDataset(
+        Episode_path=episode_path,
+        key_map=key_map,
+        transform_list=_build_eva_bimanual_transform_list(
+            chunk_length=6, stride=1, is_quat=True
+        ),
+    )
+    dataset = MultiDataset(datasets={"eva_episode": leaf}, mode="total")
+
+    sample = dataset[1]
+
+    for arm, base_T_cam in Eva.EXTRINSICS.items():
         np.testing.assert_allclose(
-            zarr_val,
-            lerobot_val,
-            atol=1e-5,
-            err_msg=f"{key_name}: expected last dim 12 for pose comparison",
+            np.asarray(leaf.metadata["extrinsics"][arm]), base_T_cam
         )
-        return
-
+    assert sample["actions_cartesian"].shape == (6, 14)
+    assert sample["observations.state.ee_pose"].shape == (14,)
+    assert sample["embodiment"] == get_embodiment_id("eva_bimanual")
+    assert sample["episode_hash"] == "eva_episode"
+    assert torch.isfinite(sample["actions_cartesian"]).all()
     np.testing.assert_allclose(
-        zarr_val[..., :3],
-        lerobot_val[..., :3],
-        rtol=0.0,
-        atol=1e-4,
-        err_msg=f"{key_name}: left xyz mismatch",
-    )
-    np.testing.assert_allclose(
-        zarr_val[..., 6:9],
-        lerobot_val[..., 6:9],
-        rtol=0.0,
-        atol=1e-4,
-        err_msg=f"{key_name}: right xyz mismatch",
-    )
-
-    z_left = zarr_val[..., 3:6].reshape(-1, 3)
-    l_left = lerobot_val[..., 3:6].reshape(-1, 3)
-    z_right = zarr_val[..., 9:12].reshape(-1, 3)
-    l_right = lerobot_val[..., 9:12].reshape(-1, 3)
-
-    np.testing.assert_allclose(
-        R.from_euler("ZYX", z_left, degrees=False).as_matrix(),
-        R.from_euler("zyx", l_left, degrees=False).as_matrix(),
-        atol=1e-5,
-        err_msg=f"{key_name}: left YPR rotation mismatch",
+        sample["intrinsics"].numpy(), _camera_intrinsics()["front_1"]
     )
     np.testing.assert_allclose(
-        R.from_euler("ZYX", z_right, degrees=False).as_matrix(),
-        R.from_euler("zyx", l_right, degrees=False).as_matrix(),
-        atol=1e-5,
-        err_msg=f"{key_name}: right YPR rotation mismatch",
+        sample["actions_cartesian"][[0, -1], 6].numpy(),
+        left_cmd_gripper[[1, 4], 0],
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        sample["actions_cartesian"][[0, -1], 13].numpy(),
+        right_cmd_gripper[[1, 4], 0],
+        atol=1e-6,
     )
 
 
-def _check_equal_dict(left: dict, right: dict, path: str = "root") -> None:
-    assert set(left.keys()) == set(right.keys()), (
-        f"{path}: key mismatch. left_only={set(left.keys()) - set(right.keys())}, "
-        f"right_only={set(right.keys()) - set(left.keys())}"
-    )
+def test_human_zarr_dataset_runs_current_transform_pipeline(tmp_path) -> None:
+    length = 4
+    episode_path = tmp_path / "human_episode.zarr"
+    left_poses = _pose_sequence(length, x_offset=0.1)
+    right_poses = _pose_sequence(length, x_offset=0.4)
+    head_poses = np.zeros((length, 7), dtype=np.float64)
+    head_poses[:, 3] = 1.0
 
-    for key in left:
-        left_value = left[key]
-        right_value = right[key]
-        key_path = f"{path}.{key}"
-
-        if isinstance(left_value, dict) and isinstance(right_value, dict):
-            _check_equal_dict(left_value, right_value, key_path)
-            continue
-
-        left_np = _to_numpy(left_value)
-        right_np = _to_numpy(right_value)
-
-        if isinstance(left_np, np.ndarray) or isinstance(right_np, np.ndarray):
-            assert isinstance(left_np, np.ndarray) and isinstance(
-                right_np, np.ndarray
-            ), (
-                f"{key_path}: expected both values to be tensor/ndarray, "
-                f"got {type(left_value)} vs {type(right_value)}"
-            )
-            assert left_np.shape == right_np.shape, (
-                f"{key_path}: shape mismatch {left_np.shape} vs {right_np.shape}"
-            )
-
-            if np.issubdtype(left_np.dtype, np.floating) or np.issubdtype(
-                right_np.dtype, np.floating
-            ):
-                np.testing.assert_allclose(
-                    left_np,
-                    right_np,
-                    rtol=1e-5,
-                    atol=1e-5,
-                    err_msg=f"{key_path}: floating values differ",
-                )
-            else:
-                np.testing.assert_array_equal(
-                    left_np, right_np, err_msg=f"{key_path}: values differ"
-                )
-            continue
-
-        assert left_value == right_value, (
-            f"{key_path}: value mismatch {left_value!r} vs {right_value!r}"
-        )
-
-
-def _build_zarr_dataset_eva() -> MultiDataset:
-    key_map = {
-        "observations.images.front_img_1": {"zarr_key": "images.front_1"},
-        "observations.images.right_wrist_img": {"zarr_key": "images.right_wrist"},
-        "observations.images.left_wrist_img": {"zarr_key": "images.left_wrist"},
-        "right.obs_ee_pose": {"zarr_key": "right.obs_ee_pose"},
-        "right.obs_gripper": {"zarr_key": "right.gripper"},
-        "left.obs_ee_pose": {"zarr_key": "left.obs_ee_pose"},
-        "left.obs_gripper": {"zarr_key": "left.gripper"},
-        "right.gripper": {"zarr_key": "right.gripper", "horizon": ACTION_HORIZON_REAL},
-        "left.gripper": {"zarr_key": "left.gripper", "horizon": ACTION_HORIZON_REAL},
-        "right.cmd_ee_pose": {
-            "zarr_key": "right.cmd_ee_pose",
-            "horizon": ACTION_HORIZON_REAL,
+    ZarrWriter.create_and_write(
+        episode_path=episode_path,
+        numeric_data={
+            "left.obs_ee_pose": left_poses,
+            "right.obs_ee_pose": right_poses,
+            "obs_head_pose": head_poses,
         },
-        "left.cmd_ee_pose": {
-            "zarr_key": "left.cmd_ee_pose",
-            "horizon": ACTION_HORIZON_REAL,
-        },
-    }
-
-    extrinsics = Eva.EXTRINSICS
-    left_extrinsics_pose = _matrix_to_xyzypr(extrinsics["left"][None, :])[0]
-    right_extrinsics_pose = _matrix_to_xyzypr(extrinsics["right"][None, :])[0]
-
-    transform_list = build_eva_bimanual_transform_list(
-        chunk_length=ACTION_CHUNK_LENGTH,
-        stride=1,
-        left_extra_batch_key={"left_extrinsics_pose": left_extrinsics_pose},
-        right_extra_batch_key={"right_extrinsics_pose": right_extrinsics_pose},
+        embodiment="human_bimanual",
+        intrinsics=_camera_intrinsics(),
+        extrinsics=None,
+        chunk_timesteps=4,
     )
 
-    single_dataset = ZarrDataset(
-        Episode_path=ZARR_EPISODE_PATH,
-        key_map=key_map,
-        transform_list=transform_list,
-    )
-    return MultiDataset(datasets={"single_episode": single_dataset}, mode="total")
-
-
-def _build_lerobot_dataset() -> S3RLDBDataset:
-    return S3RLDBDataset(
-        filters={"episode_hash": LEROBOT_EPISODE_HASH},
-        mode="total",
-        cache_root=LEROBOT_CACHE_ROOT,
-        embodiment=EMBODIMENT,
-    )
-
-
-def _build_zarr_dataset_aria() -> MultiDataset:
     key_map = {
-        "observations.images.front_img_1": {"zarr_key": "images.front_1"},
-        "left.obs_ee_pose": {"zarr_key": "left.obs_ee_pose"},
-        "right.obs_ee_pose": {"zarr_key": "right.obs_ee_pose"},
         "left.action_ee_pose": {
             "zarr_key": "left.obs_ee_pose",
-            "horizon": ARIA_ACTION_HORIZON_REAL,
+            "horizon": length,
         },
         "right.action_ee_pose": {
             "zarr_key": "right.obs_ee_pose",
-            "horizon": ARIA_ACTION_HORIZON_REAL,
+            "horizon": length,
         },
-        "obs_head_pose": {"zarr_key": "obs_head_pose"},
-    }
-
-    transform_list = build_human_bimanual_transform_list(
-        chunk_length=ARIA_ACTION_CHUNK_LENGTH,
-        stride=ARIA_ACTION_STRIDE,
-        left_action_world="left.action_ee_pose",
-        right_action_world="right.action_ee_pose",
-        actions_key="actions_cartesian",
-        obs_key="observations.state.ee_pose",
-    )
-
-    single_dataset = ZarrDataset(
-        Episode_path=ARIA_ZARR_EPISODE_PATH,
-        key_map=key_map,
-        transform_list=transform_list,
-    )
-    return MultiDataset(datasets={"single_episode": single_dataset}, mode="total")
-
-
-def _build_lerobot_dataset_aria() -> S3RLDBDataset:
-    return S3RLDBDataset(
-        filters={"episode_hash": ARIA_LEROBOT_EPISODE_HASH},
-        mode="total",
-        cache_root=LEROBOT_CACHE_ROOT,
-        embodiment=ARIA_EMBODIMENT,
-    )
-
-
-def _first_batch(dataset: torch.utils.data.Dataset) -> dict:
-    loader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=False)
-    return next(iter(loader))
-
-
-def test_zarr_batch_matches_lerobot_batch_eva() -> None:
-    if not ZARR_EPISODE_PATH.exists():
-        pytest.skip(f"Zarr path not found: {ZARR_EPISODE_PATH}")
-
-    zarr_batch = _first_batch(_build_zarr_dataset_eva())
-    lerobot_batch = _first_batch(_build_lerobot_dataset())
-
-    missing_keys = [key for key in KEYS_TO_COMPARE if key not in lerobot_batch]
-    assert not missing_keys, (
-        f"Lerobot batch missing keys required for comparison: {missing_keys}"
-    )
-
-    missing_zarr_keys = [key for key in KEYS_TO_COMPARE if key not in zarr_batch]
-    assert not missing_zarr_keys, (
-        f"Zarr batch missing keys required for comparison: {missing_zarr_keys}"
-    )
-
-    zarr_subset = {key: zarr_batch[key] for key in KEYS_TO_COMPARE}
-    lerobot_subset = {key: lerobot_batch[key] for key in KEYS_TO_COMPARE}
-
-    for key in IMAGE_KEYS:
-        lerobot_arr = _to_numpy(lerobot_subset[key])
-        zarr_arr = _to_numpy(zarr_subset[key])
-        assert isinstance(lerobot_arr, np.ndarray) and isinstance(
-            zarr_arr, np.ndarray
-        ), (
-            f"{key}: expected array/tensor values, got {type(lerobot_subset[key])} "
-            f"and {type(zarr_subset[key])}"
-        )
-        assert lerobot_arr.shape == zarr_arr.shape, (
-            f"{key}: image shape mismatch {lerobot_arr.shape} vs {zarr_arr.shape}"
-        )
-
-    non_image_lerobot = {
-        key: value for key, value in lerobot_subset.items() if key not in IMAGE_KEYS
-    }
-    non_image_zarr = {
-        key: value for key, value in zarr_subset.items() if key not in IMAGE_KEYS
-    }
-
-    lerobot_actions = _to_numpy(non_image_lerobot.pop("actions_cartesian"))
-    zarr_actions = _to_numpy(non_image_zarr.pop("actions_cartesian"))
-    assert isinstance(lerobot_actions, np.ndarray) and isinstance(
-        zarr_actions, np.ndarray
-    ), "actions_cartesian must be tensors/arrays"
-    assert lerobot_actions.shape == zarr_actions.shape, (
-        f"actions_cartesian shape mismatch: {lerobot_actions.shape} vs {zarr_actions.shape}"
-    )
-
-    np.testing.assert_allclose(
-        lerobot_actions,
-        zarr_actions,
-        rtol=0.0,
-        atol=2e-3,
-        err_msg="actions_cartesian mismatch",
-    )
-
-    _check_equal_dict(non_image_lerobot, non_image_zarr)
-
-
-def test_zarr_batch_matches_lerobot_batch_aria() -> None:
-    if not ARIA_ZARR_EPISODE_PATH.exists():
-        pytest.skip(f"Aria zarr path not found: {ARIA_ZARR_EPISODE_PATH}")
-
-    zarr_batch = _first_batch(_build_zarr_dataset_aria())
-    lerobot_batch = _first_batch(_build_lerobot_dataset_aria())
-
-    missing_keys = [key for key in ARIA_KEYS_TO_COMPARE if key not in lerobot_batch]
-    assert not missing_keys, (
-        f"Lerobot Aria batch missing keys required for comparison: {missing_keys}"
-    )
-
-    missing_zarr_keys = [key for key in ARIA_KEYS_TO_COMPARE if key not in zarr_batch]
-    assert not missing_zarr_keys, (
-        f"Zarr Aria batch missing keys required for comparison: {missing_zarr_keys}"
-    )
-
-    zarr_subset = {key: zarr_batch[key] for key in ARIA_KEYS_TO_COMPARE}
-    lerobot_subset = {key: lerobot_batch[key] for key in ARIA_KEYS_TO_COMPARE}
-
-    for key in ARIA_IMAGE_KEYS:
-        lerobot_arr = _to_numpy(lerobot_subset[key])
-        zarr_arr = _to_numpy(zarr_subset[key])
-        assert isinstance(lerobot_arr, np.ndarray) and isinstance(
-            zarr_arr, np.ndarray
-        ), (
-            f"{key}: expected array/tensor values, got {type(lerobot_subset[key])} "
-            f"and {type(zarr_subset[key])}"
-        )
-        assert lerobot_arr.shape == zarr_arr.shape, (
-            f"{key}: image shape mismatch {lerobot_arr.shape} vs {zarr_arr.shape}"
-        )
-
-    non_image_lerobot = {
-        key: value
-        for key, value in lerobot_subset.items()
-        if key not in ARIA_IMAGE_KEYS
-    }
-    non_image_zarr = {
-        key: value for key, value in zarr_subset.items() if key not in ARIA_IMAGE_KEYS
-    }
-
-    _check_equal_dict(non_image_lerobot, non_image_zarr)
-
-
-# ---------------------------------------------------------------------------
-# Scale bimanual helpers & test
-# ---------------------------------------------------------------------------
-
-
-def _build_zarr_dataset_scale() -> MultiDataset:
-    """Build a Scale zarr dataset with Aria-style head-frame transform."""
-    key_map = {
-        "observations.images.front_img_1": {"zarr_key": "images.front_1"},
         "left.obs_ee_pose": {"zarr_key": "left.obs_ee_pose"},
         "right.obs_ee_pose": {"zarr_key": "right.obs_ee_pose"},
-        "left.action_ee_pose": {
-            "zarr_key": "left.obs_ee_pose",
-            "horizon": SCALE_ACTION_HORIZON_REAL,
-        },
-        "right.action_ee_pose": {
-            "zarr_key": "right.obs_ee_pose",
-            "horizon": SCALE_ACTION_HORIZON_REAL,
-        },
         "obs_head_pose": {"zarr_key": "obs_head_pose"},
     }
-
-    transform_list = build_human_bimanual_transform_list(
-        chunk_length=SCALE_ACTION_CHUNK_LENGTH,
-        stride=SCALE_ACTION_STRIDE,
-        left_action_world="left.action_ee_pose",
-        right_action_world="right.action_ee_pose",
-        target_world_is_quat=False,
-        actions_key="actions_cartesian",
-        obs_key="observations.state.ee_pose",
-    )
-
-    single_dataset = ZarrDataset(
-        Episode_path=SCALE_ZARR_EPISODE_PATH,
+    dataset = ZarrDataset(
+        Episode_path=episode_path,
         key_map=key_map,
-        transform_list=transform_list,
-    )
-    return MultiDataset(datasets={"single_episode": single_dataset}, mode="total")
-
-
-def _build_lerobot_dataset_scale() -> S3RLDBDataset:
-    return S3RLDBDataset(
-        filters={"episode_hash": SCALE_LEROBOT_EPISODE_HASH},
-        mode="total",
-        cache_root=SCALE_CACHE_ROOT,
-        embodiment=SCALE_EMBODIMENT,
+        transform_list=_build_human_cartesian_bimanual_transform_list(
+            chunk_length=6,
+            stride=1,
+            target_world_is_quat=True,
+        ),
     )
 
+    sample = dataset[0]
 
-def test_zarr_batch_matches_lerobot_batch_scale() -> None:
-    if not SCALE_ZARR_EPISODE_PATH.exists():
-        pytest.skip(f"Scale zarr path not found: {SCALE_ZARR_EPISODE_PATH}")
-
-    zarr_batch = _first_batch(_build_zarr_dataset_scale())
-    lerobot_batch = _first_batch(_build_lerobot_dataset_scale())
-
-    # Check that expected keys exist in each batch (under their own names)
-    missing_zarr = [z for z in SCALE_KEY_MAP if z not in zarr_batch]
-    assert not missing_zarr, f"Zarr batch missing keys: {missing_zarr}"
-
-    missing_lr = [key for key in SCALE_KEY_MAP.values() if key not in lerobot_batch]
-    assert not missing_lr, f"Lerobot batch missing keys: {missing_lr}"
-
-    for zarr_key, lerobot_key in SCALE_KEY_MAP.items():
-        zarr_val = _to_numpy(zarr_batch[zarr_key])
-        lerobot_val = _to_numpy(lerobot_batch[lerobot_key])
-
-        if zarr_key in SCALE_IMAGE_KEYS:
-            assert isinstance(zarr_val, np.ndarray) and isinstance(
-                lerobot_val, np.ndarray
-            ), (
-                f"{zarr_key}: expected arrays, got {type(zarr_val)} / {type(lerobot_val)}"
-            )
-            assert zarr_val.shape == lerobot_val.shape, (
-                f"{zarr_key}: image shape mismatch {zarr_val.shape} vs {lerobot_val.shape}"
-            )
-        else:
-            assert isinstance(zarr_val, np.ndarray) and isinstance(
-                lerobot_val, np.ndarray
-            ), (
-                f"{zarr_key}->{lerobot_key}: expected arrays, got "
-                f"{type(zarr_val)} / {type(lerobot_val)}"
-            )
-            if zarr_key in {"actions_cartesian", "observations.state.ee_pose"}:
-                _assert_scale_pose_equivalent(
-                    zarr_val,
-                    lerobot_val,
-                    key_name=f"{zarr_key} (zarr) vs {lerobot_key} (lerobot)",
-                )
-            else:
-                np.testing.assert_allclose(
-                    zarr_val,
-                    lerobot_val,
-                    atol=1e-5,
-                    err_msg=f"{zarr_key} (zarr) vs {lerobot_key} (lerobot)",
-                )
+    assert sample["actions_cartesian"].shape == (6, 12)
+    assert sample["observations.state.ee_pose"].shape == (12,)
+    assert sample["embodiment"] == get_embodiment_id("human_bimanual")
+    assert torch.isfinite(sample["actions_cartesian"]).all()
+    np.testing.assert_allclose(
+        sample["observations.state.ee_pose"][[0, 6]].numpy(),
+        np.array([left_poses[0, 0], right_poses[0, 0]]),
+        atol=1e-6,
+    )

--- a/egomimic/rldb/zarr/zarr_writer.py
+++ b/egomimic/rldb/zarr/zarr_writer.py
@@ -332,10 +332,12 @@ class ZarrWriter:
                 "intrinsics" key in zarr.json metadata. Optional in this low-level
                 constructor; create_and_write requires it.
             extrinsics: Optional camera extrinsics. None (egocentric human data) or
-                a dict mapping a key to its transform matrix; robots key per-arm
-                (e.g. {"left": world<-cam, "right": world<-cam}). Stored under the
-                "extrinsics" key in zarr.json metadata. create_and_write enforces
-                the None-or-non-empty-dict contract.
+                a dict mapping a key to `ref_T_cam`, the camera pose in the declared
+                reference frame. Robots key per-arm (for example,
+                {"left": left_base_T_cam, "right": right_base_T_cam}). Stored
+                under the "extrinsics" key in zarr.json metadata.
+                `create_and_write` enforces the None-or-non-empty-dict contract.
+                See `docs/CONVENTIONS.md`.
         """
         self.episode_path = Path(episode_path)
 
@@ -777,9 +779,11 @@ class ZarrWriter:
             intrinsics: REQUIRED {camera_key: 3x4 K matrix} dict (single-camera =
                 one entry, e.g. {"front_1": K}). Stored in zarr.json metadata.
             extrinsics: Optional camera extrinsics. Either None (e.g. egocentric
-                human data) or a non-empty dict mapping a key to its transform
-                matrix (robots key per-arm, e.g. {"left": T, "right": T}). Stored
-                in zarr.json metadata.
+                human data) or a non-empty dict mapping a key to `ref_T_cam`, the
+                camera pose in the declared reference frame. Robots key per-arm
+                (for example, {"left": left_base_T_cam,
+                "right": right_base_T_cam}). Stored in zarr.json metadata. See
+                `docs/CONVENTIONS.md`.
             metadata_override: Optional metadata overrides.
 
         Returns:
@@ -828,15 +832,16 @@ class ZarrWriter:
                 '"right": T}). See CONTRIBUTING_DATA.md §6.3.'
             )
         if extrinsics is not None:
-            for ext_key, T in extrinsics.items():
+            for ext_key, ref_T_cam in extrinsics.items():
                 try:
-                    T_arr = np.asarray(T, dtype=np.float64)
+                    ref_T_cam_arr = np.asarray(ref_T_cam, dtype=np.float64)
                 except (TypeError, ValueError):
-                    T_arr = None
-                if T_arr is None or T_arr.shape != (4, 4):
+                    ref_T_cam_arr = None
+                if ref_T_cam_arr is None or ref_T_cam_arr.shape != (4, 4):
                     raise ValueError(
                         f"extrinsics[{ext_key!r}] must be a 4x4 transform matrix, "
-                        f"got {getattr(T_arr, 'shape', type(T).__name__)}. "
+                        "named and directed as ref_T_cam; got "
+                        f"{getattr(ref_T_cam_arr, 'shape', type(ref_T_cam).__name__)}. "
                         "See CONTRIBUTING_DATA.md §6.3."
                     )
         writer = ZarrWriter(

--- a/egomimic/rldb/zarr/zarr_writer.py
+++ b/egomimic/rldb/zarr/zarr_writer.py
@@ -294,12 +294,7 @@ class _IncrementalHandle:
 
 
 class ZarrWriter:
-    """
-    General-purpose writer for Zarr v3 episode stores.
-
-    Creates episodes compatible with the ZarrEpisode reader, handling both
-    numeric and image data with intelligent chunking and optional sharding.
-    """
+    """Write numeric arrays and JPEG image arrays to a Zarr v3 episode store."""
 
     JPEG_QUALITY = 85  # Fixed JPEG quality for image compression
 
@@ -316,28 +311,22 @@ class ZarrWriter:
         extrinsics: dict | None = None,
         verbose: bool = False,
     ):
-        """
-        Initialize ZarrWriter.
+        """Configure a writer for one Zarr v3 episode.
 
         Args:
-            episode_path: Path to episode .zarr directory.
-            embodiment: Robot type identifier (e.g., "eva_bimanual").
-            fps: Frames per second for playback (default: 30).
-            task_name: Task name.
-            task_description: Task description.
-            annotations: List of (text, start_idx, end_idx) tuples describing language annotations.
-            chunk_timesteps: Number of timesteps per chunk for numeric arrays (default: 100).
-            intrinsics: Camera intrinsics as a {camera_key: 3x4 K matrix} dict
-                (single-camera = one entry, e.g. {"front_1": K}). Stored under the
-                "intrinsics" key in zarr.json metadata. Optional in this low-level
-                constructor; create_and_write requires it.
-            extrinsics: Optional camera extrinsics. None (egocentric human data) or
-                a dict mapping a key to `ref_T_cam`, the camera pose in the declared
-                reference frame. Robots key per-arm (for example,
-                {"left": left_base_T_cam, "right": right_base_T_cam}). Stored
-                under the "extrinsics" key in zarr.json metadata.
-                `create_and_write` enforces the None-or-non-empty-dict contract.
-                See `docs/CONVENTIONS.md`.
+            episode_path: Path of the output ``.zarr`` directory.
+            embodiment: Embodiment identifier, such as ``"eva_bimanual"``.
+            fps: Capture rate in frames per second.
+            task_name: Task identifier stored in episode metadata.
+            task_description: Trial description stored in episode metadata.
+            annotations: ``(text, start_idx, end_idx)`` annotation tuples.
+            chunk_timesteps: Number of frames in each numeric-array chunk.
+            intrinsics: A mapping from camera keys to 3×4 camera matrices. This
+                low-level constructor permits ``None``.
+            extrinsics: ``None`` or a mapping from keys to 4×4 ``ref_T_cam``
+                matrices. Robot episodes use arm names as keys. See
+                ``docs/CONVENTIONS.md``.
+            verbose: If true, print progress information during writes.
         """
         self.episode_path = Path(episode_path)
 
@@ -761,39 +750,39 @@ class ZarrWriter:
         extrinsics: dict | None = None,
         metadata_override: dict[str, Any] | None = None,
     ) -> Path:
-        """
-        Convenience method: create writer and write in one call.
+        """Validate episode metadata and write one Zarr v3 episode.
 
         Args:
-            episode_path: Path to episode .zarr directory.
-            numeric_data: Dictionary of numeric arrays (state, actions, etc.).
-            image_data: Dictionary of image arrays with shape (T, H, W, 3).
-            pre_encoded_image_data: Dict mapping key to (encoded_array, image_shape).
-                Skips internal JPEG encoding for these keys.
-            embodiment: Robot type identifier.
-            fps: Frames per second (default: 30).
-            task_name: Task name.
-            task_description: Task description.
-            annotations: List of (text, start_idx, end_idx) tuples describing language annotations.
-            chunk_timesteps: Number of timesteps per chunk for numeric arrays (default: 100).
-            intrinsics: REQUIRED {camera_key: 3x4 K matrix} dict (single-camera =
-                one entry, e.g. {"front_1": K}). Stored in zarr.json metadata.
-            extrinsics: Optional camera extrinsics. Either None (e.g. egocentric
-                human data) or a non-empty dict mapping a key to `ref_T_cam`, the
-                camera pose in the declared reference frame. Robots key per-arm
-                (for example, {"left": left_base_T_cam,
-                "right": right_base_T_cam}). Stored in zarr.json metadata. See
-                `docs/CONVENTIONS.md`.
-            metadata_override: Optional metadata overrides.
+            episode_path: Path of the output ``.zarr`` directory.
+            numeric_data: Numeric arrays. Each array uses its first dimension
+                for frames.
+            image_data: RGB image arrays with shape ``(T, H, W, 3)``.
+            pre_encoded_image_data: A mapping from keys to
+                ``(jpeg_byte_array, [H, W, 3])`` tuples.
+            embodiment: A current ``EMBODIMENT`` name. Validation ignores
+                letter case.
+            fps: Capture rate in frames per second.
+            task_name: Task identifier stored in episode metadata.
+            task_description: Trial description stored in episode metadata.
+            annotations: ``(text, start_idx, end_idx)`` annotation tuples.
+            chunk_timesteps: Number of frames in each numeric-array chunk.
+            intrinsics: A non-empty mapping from camera keys to 3×4 camera
+                matrices.
+            extrinsics: ``None`` or a non-empty mapping from keys to 4×4
+                ``ref_T_cam`` matrices. Robot episodes use arm names as keys.
+                See ``docs/CONVENTIONS.md``.
+            metadata_override: Additional episode metadata. This mapping cannot
+                replace ``intrinsics`` or ``extrinsics``.
 
         Returns:
-            Path to created episode.
+            The path of the created ``.zarr`` directory.
 
         Raises:
-            ValueError: If no data is provided, if embodiment is not a valid
-                identifier (see §9), if intrinsics is not a non-empty
-                {camera_key: 3x4 K matrix} dict, or if extrinsics is neither None
-                nor a non-empty {key: 4x4 transform} dict.
+            ValueError: If no data is present or frame counts do not agree.
+            ValueError: If ``embodiment`` is not a current identifier.
+            ValueError: If ``intrinsics`` is empty or contains a non-3×4 value.
+            ValueError: If ``extrinsics`` is not ``None`` or a non-empty mapping
+                of 4×4 matrices.
         """
         # Validate the embodiment up front (it is guaranteed to be consumed by
         # the reader via get_embodiment_id) so a bad/empty/typo'd value fails

--- a/egomimic/robot/collect_demo.py
+++ b/egomimic/robot/collect_demo.py
@@ -651,7 +651,6 @@ def collect_demo(
     # Demo recording state
     demo_data = dict()
 
-    camera_names = robot_interface.recorders.keys()
     cmd_pos = dict()
     cmd_quat = dict()
     cmd_joints = dict()

--- a/egomimic/robot/eva/eva_ws/src/eva/robot_interface.py
+++ b/egomimic/robot/eva/eva_ws/src/eva/robot_interface.py
@@ -1,7 +1,7 @@
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-import time
 import numpy as np
 import yaml
 from scipy.spatial.transform import Rotation as R

--- a/egomimic/robot/rollout.py
+++ b/egomimic/robot/rollout.py
@@ -11,7 +11,6 @@ import cv2
 import h5py
 import numpy as np
 import torch
-from egomimic.robot.robot_utils import RateLoop
 from scipy.spatial.transform import Rotation as R
 from torch.utils.data import default_collate
 
@@ -20,9 +19,14 @@ from egomimic.pl_utils.pl_model import ModelWrapper
 from egomimic.rldb.embodiment.embodiment import get_embodiment
 from egomimic.rldb.embodiment.eva import Eva
 from egomimic.rldb.embodiment.human import Human
-from egomimic.utils.pose_utils import cam_frame_to_base_frame, interpolate_arr, interpolate_arr_euler
+from egomimic.robot.robot_utils import RateLoop
+from egomimic.utils.pose_utils import (
+    cam_frame_to_base_frame,
+    interpolate_arr,
+    interpolate_arr_euler,
+    xyzw_to_wxyz,
+)
 from egomimic.utils.viz_utils import draw_actions
-from egomimic.utils.pose_utils import xyzw_to_wxyz
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "eva/eva_ws/src/eva"))
 

--- a/egomimic/scripts/aria_process/aria_utils.py
+++ b/egomimic/scripts/aria_process/aria_utils.py
@@ -287,7 +287,7 @@ def slam_to_rgb(provider, height=480, width=640):
         slam_label,
         slam_calib.get_transform_device_camera(),
     )
-    T_device_slam_camera = (
+    device_T_slam_camera = (
         slam_camera.get_transform_device_camera()
     )  # slam to device frame
 
@@ -297,13 +297,13 @@ def slam_to_rgb(provider, height=480, width=640):
     rgb_camera = calibration.get_linear_camera_calibration(
         height, width, focal_length, rgb_label, rgb_calib.get_transform_device_camera()
     )
-    T_device_rgb_camera = (
+    device_T_rgb_camera = (
         rgb_camera.get_transform_device_camera()
     )  # rgb to device frame
 
-    transform = T_device_rgb_camera.inverse() @ T_device_slam_camera
+    rgb_T_slam = device_T_rgb_camera.inverse() @ device_T_slam_camera
 
-    return transform
+    return rgb_T_slam
 
 
 def compute_coordinate_frame(palm_pose, wrist_pose, palm_normal):
@@ -554,27 +554,27 @@ class AriaVRSExtractor:
             for key, stream_id in stream_ids.items()
         }
 
-        rgb_to_device_T = slam_to_rgb(
+        rgb_T_slam = slam_to_rgb(
             vrs_reader, height=height, width=width
         )  # aria sophus SE3
 
         hand_cartesian_pose = AriaVRSExtractor.get_ee_pose(
-            world_device_T=closed_loop_traj,
+            world_T_device_poses=closed_loop_traj,
             stream_timestamps_ns=stream_timestamps_ns,
             hand_tracking_results=hand_tracking_results,
             arm=arm,
         )
 
         hand_keypoints_pose = AriaVRSExtractor.get_hand_keypoints(
-            world_device_T=closed_loop_traj,
+            world_T_device_poses=closed_loop_traj,
             stream_timestamps_ns=stream_timestamps_ns,
             hand_tracking_results=hand_tracking_results,
             arm=arm,
         )
 
         head_pose = AriaVRSExtractor.get_head_pose(
-            world_device_T=closed_loop_traj,
-            device_rgb_T=rgb_to_device_T.inverse(),
+            world_T_device_poses=closed_loop_traj,
+            device_T_rgb=rgb_T_slam.inverse(),
             stream_timestamps_ns=stream_timestamps_ns,
         )
         if use_eye_gaze:
@@ -768,7 +768,7 @@ class AriaVRSExtractor:
 
     @staticmethod
     def get_hand_keypoints(
-        world_device_T,
+        world_T_device_poses,
         stream_timestamps_ns: dict,
         hand_tracking_results,
         arm: str,
@@ -777,8 +777,8 @@ class AriaVRSExtractor:
         Get Hand Keypoints from VRS
         Parameters
         ----------
-        world_device_T : np.array
-            Transform from world coordinates to ARIA camera frame
+        world_T_device_poses : sequence
+            Timestamped device poses in the world frame.
         stream_timestamps_ns : dict
         hand_tracking_results : dict
         arm : str
@@ -799,9 +799,11 @@ class AriaVRSExtractor:
             hand_tracking_result_t = get_nearest_hand_tracking_result(
                 hand_tracking_results, query_timestamp
             )
-            world_device_T_t = get_nearest_pose(world_device_T, query_timestamp)
-            if world_device_T_t is not None:
-                world_device_T_t = world_device_T_t.transform_world_device
+            world_T_device = get_nearest_pose(
+                world_T_device_poses, query_timestamp
+            )
+            if world_T_device is not None:
+                world_T_device = world_T_device.transform_world_device
 
             right_confidence = getattr(
                 getattr(hand_tracking_result_t, "right_hand", None), "confidence", -1
@@ -813,25 +815,25 @@ class AriaVRSExtractor:
             if (
                 use_left_hand
                 and not left_confidence < 0
-                and world_device_T_t is not None
+                and world_T_device is not None
             ):
                 left_hand_keypoints = np.stack(
                     hand_tracking_result_t.left_hand.landmark_positions_device, axis=0
                 )
-                wrist_T = (
+                device_T_wrist = (
                     hand_tracking_result_t.left_hand.transform_device_wrist
                 )  # Sophus SE3
 
-                world_wrist_T = world_device_T_t @ wrist_T
+                world_T_wrist = world_T_device @ device_T_wrist
                 world_keypoints = (
-                    world_device_T_t @ left_hand_keypoints.T
+                    world_T_device @ left_hand_keypoints.T
                 ).T  # keypoints are in device frame
 
-                world_wrist_T = sp.SE3.from_matrix(
-                    T_rot_orientation(world_wrist_T.to_matrix(), T_ROT_CAM)
+                world_T_wrist = sp.SE3.from_matrix(
+                    T_rot_orientation(world_T_wrist.to_matrix(), T_ROT_CAM)
                 )
                 wrist_quat_and_translation = quat_translation_swap(
-                    world_wrist_T.to_quat_and_translation()
+                    world_T_wrist.to_quat_and_translation()
                 )
                 if wrist_quat_and_translation.ndim == 2:
                     wrist_quat_and_translation = wrist_quat_and_translation[0]
@@ -842,28 +844,28 @@ class AriaVRSExtractor:
             if (
                 use_right_hand
                 and not right_confidence < 0
-                and world_device_T_t is not None
+                and world_T_device is not None
             ):
                 right_hand_keypoints = np.stack(
                     hand_tracking_result_t.right_hand.landmark_positions_device, axis=0
                 )
-                wrist_T = (
+                device_T_wrist = (
                     hand_tracking_result_t.right_hand.transform_device_wrist
                 )  # Sophus SE3
 
-                world_wrist_T = world_device_T_t @ wrist_T
+                world_T_wrist = world_T_device @ device_T_wrist
                 world_keypoints = (
-                    world_device_T_t @ right_hand_keypoints.T
+                    world_T_device @ right_hand_keypoints.T
                 ).T  # keypoints are in device frame
 
-                world_wrist_T = sp.SE3.from_matrix(
+                world_T_wrist = sp.SE3.from_matrix(
                     T_rot_orientation(
-                        world_wrist_T.to_matrix(),
+                        world_T_wrist.to_matrix(),
                         T_ROT_CAM,
                     )
                 )
                 wrist_quat_and_translation = quat_translation_swap(
-                    world_wrist_T.to_quat_and_translation()
+                    world_T_wrist.to_quat_and_translation()
                 )
                 if wrist_quat_and_translation.ndim == 2:
                     wrist_quat_and_translation = wrist_quat_and_translation[0]
@@ -884,16 +886,16 @@ class AriaVRSExtractor:
 
     @staticmethod
     def get_head_pose(
-        world_device_T,
-        device_rgb_T,
+        world_T_device_poses,
+        device_T_rgb,
         stream_timestamps_ns: dict,
     ):
         """
         Get Head Pose from VRS
         Parameters
         ----------
-        world_device_T : np.array
-            Transform from world coordinates to ARIA camera frame
+        world_T_device_poses : sequence
+            Timestamped device poses in the world frame.
         stream_timestamps_ns : dict
             dict that maps sensor keys to a list of nanosecond timestamps in device time
 
@@ -905,20 +907,22 @@ class AriaVRSExtractor:
         head_pose = []
         frame_length = len(stream_timestamps_ns["rgb"])
 
-        rgb_to_rgbprime_rot = np.eye(4)
-        rgb_to_rgbprime_rot[:3, :3] = ROTATION_MATRIX.T
-        rgb_to_rgbprime_T = sp.SE3.from_matrix(rgb_to_rgbprime_rot)
-        rgbprime_to_rgb_T = rgb_to_rgbprime_T.inverse()
+        rgbprime_T_rgb_matrix = np.eye(4)
+        rgbprime_T_rgb_matrix[:3, :3] = ROTATION_MATRIX.T
+        rgbprime_T_rgb = sp.SE3.from_matrix(rgbprime_T_rgb_matrix)
+        rgb_T_rgbprime = rgbprime_T_rgb.inverse()
         for t in range(frame_length):
             query_timestamp = stream_timestamps_ns["rgb"][t]
-            world_device_T_t = get_nearest_pose(world_device_T, query_timestamp)
-            if world_device_T_t is not None:
-                world_device_T_t = world_device_T_t.transform_world_device
+            world_T_device = get_nearest_pose(
+                world_T_device_poses, query_timestamp
+            )
+            if world_T_device is not None:
+                world_T_device = world_T_device.transform_world_device
             head_pose_obs_t = np.full(7, 1e9)
-            if world_device_T_t is not None:
-                world_rgb_T_t = world_device_T_t @ device_rgb_T @ rgbprime_to_rgb_T
+            if world_T_device is not None:
+                world_T_rgbprime = world_T_device @ device_T_rgb @ rgb_T_rgbprime
                 head_pose_quat_and_translation = quat_translation_swap(
-                    world_rgb_T_t.to_quat_and_translation()
+                    world_T_rgbprime.to_quat_and_translation()
                 )
                 if head_pose_quat_and_translation.ndim == 2:
                     head_pose_quat_and_translation = head_pose_quat_and_translation[0]
@@ -946,7 +950,7 @@ class AriaVRSExtractor:
 
     @staticmethod
     def get_ee_pose(
-        world_device_T,
+        world_T_device_poses,
         stream_timestamps_ns: dict,
         hand_tracking_results,
         arm: str,
@@ -955,8 +959,8 @@ class AriaVRSExtractor:
         Get EE Pose from VRS
         Parameters
         ----------
-        world_device_T : np.array
-            Transform from world coordinates to ARIA camera frame
+        world_T_device_poses : sequence
+            Timestamped device poses in the world frame.
         stream_timestamps_ns : dict
             dict that maps sensor keys to a list of nanosecond timestamps in device time
         hand_tracking_results : dict
@@ -980,9 +984,11 @@ class AriaVRSExtractor:
             hand_tracking_result_t = get_nearest_hand_tracking_result(
                 hand_tracking_results, query_timestamp
             )
-            world_device_T_t = get_nearest_pose(world_device_T, query_timestamp)
-            if world_device_T_t is not None:
-                world_device_T_t = world_device_T_t.transform_world_device
+            world_T_device = get_nearest_pose(
+                world_T_device_poses, query_timestamp
+            )
+            if world_T_device is not None:
+                world_T_device = world_T_device.transform_world_device
 
             right_confidence = getattr(
                 getattr(hand_tracking_result_t, "right_hand", None), "confidence", -1
@@ -995,7 +1001,7 @@ class AriaVRSExtractor:
             if (
                 use_left_hand
                 and not left_confidence < 0
-                and world_device_T_t is not None
+                and world_T_device is not None
             ):
                 left_palm_pose = (
                     hand_tracking_result_t.left_hand.get_palm_position_device()
@@ -1010,17 +1016,17 @@ class AriaVRSExtractor:
                     wrist_pose=left_wrist_pose,
                     palm_normal=left_palm_normal,
                 )
-                left_T_t = np.eye(4)
-                left_T_t[:3, :3] = left_rot_matrix
-                left_T_t[:3, 3] = left_palm_pose
-                left_T_t = sp.SE3.from_matrix(left_T_t)
-                left_T_t = world_device_T_t @ left_T_t
-                left_T_t = sp.SE3.from_matrix(
-                    T_rot_orientation(left_T_t.to_matrix(), T_ROT_CAM)
+                device_T_left_hand_matrix = np.eye(4)
+                device_T_left_hand_matrix[:3, :3] = left_rot_matrix
+                device_T_left_hand_matrix[:3, 3] = left_palm_pose
+                device_T_left_hand = sp.SE3.from_matrix(device_T_left_hand_matrix)
+                world_T_left_hand = world_T_device @ device_T_left_hand
+                world_T_left_hand = sp.SE3.from_matrix(
+                    T_rot_orientation(world_T_left_hand.to_matrix(), T_ROT_CAM)
                 )
 
                 left_quat_and_translation = quat_translation_swap(
-                    left_T_t.to_quat_and_translation()
+                    world_T_left_hand.to_quat_and_translation()
                 )
                 if left_quat_and_translation.ndim == 2:
                     left_quat_and_translation = left_quat_and_translation[0]
@@ -1030,7 +1036,7 @@ class AriaVRSExtractor:
             if (
                 use_right_hand
                 and not right_confidence < 0
-                and world_device_T_t is not None
+                and world_T_device is not None
             ):
                 right_palm_pose = (
                     hand_tracking_result_t.right_hand.get_palm_position_device()
@@ -1045,18 +1051,18 @@ class AriaVRSExtractor:
                     wrist_pose=right_wrist_pose,
                     palm_normal=right_palm_normal,
                 )
-                right_T_t = np.eye(4)
-                right_T_t[:3, :3] = right_rot_matrix
-                right_T_t[:3, 3] = right_palm_pose
-                right_T_t = sp.SE3.from_matrix(right_T_t)
-                right_T_t = world_device_T_t @ right_T_t
-                right_T_t = sp.SE3.from_matrix(
+                device_T_right_hand_matrix = np.eye(4)
+                device_T_right_hand_matrix[:3, :3] = right_rot_matrix
+                device_T_right_hand_matrix[:3, 3] = right_palm_pose
+                device_T_right_hand = sp.SE3.from_matrix(device_T_right_hand_matrix)
+                world_T_right_hand = world_T_device @ device_T_right_hand
+                world_T_right_hand = sp.SE3.from_matrix(
                     T_rot_orientation(
-                        right_T_t.to_matrix(), T_ROT_CAM
+                        world_T_right_hand.to_matrix(), T_ROT_CAM
                     )
                 )
                 right_quat_and_translation = quat_translation_swap(
-                    right_T_t.to_quat_and_translation()
+                    world_T_right_hand.to_quat_and_translation()
                 )
                 if right_quat_and_translation.ndim == 2:
                     right_quat_and_translation = right_quat_and_translation[0]

--- a/egomimic/scripts/aria_process/aria_utils.py
+++ b/egomimic/scripts/aria_process/aria_utils.py
@@ -773,20 +773,25 @@ class AriaVRSExtractor:
         hand_tracking_results,
         arm: str,
     ):
-        """
-        Get Hand Keypoints from VRS
-        Parameters
-        ----------
-        world_T_device_poses : sequence
-            Timestamped device poses in the world frame.
-        stream_timestamps_ns : dict
-        hand_tracking_results : dict
-        arm : str
-            arm to get hand keypoints for
-        Returns
-        -------
-        hand_keypoints : np.array
-            hand_keypoints
+        """Sample wrist poses and hand keypoints at the RGB timestamps.
+
+        Args:
+            world_T_device_poses: Timestamped MPS device poses in the world
+                frame.
+            stream_timestamps_ns: Stream timestamps in device-time nanoseconds.
+                The ``"rgb"`` entry sets the output length and sample times.
+            hand_tracking_results: Timestamped MPS hand-tracking results.
+            arm: ``"left"``, ``"right"``, or ``"both"``.
+
+        Returns:
+            A ``(T, 70)`` array for one hand or a ``(T, 140)`` array for both
+            hands. Each hand contains a seven-value world-frame wrist pose and
+            21 world-frame XYZ keypoints. Poses use
+            ``[x, y, z, qw, qx, qy, qz]``. Missing samples contain ``1e9``.
+
+        Raises:
+            ValueError: If ``arm`` is not ``"left"``, ``"right"``, or
+                ``"both"``.
         """
         frame_length = len(stream_timestamps_ns["rgb"])
 
@@ -890,19 +895,19 @@ class AriaVRSExtractor:
         device_T_rgb,
         stream_timestamps_ns: dict,
     ):
-        """
-        Get Head Pose from VRS
-        Parameters
-        ----------
-        world_T_device_poses : sequence
-            Timestamped device poses in the world frame.
-        stream_timestamps_ns : dict
-            dict that maps sensor keys to a list of nanosecond timestamps in device time
+        """Sample the RGB camera pose at each RGB timestamp.
 
-        Returns
-        -------
-        head_pose : np.array
-            head_pose
+        Args:
+            world_T_device_poses: Timestamped MPS device poses in the world
+                frame.
+            device_T_rgb: The RGB camera pose in the device frame.
+            stream_timestamps_ns: Stream timestamps in device-time nanoseconds.
+                The ``"rgb"`` entry sets the output length and sample times.
+
+        Returns:
+            A ``(T, 7)`` array of world-frame RGB camera poses. Each pose uses
+            ``[x, y, z, qw, qx, qy, qz]``. A missing pose contains ``1e9`` in
+            all seven fields.
         """
         head_pose = []
         frame_length = len(stream_timestamps_ns["rgb"])
@@ -955,23 +960,24 @@ class AriaVRSExtractor:
         hand_tracking_results,
         arm: str,
     ):
-        """
-        Get EE Pose from VRS
-        Parameters
-        ----------
-        world_T_device_poses : sequence
-            Timestamped device poses in the world frame.
-        stream_timestamps_ns : dict
-            dict that maps sensor keys to a list of nanosecond timestamps in device time
-        hand_tracking_results : dict
-            dict that maps sensor keys to a list of hand tracking results
-        arm : str
-            arm to get hand keypoints for
-        Returns
-        -------
-        ee_pose : np.array
-            ee_pose (6D per arm)
-            -1 if no hand tracking data is available
+        """Sample canonical hand poses at the RGB timestamps.
+
+        Args:
+            world_T_device_poses: Timestamped MPS device poses in the world
+                frame.
+            stream_timestamps_ns: Stream timestamps in device-time nanoseconds.
+                The ``"rgb"`` entry sets the output length and sample times.
+            hand_tracking_results: Timestamped MPS hand-tracking results.
+            arm: ``"left"``, ``"right"``, or ``"both"``.
+
+        Returns:
+            A ``(T, 7)`` array for one hand or a ``(T, 14)`` array for both
+            hands. Each world-frame pose uses
+            ``[x, y, z, qw, qx, qy, qz]``. Missing samples contain ``1e9``.
+
+        Raises:
+            ValueError: If ``arm`` is not ``"left"``, ``"right"``, or
+                ``"both"``.
         """
         ee_pose = []
         frame_length = len(stream_timestamps_ns["rgb"])

--- a/egomimic/scripts/backfill_scripts/stage_processed_folder.py
+++ b/egomimic/scripts/backfill_scripts/stage_processed_folder.py
@@ -26,11 +26,9 @@ Usage (on aria-head-node, Ray cluster up):
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
 
 from sqlalchemy import text
 
@@ -92,7 +90,8 @@ def read_batch(prefixes, folder, cfg):
     worker regardless of whether egomimic / ~/.egoverse_env are present there."""
     import json as _json
     import re as _re
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
 
     import boto3
 

--- a/egomimic/scripts/data_visualization/inspector_lib/dataset_view.py
+++ b/egomimic/scripts/data_visualization/inspector_lib/dataset_view.py
@@ -39,20 +39,10 @@ from functools import lru_cache
 
 import numpy as np
 
-# Canonical overlay path. The head-frame convention (head IS the camera, no
-# per-arm extrinsic) is built locally in `_world_T_head` / `_intrinsics_from_zarr`
-# below; the cam-frame inputs assembled here are then handed to the EMBODIMENT
-# CLASS's `viz` method (e.g. `Human.viz` for `human_bimanual`, `Eva.viz` for
-# `eva_*`), so the trajectory / orientation-axes / keypoint rendering lives in
-# exactly one place and the browser is embodiment-generic. `<EmbClass>.viz`
-# performs the projection internally (it takes `intrinsics`), so this module
-# hands it CAM-FRAME viz_data and never projects to pixels itself.
-# `ee_pose_to_cam_frame` (from `egomimicUtils`, NOT the viz helpers module) is reused for the
-# world -> head-frame point transform (it applies inv(T)).
-#
-# The embodiment classes pull in the `projectaria_tools` stack; that's present in
-# the egomimic env (skynet) but optional in the standalone viz venv, so the import
-# is guarded — if it's unavailable the overlay falls back to the badge.
+# Convert source poses to the camera frame in this module. The selected
+# `Embodiment.viz` method projects the poses and draws the overlay.
+# `projectaria_tools` is optional in the standalone visualization environment.
+# If an embodiment import fails, the browser shows an unavailable badge.
 from egomimic.utils.pose_utils import ee_pose_to_cam_frame
 
 from .images import (
@@ -82,10 +72,11 @@ except Exception as _e:  # pragma: no cover - optional heavy dep
 
 
 def _embodiment_class(grp):
-    """Resolve the embodiment CLASS for an episode from `grp.attrs["embodiment"]`
-    (e.g. `"human_bimanual"` -> `Human`, `"eva_*"` -> `Eva`). Falls back to
-    `Human` if the attr is missing/unknown. Returns None only if the embodiment
-    classes failed to import."""
+    """Return the class identified by ``grp.attrs["embodiment"]``.
+
+    The function returns ``Human`` if the attribute is absent or unknown. It
+    returns ``None`` if the embodiment package did not import.
+    """
     if Human is None:
         return None
     try:
@@ -311,17 +302,13 @@ def _intrinsics_from_zarr(grp):
 
 
 def _extrinsics_from_zarr(grp):
-    """Per-episode EVA (robot) camera extrinsics from zarr.json metadata
-    (`attrs["extrinsics"]`), one `base_T_cam` per arm: the camera pose in that
-    robot arm's base frame. Returns `{"left": 4x4, "right": 4x4}` (only the
-    arms actually present) or None if the attribute is absent or unparseable.
+    """Read per-arm ``base_T_cam`` matrices from episode metadata.
 
-    These are the `base_T_cam` matrices that `Eva.EXTRINSICS` hardcodes and that
-    `_build_eva_bimanual_transform_list` feeds (as xyzwxyz) into
-    `PoseCoordinateFrameTransform(target_world=base_T_cam_pose_key,
-    pose_world=base_T_ee_pose_key)`
-    to compute `inv(base_T_cam) @ base_T_ee`, expressing the end-effector pose
-    in the camera frame."""
+    Returns:
+        A dictionary with valid ``"left"`` and ``"right"`` 4×4 matrices.
+        The function returns ``None`` if no valid matrix is present. It ignores
+        missing, non-numeric, and incorrectly shaped values.
+    """
     try:
         extr = dict(grp.attrs).get("extrinsics")
         if not extr:
@@ -343,10 +330,17 @@ def _extrinsics_from_zarr(grp):
 
 
 def _world_T_head(grp, frame: int):
-    """`world_T_head` (4x4) for `frame` from `obs_head_pose` (xyz + quat wxyz).
-    Returns None if the head pose is missing/malformed. Built with scipy only
-    (same math as egomimicUtils' xyzwxyz->matrix: wxyz quat reordered to xyzw)
-    to keep the overlay free of heavyweight egomimic imports."""
+    """Read one ``world_T_head`` matrix from ``obs_head_pose``.
+
+    Args:
+        grp: An episode Zarr group.
+        frame: The zero-based frame index.
+
+    Returns:
+        A 4×4 matrix. The source pose uses
+        ``[x, y, z, qw, qx, qy, qz]``. The function returns ``None`` if the
+        value is absent, malformed, or outside the array.
+    """
     arr = _resolve_zarr_path(grp, "obs_head_pose")
     if arr is None:
         return None
@@ -367,11 +361,18 @@ def _world_T_head(grp, frame: int):
 
 
 def _reference_pose_to_cam_cartesian(seq, ref_T_cam):
-    """`[N,7]` reference-frame poses (xyz + quat wxyz) -> `[N,6]` camera-frame
-    `[xyz, ypr]` (ZYX-euler), matching egomimic's `actions_cartesian` per-arm
-    layout that `_split_action_pose` consumes. The transform is
-    `inv(ref_T_cam) @ ref_T_pose`, matching `base_frame_to_cam_frame` and
-    `ee_pose_to_cam_frame`."""
+    """Convert reference-frame poses to camera-frame Cartesian poses.
+
+    Args:
+        seq: An ``(N, 7)`` array of
+            ``[x, y, z, qw, qx, qy, qz]`` reference-frame poses.
+        ref_T_cam: A 4×4 camera pose in the reference frame.
+
+    Returns:
+        An ``(N, 6)`` array of camera-frame ``[x, y, z, yaw, pitch, roll]``
+        poses. The Euler angles use ZYX order and radians. The transform is
+        ``inv(ref_T_cam) @ ref_T_pose``.
+    """
     from scipy.spatial.transform import Rotation as R
 
     seq = np.asarray(seq, dtype=float).reshape(-1, 7)
@@ -387,8 +388,16 @@ def _reference_pose_to_cam_cartesian(seq, ref_T_cam):
 
 
 def _world_keypoints_to_cam(seq, world_T_head):
-    """`[63]` (21x3) world keypoints for one arm -> flat `[63]` CAMERA-frame
-    xyz (head IS the camera)."""
+    """Convert 21 world-frame keypoints to a flat camera-frame array.
+
+    Args:
+        seq: An array with 63 XYZ values.
+        world_T_head: The 4×4 head pose in the world frame. The head frame is
+            the camera frame.
+
+    Returns:
+        A flat array with 63 camera-frame XYZ values.
+    """
     pts = np.asarray(seq, dtype=float).reshape(-1, 3)
     cam = ee_pose_to_cam_frame(pts, world_T_head)
     return cam.reshape(-1)
@@ -634,16 +643,9 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
     if intr is None:
         return _badge(img_rgb.copy(), f"overlay {overlay}: no intrinsics"), False, "no K"
 
-    # Cam-frame transform source, branched by what the episode carries:
-    #   - human (`obs_head_pose` present): the head IS the camera, so each world
-    #     pose is transformed world -> head via the per-frame `world_T_head`
-    #     (one shared transform for both arms).
-    #   - eva (`extrinsics` present, no head pose): each arm's base-frame ee_pose
-    #     is transformed base -> cam via that arm's STATIC 4x4 extrinsic, mirroring
-    #     `_build_eva_bimanual_transform_list`'s directed base/camera pose keys.
-    #     (inverse=True default -> inv(extrinsic) @ ee_pose, then xyz+ypr ZYX).
-    #     `_reference_pose_to_cam_cartesian` computes exactly that
-    #     `inv(base_T_cam) @ base_T_pose` plus ZYX Euler conversion.
+    # Select the transform that locates the camera in the pose reference frame.
+    # Human episodes use one `world_T_head` for both arms at each frame.
+    # EVA episodes use one static `base_T_cam` matrix for each arm.
     world_T_head = _world_T_head(grp, frame)
     extr = _extrinsics_from_zarr(grp)
     if world_T_head is None and not extr:
@@ -658,11 +660,12 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
                 return _badge(img_rgb.copy(), f"{overlay}: no ee_pose"), False, "no pose"
 
             def _chunk(seq, arm):
-                """Per-arm cam-frame [H,6] (xyz+ypr). For orientation only the
-                single current frame; for cartesian the [frame, frame+horizon]
-                window. The cam transform is the per-frame head pose (human) or
-                this arm's static extrinsic (eva). Missing arm/transform ->
-                None (drawn as off-screen no-op)."""
+                """Return camera-frame poses for one arm and display window.
+
+                Orientation mode returns one pose. Cartesian mode returns at
+                most ``horizon`` poses. The function returns ``None`` if the
+                source poses or camera transform are absent.
+                """
                 if seq is None:
                     return None
                 ref_T_cam = (

--- a/egomimic/scripts/data_visualization/inspector_lib/dataset_view.py
+++ b/egomimic/scripts/data_visualization/inspector_lib/dataset_view.py
@@ -39,17 +39,8 @@ from functools import lru_cache
 
 import numpy as np
 
-from .images import (
-    _bytes_from_zarr_element,
-    _candidate_image_keys,
-    _resolve_zarr_path,
-    open_zarr_for_hash,
-)
-from .language import annotation_intervals, interval_for_frame
-from .views import ACCENT, BORDER, CANVAS, CARD_STYLE, LABEL_STYLE, MUTED, PANEL, TEXT
-
 # Canonical overlay path. The head-frame convention (head IS the camera, no
-# per-arm extrinsic) is built locally in `_head_T_world` / `_intrinsics_from_zarr`
+# per-arm extrinsic) is built locally in `_world_T_head` / `_intrinsics_from_zarr`
 # below; the cam-frame inputs assembled here are then handed to the EMBODIMENT
 # CLASS's `viz` method (e.g. `Human.viz` for `human_bimanual`, `Eva.viz` for
 # `eva_*`), so the trajectory / orientation-axes / keypoint rendering lives in
@@ -63,6 +54,15 @@ from .views import ACCENT, BORDER, CANVAS, CARD_STYLE, LABEL_STYLE, MUTED, PANEL
 # the egomimic env (skynet) but optional in the standalone viz venv, so the import
 # is guarded — if it's unavailable the overlay falls back to the badge.
 from egomimic.utils.pose_utils import ee_pose_to_cam_frame
+
+from .images import (
+    _bytes_from_zarr_element,
+    _candidate_image_keys,
+    _resolve_zarr_path,
+    open_zarr_for_hash,
+)
+from .language import annotation_intervals, interval_for_frame
+from .views import ACCENT, BORDER, CARD_STYLE, LABEL_STYLE, MUTED, PANEL, TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -320,14 +320,16 @@ def _intrinsics_from_zarr(grp):
 
 def _extrinsics_from_zarr(grp):
     """Per-episode EVA (robot) camera extrinsics from zarr.json metadata
-    (`attrs["extrinsics"]`), a per-arm 4x4 `T_cam_base` mapping the robot BASE
-    frame to the camera frame. Returns `{"left": 4x4, "right": 4x4}` (only the
-    arms actually present) or None if the attr is absent/unparseable.
+    (`attrs["extrinsics"]`), one `base_T_cam` per arm: the camera pose in that
+    robot arm's base frame. Returns `{"left": 4x4, "right": 4x4}` (only the
+    arms actually present) or None if the attribute is absent or unparseable.
 
-    These are the `cam_T_base` matrices that `Eva.EXTRINSICS` hardcodes and that
+    These are the `base_T_cam` matrices that `Eva.EXTRINSICS` hardcodes and that
     `_build_eva_bimanual_transform_list` feeds (as xyzwxyz) into
-    `PoseCoordinateFrameTransform(target_world=extrinsic, pose_world=ee_pose)`
-    to express a base-frame ee_pose in the camera frame."""
+    `PoseCoordinateFrameTransform(target_world=base_T_cam_pose_key,
+    pose_world=base_T_ee_pose_key)`
+    to compute `inv(base_T_cam) @ base_T_ee`, expressing the end-effector pose
+    in the camera frame."""
     try:
         extr = dict(grp.attrs).get("extrinsics")
         if not extr:
@@ -348,8 +350,8 @@ def _extrinsics_from_zarr(grp):
     return out or None
 
 
-def _head_T_world(grp, frame: int):
-    """`T_world_head` (4x4) for `frame` from `obs_head_pose` (xyz + quat wxyz).
+def _world_T_head(grp, frame: int):
+    """`world_T_head` (4x4) for `frame` from `obs_head_pose` (xyz + quat wxyz).
     Returns None if the head pose is missing/malformed. Built with scipy only
     (same math as egomimicUtils' xyzwxyz->matrix: wxyz quat reordered to xyzw)
     to keep the overlay free of heavyweight egomimic imports."""
@@ -364,20 +366,20 @@ def _head_T_world(grp, frame: int):
             return None
         quat_wxyz = pose[3:7]
         quat_xyzw = np.array([quat_wxyz[1], quat_wxyz[2], quat_wxyz[3], quat_wxyz[0]])
-        T = np.eye(4)
-        T[:3, :3] = R.from_quat(quat_xyzw).as_matrix()
-        T[:3, 3] = pose[:3]
-        return T
+        world_T_head = np.eye(4)
+        world_T_head[:3, :3] = R.from_quat(quat_xyzw).as_matrix()
+        world_T_head[:3, 3] = pose[:3]
+        return world_T_head
     except Exception:
         return None
 
 
-def _world_pose_to_cam_cartesian(seq, T_world_head):
-    """`[N,7]` world poses (xyz + quat wxyz) -> `[N,6]` CAMERA-frame
+def _reference_pose_to_cam_cartesian(seq, ref_T_cam):
+    """`[N,7]` reference-frame poses (xyz + quat wxyz) -> `[N,6]` camera-frame
     `[xyz, ypr]` (ZYX-euler), matching egomimic's `actions_cartesian` per-arm
-    layout that `_split_action_pose` consumes. The head IS the camera, so the
-    transform is `inv(T_world_head) @ pose` (same convention as
-    `egomimicUtils.base_frame_to_cam_frame` / `ee_pose_to_cam_frame`)."""
+    layout that `_split_action_pose` consumes. The transform is
+    `inv(ref_T_cam) @ ref_T_pose`, matching `base_frame_to_cam_frame` and
+    `ee_pose_to_cam_frame`."""
     from scipy.spatial.transform import Rotation as R
 
     seq = np.asarray(seq, dtype=float).reshape(-1, 7)
@@ -386,17 +388,17 @@ def _world_pose_to_cam_cartesian(seq, T_world_head):
     se3 = np.tile(np.eye(4), (n, 1, 1))
     se3[:, :3, :3] = R.from_quat(quat_xyzw).as_matrix()
     se3[:, :3, 3] = seq[:, :3]
-    cam = np.linalg.inv(T_world_head) @ se3
+    cam = np.linalg.inv(ref_T_cam) @ se3
     xyz = cam[:, :3, 3]
     ypr = R.from_matrix(cam[:, :3, :3]).as_euler("ZYX", degrees=False)
     return np.concatenate([xyz, ypr], axis=1)
 
 
-def _world_keypoints_to_cam(seq, T_world_head):
+def _world_keypoints_to_cam(seq, world_T_head):
     """`[63]` (21x3) world keypoints for one arm -> flat `[63]` CAMERA-frame
-    xyz (head IS the camera). `ee_pose_to_cam_frame(pts, T)` applies inv(T)."""
+    xyz (head IS the camera)."""
     pts = np.asarray(seq, dtype=float).reshape(-1, 3)
-    cam = ee_pose_to_cam_frame(pts, T_world_head)
+    cam = ee_pose_to_cam_frame(pts, world_T_head)
     return cam.reshape(-1)
 
 
@@ -642,18 +644,17 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
 
     # Cam-frame transform source, branched by what the episode carries:
     #   - human (`obs_head_pose` present): the head IS the camera, so each world
-    #     pose is transformed world -> head via the per-FRAME `T_world_head`
+    #     pose is transformed world -> head via the per-frame `world_T_head`
     #     (one shared transform for both arms).
     #   - eva (`extrinsics` present, no head pose): each arm's base-frame ee_pose
     #     is transformed base -> cam via that arm's STATIC 4x4 extrinsic, mirroring
-    #     `_build_eva_bimanual_transform_list`'s
-    #     `PoseCoordinateFrameTransform(target_world=extrinsic, pose_world=ee_pose)`
+    #     `_build_eva_bimanual_transform_list`'s directed base/camera pose keys.
     #     (inverse=True default -> inv(extrinsic) @ ee_pose, then xyz+ypr ZYX).
-    #     `_world_pose_to_cam_cartesian` computes exactly that inv(T) @ pose + ZYX
-    #     euler, so we reuse it per-arm with T = extrinsic[arm].
-    T_world_head = _head_T_world(grp, frame)
+    #     `_reference_pose_to_cam_cartesian` computes exactly that
+    #     `inv(base_T_cam) @ base_T_pose` plus ZYX Euler conversion.
+    world_T_head = _world_T_head(grp, frame)
     extr = _extrinsics_from_zarr(grp)
-    if T_world_head is None and not extr:
+    if world_T_head is None and not extr:
         return _badge(img_rgb.copy(),
                       f"overlay {overlay}: no head pose / extrinsics"), False, "no cam"
 
@@ -672,8 +673,12 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
                 None (drawn as off-screen no-op)."""
                 if seq is None:
                     return None
-                T = T_world_head if T_world_head is not None else (extr or {}).get(arm)
-                if T is None:
+                ref_T_cam = (
+                    world_T_head
+                    if world_T_head is not None
+                    else (extr or {}).get(arm)
+                )
+                if ref_T_cam is None:
                     return None
                 seq = np.asarray(seq)
                 if overlay == "orientation":
@@ -683,7 +688,7 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
                     win = seq[lo:hi, :7]
                 if win.shape[0] < 1:
                     return None
-                return _world_pose_to_cam_cartesian(win, T)
+                return _reference_pose_to_cam_cartesian(win, ref_T_cam)
 
             lc, rc = _chunk(left, "left"), _chunk(right, "right")
             n = max(lc.shape[0] if lc is not None else 0,
@@ -704,7 +709,7 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
             if not hasattr(emb_cls, "viz"):
                 return _badge(img_rgb.copy(), "keypoint: viz unavailable"), False, "no viz"
             # Keypoints are a head-frame (human) concept; eva has none -> badge.
-            if T_world_head is None:
+            if world_T_head is None:
                 return _badge(img_rgb.copy(), "keypoint: no keypoints"), False, "no kp"
             parts = []
             for arm in ("left", "right"):
@@ -713,7 +718,7 @@ def _draw_overlay(img_rgb, grp, frame: int, overlay: str, horizon: int = 16):
                 if a is None:
                     parts.append(np.zeros(63))
                     continue
-                parts.append(_world_keypoints_to_cam(a[frame], T_world_head))
+                parts.append(_world_keypoints_to_cam(a[frame], world_T_head))
             if all(np.allclose(p, 0) for p in parts):
                 return _badge(img_rgb.copy(), "keypoint: no pts"), False, "off"
             # canonical keypoints (wrist_in_data=False) layout: [L 63, R 63];

--- a/egomimic/scripts/data_visualization/inspector_lib/dataset_view.py
+++ b/egomimic/scripts/data_visualization/inspector_lib/dataset_view.py
@@ -67,25 +67,17 @@ from .views import ACCENT, BORDER, CARD_STYLE, LABEL_STYLE, MUTED, PANEL, TEXT
 logger = logging.getLogger(__name__)
 
 try:
-    from egomimic.rldb.embodiment.embodiment import Embodiment
-    from egomimic.rldb.embodiment.eva import Eva
-    from egomimic.rldb.embodiment.human import Human
-
-    # Mirror `egomimic/scripts/viz_language.py`'s `_EMBODIMENT_CLASSES` so the
-    # browser resolves the same class for an episode's `embodiment` attr.
-    _EMBODIMENT_CLASSES: dict[str, type] = {
-        "eva_bimanual": Eva,
-        "eva_right_arm": Eva,
-        "eva_left_arm": Eva,
-        "human_bimanual": Human,
-        "human_right_arm": Human,
-        "human_left_arm": Human,
-    }
+    from egomimic.rldb.embodiment import (
+        Embodiment,
+        Eva,
+        Human,
+        get_embodiment_class,
+    )
 except Exception as _e:  # pragma: no cover - optional heavy dep
     Embodiment = None
     Eva = None
     Human = None
-    _EMBODIMENT_CLASSES = {}
+    get_embodiment_class = None
     logger.warning("Embodiment classes unavailable, overlays disabled: %s", _e)
 
 
@@ -97,10 +89,10 @@ def _embodiment_class(grp):
     if Human is None:
         return None
     try:
-        emb = str(dict(grp.attrs).get("embodiment", "")).lower()
+        emb = str(dict(grp.attrs).get("embodiment", ""))
     except Exception:
         emb = ""
-    return _EMBODIMENT_CLASSES.get(emb, Human)
+    return get_embodiment_class(emb, default=Human)
 
 # ---- render cache + prefetch (so scrubbing/playback don't re-render) -------
 # Rendered JPEG bytes keyed by (root, ep, frame, overlay, annotate).

--- a/egomimic/scripts/eva_process/eva_to_zarr.py
+++ b/egomimic/scripts/eva_process/eva_to_zarr.py
@@ -17,8 +17,8 @@ from egomimic.rldb.embodiment.eva import Eva
 from egomimic.rldb.zarr.zarr_writer import ZarrWriter
 from egomimic.scripts.eva_process.eva_utils import EvaHD5Extractor
 from egomimic.utils.aws.aws_sql import timestamp_ms_to_episode_hash
-from egomimic.utils.type_utils import str2bool
 from egomimic.utils.pose_utils import xyzw_to_wxyz
+from egomimic.utils.type_utils import str2bool
 from egomimic.utils.video_utils import resize_video_thwc, save_preview_mp4
 
 logger = logging.getLogger(__name__)

--- a/egomimic/scripts/language_process/scale_to_zarr_annotation.py
+++ b/egomimic/scripts/language_process/scale_to_zarr_annotation.py
@@ -14,7 +14,6 @@ import os
 from subprocess import run
 
 import hydra
-import pandas as pd
 from omegaconf import OmegaConf
 from scaleapi import ScaleClient
 
@@ -29,7 +28,6 @@ from egomimic.utils.scale_utils import (
     get_available_hashes,
     get_episode_hash_to_tid,
     get_tasks,
-    get_tid_to_episode_hash,
     load_scale_annotation_csv,
 )
 

--- a/egomimic/scripts/mecka_process/download_episodes.py
+++ b/egomimic/scripts/mecka_process/download_episodes.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import argparse
 import os
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 

--- a/egomimic/scripts/mecka_process/mecka_to_zarr.py
+++ b/egomimic/scripts/mecka_process/mecka_to_zarr.py
@@ -116,10 +116,10 @@ def pose_to_transform(pose: np.ndarray) -> np.ndarray:
     x, y, z, qw, qx, qy, qz = pose
     # SciPy from_quat expects (x, y, z, w); pose[3:7] is (w, x, y, z) = WXYZ
     rotation = Rotation.from_quat([qx, qy, qz, qw])
-    T = np.eye(4)
-    T[:3, :3] = rotation.as_matrix()
-    T[:3, 3] = [x, y, z]
-    return T
+    parent_T_child = np.eye(4)
+    parent_T_child[:3, :3] = rotation.as_matrix()
+    parent_T_child[:3, 3] = [x, y, z]
+    return parent_T_child
 
 
 def extract_mecka_metadata(
@@ -159,18 +159,18 @@ def extract_mecka_metadata(
     }
 
 
-def transform_to_pose(T: np.ndarray) -> np.ndarray:
+def transform_to_pose(parent_T_child: np.ndarray) -> np.ndarray:
     """
     Convert 4x4 homogeneous transform matrix to 7DOF pose in WXYZ format.
 
     Args:
-        T: Array of shape (4, 4) representing SE(3) transform.
+        parent_T_child: Array of shape (4, 4) representing an SE(3) transform.
 
     Returns:
         Array of shape (7,) with [x, y, z, qw, qx, qy, qz] (quat in WXYZ).
     """
-    pos = T[:3, 3]
-    rotation = Rotation.from_matrix(T[:3, :3])
+    pos = parent_T_child[:3, 3]
+    rotation = Rotation.from_matrix(parent_T_child[:3, :3])
     quat_xyzw = rotation.as_quat()  # SciPy returns (x, y, z, w)
     quat_wxyz = np.array([quat_xyzw[3], quat_xyzw[0], quat_xyzw[1], quat_xyzw[2]])
     return np.concatenate([pos, quat_wxyz])
@@ -373,11 +373,11 @@ class MeckaExtractor:
             frames_df = pd.read_csv(frames_path)
             annotations_df = pd.read_csv(annotations_path)
 
-            # Per-frame camera poses (world-to-camera) for hand transform
-            camera_transforms = MeckaExtractor._extract_camera_transforms(egomotion)
+            # Per-frame camera poses in the world frame.
+            world_T_cams = MeckaExtractor._extract_camera_transforms(egomotion)
             hand_poses_world, hand_keypoints_world, wrist_poses_world = (
                 MeckaExtractor._extract_hand_data(
-                    hands_df, frames_df, arm, camera_transforms
+                    hands_df, frames_df, arm, world_T_cams
                 )
             )
 
@@ -449,7 +449,7 @@ class MeckaExtractor:
 
 
         Returns:
-            List of T 4x4 homogeneous transforms (wTc), one per frame.
+            List of `world_T_cam` 4x4 homogeneous transforms, one per frame.
         """
         transforms = []
 
@@ -461,14 +461,14 @@ class MeckaExtractor:
             q = egomotion[i, 7:11]
 
             # Convert quaternion -> rotation matrix
-            R_mat = Rotation.from_quat(q).as_matrix()
+            world_R_cam = Rotation.from_quat(q).as_matrix()
 
             # Build homogeneous SE(3)
-            T = np.eye(4)
-            T[:3, :3] = R_mat
-            T[:3, 3] = t
+            world_T_cam = np.eye(4)
+            world_T_cam[:3, :3] = world_R_cam
+            world_T_cam[:3, 3] = t
 
-            transforms.append(T)
+            transforms.append(world_T_cam)
 
         return transforms
 
@@ -477,7 +477,7 @@ class MeckaExtractor:
         hands_df: pd.DataFrame,
         frames_df: pd.DataFrame,
         arm: str,
-        camera_transforms: List[np.ndarray],
+        world_T_cams: List[np.ndarray],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Extract hand poses and keypoints from hands CSV and transform to world frame.
@@ -485,14 +485,15 @@ class MeckaExtractor:
 
         Hands CSV has columns: frame, hand_index (0=left, 1=right), landmark_index,
         world_x, world_y, world_z. Hand poses are computed from keypoints in camera
-        frame via compute_hand_pose_xyzquat, then transformed to world using wTc.
+        frame via `compute_hand_pose_xyzquat`, then transformed to world using
+        `world_T_cam`.
 
 
         Args:
             hands_df: DataFrame with hand landmark positions per frame.
             frames_df: DataFrame defining frame count and sync (used for shape).
             arm: Unused; kept for API compatibility.
-            camera_transforms: List of wTc 4x4 transforms per frame.
+            world_T_cams: List of `world_T_cam` 4x4 transforms per frame.
 
 
         Returns:
@@ -516,26 +517,26 @@ class MeckaExtractor:
                     kp = hand_data[
                         ["world_x", "world_y", "world_z"]
                     ].values  # (21, 3) in camera frame
-                    wTc = camera_transforms[frame_idx]
+                    world_T_cam = world_T_cams[frame_idx]
 
                     # Transform keypoints from camera frame to world frame (same as hand poses)
                     kp_h = np.concatenate([kp, np.ones((21, 1))], axis=1)  # (21, 4)
-                    kp_world = (wTc @ kp_h.T).T[:, :3]  # (21, 3)
+                    kp_world = (world_T_cam @ kp_h.T).T[:, :3]  # (21, 3)
                     hand_keypoints[frame_idx, hand_index] = kp_world
 
-                    # Hand pose in camera frame -> transform to world via wTc
+                    # Hand pose in camera frame -> transform to world.
                     pose_xyzquat, wrist_xyzquat = compute_hand_pose_xyzquat(
                         kp, hand_index
                     )
 
-                    T_hand_cam = pose_to_transform(pose_xyzquat)
-                    T_wrist_cam = pose_to_transform(wrist_xyzquat)
+                    cam_T_hand = pose_to_transform(pose_xyzquat)
+                    cam_T_wrist = pose_to_transform(wrist_xyzquat)
 
-                    T_hand_world = wTc @ T_hand_cam
-                    pose_xyzquat = transform_to_pose(T_hand_world)
+                    world_T_hand = world_T_cam @ cam_T_hand
+                    pose_xyzquat = transform_to_pose(world_T_hand)
 
-                    T_wrist_world = wTc @ T_wrist_cam
-                    wrist_xyzquat = transform_to_pose(T_wrist_world)
+                    world_T_wrist = world_T_cam @ cam_T_wrist
+                    wrist_xyzquat = transform_to_pose(world_T_wrist)
 
                     hand_poses[frame_idx, hand_index * 7 : (hand_index + 1) * 7] = (
                         pose_xyzquat
@@ -597,7 +598,7 @@ class MeckaExtractor:
             Array of shape (T, 7) with [x, y, z, qw, qx, qy, qz] (quat in WXYZ) per frame.
         """
         # Frame remap: (x, y, z) -> (-y, -z, x) to match expected head pose convention
-        R_fix = np.array(
+        adjusted_cam_R_cam = np.array(
             [
                 [0, -1, 0],
                 [0, 0, -1],
@@ -606,33 +607,32 @@ class MeckaExtractor:
             dtype=np.float64,
         )
 
-        T_fix = np.eye(4, dtype=np.float64)
-        T_fix[:3, :3] = R_fix
-
         # Construct inverse SE(3) transform matrix for the rotation remap
-        R_fix_inv = R_fix.T
-        T_fix_inv = np.eye(4, dtype=np.float64)
-        T_fix_inv[:3, :3] = R_fix_inv
+        cam_R_adjusted_cam = adjusted_cam_R_cam.T
+        cam_T_adjusted_cam = np.eye(4, dtype=np.float64)
+        cam_T_adjusted_cam[:3, :3] = cam_R_adjusted_cam
 
         adjusted_head_poses = []
         for i in range(len(egomotion)):
-            # Build camera pose in world frame: wTc
+            # Build the camera pose in the world frame.
             t = np.asarray(egomotion[i, 1:4], dtype=np.float64)  # world translation
             q = np.asarray(egomotion[i, 7:11], dtype=np.float64)  # quat (x, y, z, w)
-            R_wc = Rotation.from_quat(q).as_matrix()
+            world_R_cam = Rotation.from_quat(q).as_matrix()
 
             # Build SE(3) transform matrix from translation and rotation
-            T_wc = np.eye(4, dtype=np.float64)
-            T_wc[:3, :3] = R_wc
-            T_wc[:3, 3] = t
+            world_T_cam = np.eye(4, dtype=np.float64)
+            world_T_cam[:3, :3] = world_R_cam
+            world_T_cam[:3, 3] = t
 
-            # Apply axis remap: wTc' = wTc @ inv(T_fix)
-            T_wc_adj = T_wc @ T_fix_inv
+            # Apply the camera-axis remap.
+            world_T_adjusted_cam = world_T_cam @ cam_T_adjusted_cam
 
             # Output head pose as [x, y, z, qw, qx, qy, qz] (WXYZ)
-            xyz_adj = T_wc_adj[:3, 3]
-            R_wc_adj = Rotation.from_matrix(T_wc_adj[:3, :3])
-            quat_xyzw = R_wc_adj.as_quat()  # SciPy returns (x, y, z, w)
+            xyz_adj = world_T_adjusted_cam[:3, 3]
+            world_R_adjusted_cam = Rotation.from_matrix(
+                world_T_adjusted_cam[:3, :3]
+            )
+            quat_xyzw = world_R_adjusted_cam.as_quat()  # SciPy returns (x, y, z, w)
             quat_wxyz = np.array(
                 [quat_xyzw[3], quat_xyzw[0], quat_xyzw[1], quat_xyzw[2]]
             )

--- a/egomimic/scripts/mecka_process/mecka_to_zarr.py
+++ b/egomimic/scripts/mecka_process/mecka_to_zarr.py
@@ -160,14 +160,14 @@ def extract_mecka_metadata(
 
 
 def transform_to_pose(parent_T_child: np.ndarray) -> np.ndarray:
-    """
-    Convert 4x4 homogeneous transform matrix to 7DOF pose in WXYZ format.
+    """Convert a homogeneous transform to a translation and quaternion.
 
     Args:
-        parent_T_child: Array of shape (4, 4) representing an SE(3) transform.
+        parent_T_child: A 4×4 matrix that gives the child pose in the parent
+            frame.
 
     Returns:
-        Array of shape (7,) with [x, y, z, qw, qx, qy, qz] (quat in WXYZ).
+        A ``(7,)`` array with ``[x, y, z, qw, qx, qy, qz]``.
     """
     pos = parent_T_child[:3, 3]
     rotation = Rotation.from_matrix(parent_T_child[:3, :3])
@@ -437,33 +437,27 @@ class MeckaExtractor:
 
     @staticmethod
     def _extract_camera_transforms(egomotion: np.ndarray) -> List[np.ndarray]:
-        """
-        Parse egomotion array into per-frame camera poses in world frame.
-
-        Egomotion format: each row has columns [?, X, Y, Z, ?, ?, ?, qx, qy, qz, qw].
-        Quaternion is XYZW (SciPy); used internally, not exposed.
-
+        """Convert Mecka egomotion rows to world-frame camera poses.
 
         Args:
-            egomotion: Array of shape (T, 11+), one row per frame.
-
+            egomotion: A ``(T, D)`` array where ``D >= 11``. Columns 1 through
+                3 contain XYZ translation. Columns 7 through 10 contain an
+                ``[qx, qy, qz, qw]`` quaternion.
 
         Returns:
-            List of `world_T_cam` 4x4 homogeneous transforms, one per frame.
+            A list of ``T`` 4×4 ``world_T_cam`` matrices.
         """
         transforms = []
 
         for i in range(len(egomotion)):
-            # Translation in world frame (columns 1-3)
-            t = egomotion[i, 1:4]  # X, Y, Z
+            # Columns 1 through 3 give the camera translation in the world frame.
+            t = egomotion[i, 1:4]
 
-            # Quaternion (columns 7-10): SciPy expects (x, y, z, w)
+            # Columns 7 through 10 use SciPy's `[x, y, z, w]` order.
             q = egomotion[i, 7:11]
 
-            # Convert quaternion -> rotation matrix
             world_R_cam = Rotation.from_quat(q).as_matrix()
 
-            # Build homogeneous SE(3)
             world_T_cam = np.eye(4)
             world_T_cam[:3, :3] = world_R_cam
             world_T_cam[:3, 3] = t
@@ -479,27 +473,22 @@ class MeckaExtractor:
         arm: str,
         world_T_cams: List[np.ndarray],
     ) -> Tuple[np.ndarray, np.ndarray]:
-        """
-        Extract hand poses and keypoints from hands CSV and transform to world frame.
-
-
-        Hands CSV has columns: frame, hand_index (0=left, 1=right), landmark_index,
-        world_x, world_y, world_z. Hand poses are computed from keypoints in camera
-        frame via `compute_hand_pose_xyzquat`, then transformed to world using
-        `world_T_cam`.
-
+        """Convert Mecka hand landmarks to world-frame poses and keypoints.
 
         Args:
-            hands_df: DataFrame with hand landmark positions per frame.
-            frames_df: DataFrame defining frame count and sync (used for shape).
-            arm: Unused; kept for API compatibility.
-            world_T_cams: List of `world_T_cam` 4x4 transforms per frame.
-
+            hands_df: A table with ``frame``, ``hand_index``,
+                ``landmark_index``, ``world_x``, ``world_y``, and ``world_z``
+                columns. ``hand_index`` is 0 for the left hand and 1 for the
+                right hand.
+            frames_df: A table whose row count sets ``T``.
+            arm: An unused compatibility argument.
+            world_T_cams: A list of ``T`` 4×4 camera poses in the world frame.
 
         Returns:
-            Tuple of (hand_poses_world, hand_keypoints_world):
-                - hand_poses_world: (T, 14) [left_7dof, right_7dof] xyz+quat(WXYZ) in world frame.
-                - hand_keypoints_world: (T, 2, 21, 3) [left_21kp, right_21kp] in world.
+            Three arrays: hand poses with shape ``(T, 14)``, hand keypoints with
+            shape ``(T, 2, 21, 3)``, and wrist poses with shape ``(T, 14)``.
+            Each pose uses ``[x, y, z, qw, qx, qy, qz]``. All values use the
+            world frame. Missing hands retain zero values.
         """
         num_frames = len(frames_df)
         hand_poses = np.zeros((num_frames, 14))
@@ -519,12 +508,12 @@ class MeckaExtractor:
                     ].values  # (21, 3) in camera frame
                     world_T_cam = world_T_cams[frame_idx]
 
-                    # Transform keypoints from camera frame to world frame (same as hand poses)
+                    # Transform the keypoints from the camera frame to the world frame.
                     kp_h = np.concatenate([kp, np.ones((21, 1))], axis=1)  # (21, 4)
                     kp_world = (world_T_cam @ kp_h.T).T[:, :3]  # (21, 3)
                     hand_keypoints[frame_idx, hand_index] = kp_world
 
-                    # Hand pose in camera frame -> transform to world.
+                    # Transform the hand and wrist poses to the world frame.
                     pose_xyzquat, wrist_xyzquat = compute_hand_pose_xyzquat(
                         kp, hand_index
                     )

--- a/egomimic/scripts/mecka_process/mecka_to_zarr.py
+++ b/egomimic/scripts/mecka_process/mecka_to_zarr.py
@@ -23,6 +23,7 @@ import pandas as pd
 from scipy.spatial.transform import Rotation
 
 from egomimic.rldb.embodiment.embodiment import EMBODIMENT
+from egomimic.rldb.embodiment.human import MECKA_INTRINSICS
 from egomimic.rldb.zarr.zarr_writer import ZarrWriter
 
 logging.basicConfig(level=logging.INFO)
@@ -669,11 +670,11 @@ class MeckaDatasetConverter:
         self.task_description = task_description
 
         if arm == "both":
-            emb = EMBODIMENT.MECKA_BIMANUAL
+            emb = EMBODIMENT.HUMAN_BIMANUAL
         elif arm == "left":
-            emb = EMBODIMENT.MECKA_LEFT_ARM
+            emb = EMBODIMENT.HUMAN_LEFT_ARM
         else:
-            emb = EMBODIMENT.MECKA_RIGHT_ARM
+            emb = EMBODIMENT.HUMAN_RIGHT_ARM
 
         self.embodiment = emb.name
 
@@ -729,6 +730,9 @@ class MeckaDatasetConverter:
             fps=self.fps,
             embodiment=self.embodiment,
             task_description=self.task_description,
+            # Mecka frames are stored at 640x360; MECKA_INTRINSICS is the
+            # 1920x1080 calibration rescaled to that size.
+            intrinsics={"front_1": MECKA_INTRINSICS},
             metadata_override=self.mecka_metadata,
         )
         mp4_path = self.output_dir / f"{self.episode_meta['id']}.mp4"

--- a/egomimic/scripts/mps_process/clean_mps.py
+++ b/egomimic/scripts/mps_process/clean_mps.py
@@ -1,6 +1,9 @@
 import os
+
 from cloudpathlib import S3Path
-from egomimic.utils.aws.aws_data_utils import load_env, get_cloudpathlib_s3_client
+
+from egomimic.utils.aws.aws_data_utils import get_cloudpathlib_s3_client, load_env
+
 
 def clean_mps_remote(raw_remote_prefix: str):
     load_env()
@@ -36,7 +39,6 @@ def clean_mps_remote(raw_remote_prefix: str):
         elif depth == 1:
             d0 = rel_parts[0]
             if d0.startswith("mps_") and d0.endswith("_vrs"):
-                name = d0[len("mps_") : -len("_vrs")]
                 has_hand = "hand_tracking" in dirnames
                 has_slam = "slam" in dirnames
                 has_gaze = "eye_gaze" in dirnames

--- a/egomimic/scripts/mps_process/s3_parallel_processor.py
+++ b/egomimic/scripts/mps_process/s3_parallel_processor.py
@@ -47,6 +47,7 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
+
 from egomimic.utils.aws.aws_data_utils import get_boto3_s3_client
 
 # ============================================================================
@@ -141,7 +142,6 @@ class Boto3Backend:
         secret_access_key: Optional[str] = None,
         session_token: Optional[str] = None,
     ):
-        import boto3
         from boto3.s3.transfer import TransferConfig
         from botocore.config import Config
 

--- a/egomimic/scripts/tutorials/aria_to_mano_convert.py
+++ b/egomimic/scripts/tutorials/aria_to_mano_convert.py
@@ -42,9 +42,9 @@ from egomimic.rldb.embodiment.human import (
     ARIA_FINGER_EDGES,
     Human,
 )
-from egomimic.scripts.aria_process.aria_utils import fit_mano_to_aria_batched
 from egomimic.rldb.filters import DatasetFilter
 from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset, S3EpisodeResolver
+from egomimic.scripts.aria_process.aria_utils import fit_mano_to_aria_batched
 from egomimic.utils.aws.aws_data_utils import load_env
 from egomimic.utils.aws.aws_sql import create_default_engine, episode_table_to_df
 
@@ -182,7 +182,9 @@ def render_side_by_side(rows, mano_left_canonical, mano_right_canonical):
             if im.shape[0] != h:
                 im = cv2.copyMakeBorder(im, 0, h - im.shape[0], 0, 0, cv2.BORDER_CONSTANT)
             return im
-        aria_vis = pad(aria_vis); mano_vis = pad(mano_vis)
+
+        aria_vis = pad(aria_vis)
+        mano_vis = pad(mano_vis)
         aria_vis = _draw_legend(aria_vis.copy())
         mano_vis = _draw_legend(mano_vis.copy())
 

--- a/egomimic/scripts/viz_language.py
+++ b/egomimic/scripts/viz_language.py
@@ -17,22 +17,11 @@ import torch
 import torchvision.io as tvio
 from omegaconf import DictConfig, OmegaConf
 
-from egomimic.rldb.embodiment.embodiment import Embodiment
-from egomimic.rldb.embodiment.eva import Eva
-from egomimic.rldb.embodiment.human import Human
+from egomimic.rldb.embodiment import Embodiment, get_embodiment_class
 from egomimic.utils.aws.aws_data_utils import load_env
 from egomimic.utils.viz_utils import _prepare_viz_image
 
 OmegaConf.register_new_resolver("eval", eval)
-
-_EMBODIMENT_CLASSES: dict[str, type[Embodiment]] = {
-    "eva_bimanual": Eva,
-    "eva_right_arm": Eva,
-    "eva_left_arm": Eva,
-    "human_bimanual": Human,
-    "human_right_arm": Human,
-    "human_left_arm": Human,
-}
 
 
 def _extract_annotation(batch: dict, annotation_key: str) -> list[str]:
@@ -163,7 +152,7 @@ def _run_viz_for_datasets(
     frames_per_file: int,
 ) -> None:
     for embodiment_name, dataset in datasets.items():
-        embodiment_cls = _EMBODIMENT_CLASSES.get(embodiment_name.lower())
+        embodiment_cls = get_embodiment_class(embodiment_name)
         if embodiment_cls is None:
             print(f"[warn] No embodiment class for '{embodiment_name}', skipping.")
             continue

--- a/egomimic/utils/metrics.py
+++ b/egomimic/utils/metrics.py
@@ -4,8 +4,8 @@ Moved out of egomimicUtils; code unchanged.
 """
 
 import math
-import torch
 
+import torch
 
 # ---- moved from egomimicUtils.py (code unchanged) ----
 

--- a/egomimic/utils/pose_utils.py
+++ b/egomimic/utils/pose_utils.py
@@ -260,11 +260,15 @@ def _split_keypoints(keypoints, wrist_in_data: bool = False, is_quat: bool = Tru
 # ---- moved from egomimicUtils.py (code unchanged) ----
 
 def ee_pose_to_cam_frame(ee_pose_base, base_T_cam):
-    """
-    ee_pose_base: (N, 3)
-    base_T_cam: (4, 4), the camera pose in the robot base frame.
+    """Convert XYZ points from the robot base frame to the camera frame.
 
-    returns ee_pose_cam: (N, 3)
+    Args:
+        ee_pose_base: An ``(N, 3)`` array of base-frame XYZ points.
+        base_T_cam: A 4×4 camera pose in the robot base frame.
+
+    Returns:
+        An ``(N, 3)`` array of camera-frame XYZ points. The function applies
+        ``inv(base_T_cam)`` to each input point.
     """
     N, _ = ee_pose_base.shape
     ee_pose_base = np.concatenate([ee_pose_base, np.ones((N, 1))], axis=1)
@@ -274,11 +278,16 @@ def ee_pose_to_cam_frame(ee_pose_base, base_T_cam):
 
 
 def base_frame_to_cam_frame(base_frame, base_T_cam):
-    """
-    base_frame: (N, 6) (x, y, z, yaw, pitch, roll)
-    base_T_cam: (4, 4), the camera pose in the robot base frame.
+    """Convert Cartesian poses from the robot base frame to the camera frame.
 
-    returns cam_frame: (N, 6) (x, y, z, yaw, pitch, roll)
+    Args:
+        base_frame: An ``(N, 6)`` array of base-frame
+            ``[x, y, z, yaw, pitch, roll]`` poses.
+        base_T_cam: A 4×4 camera pose in the robot base frame.
+
+    Returns:
+        An ``(N, 6)`` array of camera-frame poses. Euler angles use ZYX order
+        and radians.
     """
     N, _ = base_frame.shape
     se3 = np.zeros((N, 4, 4))
@@ -291,11 +300,16 @@ def base_frame_to_cam_frame(base_frame, base_T_cam):
     return np.concatenate([xyz, ypr], axis=1)
 
 def cam_frame_to_base_frame(cam_frame, base_T_cam):
-    """
-    cam_frame: (N, 6) (x, y, z, yaw, pitch, roll)
-    base_T_cam: (4, 4), the camera pose in the robot base frame.
+    """Convert Cartesian poses from the camera frame to the robot base frame.
 
-    returns base_frame: (N, 6) (x, y, z, yaw, pitch, roll)
+    Args:
+        cam_frame: An ``(N, 6)`` array of camera-frame
+            ``[x, y, z, yaw, pitch, roll]`` poses.
+        base_T_cam: A 4×4 camera pose in the robot base frame.
+
+    Returns:
+        An ``(N, 6)`` array of robot-base-frame poses. Euler angles use ZYX
+        order and radians.
     """
     N, _ = cam_frame.shape
     se3 = np.zeros((N, 4, 4))

--- a/egomimic/utils/pose_utils.py
+++ b/egomimic/utils/pose_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 from scipy.interpolate import interp1d
 from scipy.spatial.transform import Rotation as R
 from scipy.spatial.transform import Slerp
@@ -256,57 +257,54 @@ def _split_keypoints(keypoints, wrist_in_data: bool = False, is_quat: bool = Tru
         right_keypoints = keypoints[..., 63:]
         return left_keypoints, right_keypoints
 
-from scipy.spatial.transform import Rotation
-import scipy
-
-
 # ---- moved from egomimicUtils.py (code unchanged) ----
 
-def ee_pose_to_cam_frame(ee_pose_base, T_cam_base):
+def ee_pose_to_cam_frame(ee_pose_base, base_T_cam):
     """
     ee_pose_base: (N, 3)
-    T_cam_base: (4, 4)
+    base_T_cam: (4, 4), the camera pose in the robot base frame.
 
     returns ee_pose_cam: (N, 3)
     """
     N, _ = ee_pose_base.shape
     ee_pose_base = np.concatenate([ee_pose_base, np.ones((N, 1))], axis=1)
 
-    ee_pose_grip_cam = np.linalg.inv(T_cam_base) @ ee_pose_base.T
+    ee_pose_grip_cam = np.linalg.inv(base_T_cam) @ ee_pose_base.T
     return ee_pose_grip_cam.T[:, :3]
 
-def base_frame_to_cam_frame(base_frame, T_cam_base):
+
+def base_frame_to_cam_frame(base_frame, base_T_cam):
     """
     base_frame: (N, 6) (x, y, z, yaw, pitch, roll)
-    T_cam_base: (4, 4)
+    base_T_cam: (4, 4), the camera pose in the robot base frame.
 
     returns cam_frame: (N, 6) (x, y, z, yaw, pitch, roll)
     """
     N, _ = base_frame.shape
     se3 = np.zeros((N, 4, 4))
-    se3[:, :3, :3] = Rotation.from_euler("ZYX", base_frame[:, 3:6]).as_matrix()
+    se3[:, :3, :3] = R.from_euler("ZYX", base_frame[:, 3:6]).as_matrix()
     se3[:, :3, 3] = base_frame[:, :3]
     se3[:, 3, 3] = 1
-    cam_frame = np.linalg.inv(T_cam_base) @ se3
+    cam_frame = np.linalg.inv(base_T_cam) @ se3
     xyz = cam_frame[:, :3, 3]
-    ypr = Rotation.from_matrix(cam_frame[:, :3, :3]).as_euler("ZYX", degrees=False)
+    ypr = R.from_matrix(cam_frame[:, :3, :3]).as_euler("ZYX", degrees=False)
     return np.concatenate([xyz, ypr], axis=1)
 
-def cam_frame_to_base_frame(cam_frame, T_cam_base):
+def cam_frame_to_base_frame(cam_frame, base_T_cam):
     """
     cam_frame: (N, 6) (x, y, z, yaw, pitch, roll)
-    T_cam_base: (4, 4)
+    base_T_cam: (4, 4), the camera pose in the robot base frame.
 
     returns base_frame: (N, 6) (x, y, z, yaw, pitch, roll)
     """
     N, _ = cam_frame.shape
     se3 = np.zeros((N, 4, 4))
-    se3[:, :3, :3] = Rotation.from_euler("ZYX", cam_frame[:, 3:6]).as_matrix()
+    se3[:, :3, :3] = R.from_euler("ZYX", cam_frame[:, 3:6]).as_matrix()
     se3[:, :3, 3] = cam_frame[:, :3]
     se3[:, 3, 3] = 1
-    base_frame = T_cam_base @ se3
+    base_frame = base_T_cam @ se3
     xyz = base_frame[:, :3, 3]
-    ypr = Rotation.from_matrix(base_frame[:, :3, :3]).as_euler("ZYX", degrees=False)
+    ypr = R.from_matrix(base_frame[:, :3, :3]).as_euler("ZYX", degrees=False)
     return np.concatenate([xyz, ypr], axis=1)
 
 def pose_to_transform(pose):
@@ -332,33 +330,34 @@ def pose_to_transform(pose):
     )
 
     # Combined rotation: note the multiplication order
-    R = Rz @ Ry @ Rx
+    parent_R_child = Rz @ Ry @ Rx
 
     # Assemble homogeneous transformation matrix
-    T = np.eye(4)
-    T[:3, :3] = R
-    T[:3, 3] = [x, y, z]
-    return T
+    parent_T_child = np.eye(4)
+    parent_T_child[:3, :3] = parent_R_child
+    parent_T_child[:3, 3] = [x, y, z]
+    return parent_T_child
 
-def transform_to_pose(T):
+
+def transform_to_pose(parent_T_child):
     """
     Convert a 4x4 homogeneous transform back to a 6D pose [x, y, z, yaw, pitch, roll].
     Uses the ZYX (yaw-pitch-roll) convention.
     """
-    x, y, z = T[:3, 3]
-    R = T[:3, :3]
+    x, y, z = parent_T_child[:3, 3]
+    parent_R_child = parent_T_child[:3, :3]
 
-    # Extract pitch from the (3,1) element of R
-    pitch = np.arcsin(-R[2, 0])
+    # Extract pitch from the (3,1) element of the rotation matrix.
+    pitch = np.arcsin(-parent_R_child[2, 0])
     # To avoid numerical issues, check for gimbal lock:
     cos_pitch = np.cos(pitch)
     if np.abs(cos_pitch) > 1e-6:
-        yaw = np.arctan2(R[1, 0], R[0, 0])
-        roll = np.arctan2(R[2, 1], R[2, 2])
+        yaw = np.arctan2(parent_R_child[1, 0], parent_R_child[0, 0])
+        roll = np.arctan2(parent_R_child[2, 1], parent_R_child[2, 2])
     else:
         # Gimbal lock: arbitrarily set yaw=0
         yaw = 0
-        roll = np.arctan2(-R[0, 1], R[1, 1])
+        roll = np.arctan2(-parent_R_child[0, 1], parent_R_child[1, 1])
     return np.array([x, y, z, yaw, pitch, roll])
 
 def cam_frame_to_cam_pixels(ee_pose_cam, intrinsics):

--- a/egomimic/utils/tensor_utils.py
+++ b/egomimic/utils/tensor_utils.py
@@ -5,9 +5,12 @@ of numpy arrays and torch tensors.
 
 # from robomimic
 import collections
+import math
 
+import einops
 import numpy as np
 import torch
+import torch.nn as nn
 
 
 def recursive_dict_list_tuple_apply(x, type_func_dict):
@@ -986,11 +989,6 @@ def time_distributed(
         outputs, begin_axis=0, end_axis=0, target_dims=(batch_size, seq_len)
     )
     return outputs
-
-import einops
-import math
-import torch.nn as nn
-
 
 # ---- moved from egomimicUtils.py (code unchanged) ----
 

--- a/egomimic/utils/type_utils.py
+++ b/egomimic/utils/type_utils.py
@@ -1,4 +1,5 @@
 import argparse
+
 import numpy as np
 
 

--- a/egomimic/utils/viz_utils.py
+++ b/egomimic/utils/viz_utils.py
@@ -536,21 +536,19 @@ def draw_dot_on_frame(frame, pixel_vals, show=True, palette="Purples", dot_size=
     return frame
 
 def get_gaze_endpoint(yaw_rads, pitch_rads, depth, cam_T_cpf):
-    """
-    Compute the 3D gaze endpoint in camera coordinates.
-
-    The gaze originates at the CPF origin, with direction defined by yaw/pitch,
-    and length set by depth. The endpoint is transformed from CPF to camera
-    frame using `cam_T_cpf`.
+    """Return the gaze endpoint in camera-frame coordinates.
 
     Args:
         yaw_rads: Yaw angle in radians.
         pitch_rads: Pitch angle in radians.
-        depth: Gaze vector magnitude.
-        cam_T_cpf: (4, 4) SE(3) homogeneous transform from CPF to camera frame.
+        depth: Distance from the central-pupil-frame origin to the endpoint.
+        cam_T_cpf: A 4×4 central-pupil-frame pose in the camera frame.
 
     Returns:
-        np.ndarray: (3,) gaze endpoint in camera coordinates.
+        A ``(3,)`` ``float64`` array of camera-frame XYZ coordinates.
+
+    Raises:
+        ValueError: If ``cam_T_cpf`` does not have shape ``(4, 4)``.
     """
     gaze_vec_cpf = get_vector_from_yaw_pitch(yaw_rads, pitch_rads, depth)
 

--- a/egomimic/utils/viz_utils.py
+++ b/egomimic/utils/viz_utils.py
@@ -3,8 +3,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
-from egomimic.utils.pose_utils import cam_frame_to_cam_pixels
-from egomimic.utils.pose_utils import _split_action_pose, _split_keypoints
+from egomimic.utils.pose_utils import (
+    _split_action_pose,
+    _split_keypoints,
+    cam_frame_to_cam_pixels,
+    ee_pose_to_cam_frame,
+    get_vector_from_yaw_pitch,
+)
 
 
 class ColorPalette:
@@ -270,7 +275,7 @@ def _viz_gaze(
     image,
     gaze_data,
     intrinsics,
-    t_rgb_cpf,
+    rgb_T_cpf,
     palette="Purples",
     dot_size=8,
     no_gaze_sentinel=-100,
@@ -283,7 +288,7 @@ def _viz_gaze(
         return image.copy()
 
     yaw, pitch, depth = float(gaze[0]), float(gaze[1]), float(gaze[2])
-    endpoint_cam = get_gaze_endpoint(yaw, pitch, depth, t_rgb_cpf)[None, :]
+    endpoint_cam = get_gaze_endpoint(yaw, pitch, depth, rgb_T_cpf)[None, :]
     pixel = cam_frame_to_cam_pixels(endpoint_cam, intrinsics)
     return draw_dot_on_frame(
         image.copy(), pixel, show=False, palette=palette, dot_size=dot_size
@@ -444,9 +449,6 @@ def _viz_annotations(image, annotations: list[str], **kwargs):
 def save_image(image: np.ndarray, path: str) -> None:
     cv2.imwrite(path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
 
-from egomimic.utils.pose_utils import ee_pose_to_cam_frame, get_vector_from_yaw_pitch
-
-
 # ---- moved from egomimicUtils.py (code unchanged) ----
 
 def draw_actions(
@@ -533,29 +535,29 @@ def draw_dot_on_frame(frame, pixel_vals, show=True, palette="Purples", dot_size=
 
     return frame
 
-def get_gaze_endpoint(yaw_rads, pitch_rads, depth, T_cam_cpf):
+def get_gaze_endpoint(yaw_rads, pitch_rads, depth, cam_T_cpf):
     """
     Compute the 3D gaze endpoint in camera coordinates.
 
     The gaze originates at the CPF origin, with direction defined by yaw/pitch,
     and length set by depth. The endpoint is transformed from CPF to camera
-    frame using T_cam_cpf.
+    frame using `cam_T_cpf`.
 
     Args:
         yaw_rads: Yaw angle in radians.
         pitch_rads: Pitch angle in radians.
         depth: Gaze vector magnitude.
-        T_cam_cpf: (4, 4) SE(3) homogeneous transform from CPF to camera frame.
+        cam_T_cpf: (4, 4) SE(3) homogeneous transform from CPF to camera frame.
 
     Returns:
         np.ndarray: (3,) gaze endpoint in camera coordinates.
     """
     gaze_vec_cpf = get_vector_from_yaw_pitch(yaw_rads, pitch_rads, depth)
 
-    T_cam_cpf = np.asarray(T_cam_cpf, dtype=np.float64)
-    if T_cam_cpf.shape != (4, 4):
-        raise ValueError(f"T_cam_cpf must be a 4x4 transform, got {T_cam_cpf.shape}")
+    cam_T_cpf = np.asarray(cam_T_cpf, dtype=np.float64)
+    if cam_T_cpf.shape != (4, 4):
+        raise ValueError(f"cam_T_cpf must be a 4x4 transform, got {cam_T_cpf.shape}")
 
     endpoint_cpf_h = np.concatenate([gaze_vec_cpf, np.array([1.0], dtype=np.float64)])
-    endpoint_cam_h = T_cam_cpf @ endpoint_cpf_h
+    endpoint_cam_h = cam_T_cpf @ endpoint_cpf_h
     return endpoint_cam_h[:3]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,6 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.pytest.ini_options]
+testpaths = ["egomimic/rldb/zarr"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = ["."]
 
-# The embodiment registry is data that ships with the package.
+# Include the registry YAML files in built distributions.
 [tool.setuptools.package-data]
 "egomimic.rldb.embodiment.registry" = ["*.yaml"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,9 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = ["."]
 
+# The embodiment registry is data that ships with the package.
+[tool.setuptools.package-data]
+"egomimic.rldb.embodiment.registry" = ["*.yaml"]
+
 [tool.pytest.ini_options]
-testpaths = ["egomimic/rldb/zarr"]
+testpaths = ["egomimic/rldb/embodiment", "egomimic/rldb/zarr"]


### PR DESCRIPTION
Adds a registry for end effector+base factorized embodiments and defines a new transform naming convention A_T_B (frame B to frame A) to remove ambiguity when dealing with robot data