### PR TITLE
pi0.5 keypoint action path + held-out-operator split for the fold-freeform fit tests: keypoints_wristframe_pi transform (138-D wrist-first keypoints + cartesian ee_pose prompt proprio), HumanBimanualKeypoints converter, PI resizes openpi action projection

### DIFF
--- a/egomimic/algo/pi.py
+++ b/egomimic/algo/pi.py
@@ -202,8 +202,44 @@ class PI(Algo):
             )
         else:
             logger.warning("No pytorch_weight_path specified — training from scratch")
+        # Non-32 action widths (e.g. the 138-D wrist-first MANO keypoint
+        # action padded to 140): the vendored openpi PyTorch port hard-codes
+        # 32-wide action projections regardless of ``Pi0Config.action_dim``,
+        # so swap them for ``action_dim``-wide ones AFTER the (strict)
+        # base-weight load. Only these two layers start fresh;
+        # ``sample_actions`` already draws its noise at ``config.action_dim``.
+        action_dim = int(self.config.model.action_dim)
+        if action_dim != 32:
+            self._resize_action_projections(action_dim)
         self.nets = nn.ModuleDict()
         self.nets["policy"] = self.model
+
+    def _resize_action_projections(self, action_dim: int) -> None:
+        target = (
+            self.model.module
+            if isinstance(self.model, torch.nn.parallel.DistributedDataParallel)
+            else self.model
+        )
+        old_in, old_out = target.action_in_proj, target.action_out_proj
+        width = old_in.out_features
+        new_in = nn.Linear(action_dim, width).to(
+            dtype=old_in.weight.dtype, device=old_in.weight.device
+        )
+        new_out = nn.Linear(width, action_dim).to(
+            dtype=old_out.weight.dtype, device=old_out.weight.device
+        )
+        target.action_in_proj = new_in
+        target.action_out_proj = new_out
+        logger.warning(
+            "action_dim=%d != 32: re-initialized action_in_proj (%d->%d) and "
+            "action_out_proj (%d->%d); the pretrained 32-wide projections are "
+            "discarded, everything else is loaded from the base checkpoint.",
+            action_dim,
+            action_dim,
+            width,
+            width,
+            action_dim,
+        )
 
     def _control_mode_for(self, emb_name: str | None) -> str:
         if self.control_mode and emb_name is not None:

--- a/egomimic/eval/eval_pi_palm.py
+++ b/egomimic/eval/eval_pi_palm.py
@@ -1,0 +1,99 @@
+"""PIEvalVideo plus a palm-origin cam-frame metric for KEYPOINT-action pi runs.
+
+The keypoint runs are scored in cam frame over all 21 MANO keypoints per hand
+(``..._actions_keypoints_cam_paired_mse_avg``); the cartesian runs are scored on
+the palm-origin position only (``..._actions_cartesian_cam_xyz_paired_mse_avg``).
+To put the two on the same target, this evaluator reverts the predicted (and
+GT) keypoint chunks to head/cam frame exactly as PIEvalVideo does, then derives
+the palm origin from the 21 reverted keypoints with the SAME definition the
+mecka conversion used to build ``ee_pose``
+(``mecka_to_zarr.compute_hand_pose_xyzquat``: centroid of the wrist and the four
+MCPs, MANO indices 0, 5, 9, 13, 17) and reports its paired / final MSE in m² per
+coordinate — directly comparable to the cartesian runs' ``cam_xyz`` metric.
+
+Sanity: ``..._palmdef_check_step0_dist_cm`` is the distance between the GT
+palm centroid at chunk step 0 and the head-frame proprio ``ee_pose`` position in
+the same batch; near zero confirms the palm definition matches the data.
+
+The palm trajectories (pred / gt / proprio ee) are dumped to
+``<save_dir>/palm_cam_trajectories.npz`` for offline analysis.
+"""
+
+import copy
+import os
+
+import numpy as np
+import torch
+
+from egomimic.eval.eval_pi import PIEvalVideo
+from egomimic.rldb.embodiment.embodiment import Embodiment, get_embodiment
+
+# mecka_to_zarr.compute_hand_pose_xyzquat: wrist + index/middle/ring/pinky MCPs
+MECKA_PALM_IDX = (0, 5, 9, 13, 17)
+# aria_utils.MANO_PALM_IDX: pinky excluded
+ARIA_PALM_IDX = (0, 5, 9, 13)
+
+
+class PIEvalKeypointPalm(PIEvalVideo):
+    def __init__(self, *args, palm_idx=MECKA_PALM_IDX, save_dir=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.palm_idx = [int(i) for i in palm_idx]
+        self.save_dir = save_dir
+        self._dump = {"pred": [], "gt": [], "ee": []}
+
+    def compute_metrics_and_viz(self, batch, do_viz=True):
+        metrics, images = super().compute_metrics_and_viz(batch, do_viz=do_viz)
+        algo = self.model
+        preds = algo.forward_eval(batch)
+        for embodiment_id, _batch in batch.items():
+            _b = algo.norm_stats.unnormalize(_batch, embodiment_id)
+            name = get_embodiment(embodiment_id).lower()
+            ac_key = algo.ac_keys[embodiment_id]
+            pred_key = f"{name}_{ac_key}"
+            tl = self.transform_lists.get(name)
+            if tl is None or pred_key not in preds:
+                continue
+            pb = copy.deepcopy(_b)
+            pb[ac_key] = preds[pred_key]
+            gt = torch.as_tensor(Embodiment.apply_transform(_b, tl)[ac_key]).float().cpu()
+            pr = torch.as_tensor(Embodiment.apply_transform(pb, tl)[ac_key]).float().cpu()
+            B, T, D = gt.shape
+            if D != 126:  # not a keypoint action -> nothing to derive
+                continue
+            gk = gt.view(B, T, 2, 21, 3)
+            pk = pr.view(B, T, 2, 21, 3)
+            gp = gk[:, :, :, self.palm_idx].mean(3)  # (B, T, 2 hands, xyz) head frame, metres
+            pp = pk[:, :, :, self.palm_idx].mean(3)
+            err = (pp - gp) ** 2
+            metrics[f"Valid/{pred_key}_palm_cam_paired_mse_avg"] = err.mean()
+            metrics[f"Valid/{pred_key}_palm_cam_final_mse_avg"] = err[:, -1].mean()
+            metrics[f"Valid/{pred_key}_palm_cam_rmse_cm"] = err.mean().sqrt() * 100.0
+            for h, hn in enumerate(("left", "right")):
+                metrics[f"Valid/{pred_key}_palm_cam_paired_mse_{hn}"] = err[:, :, h].mean()
+            # wrist-joint-only variant (MANO 0) for reference
+            werr = (pk[:, :, :, 0] - gk[:, :, :, 0]) ** 2
+            metrics[f"Valid/{pred_key}_wristjoint_cam_paired_mse_avg"] = werr.mean()
+            ee = _b.get("observations.state.ee_pose")
+            if ee is not None:
+                ee = torch.as_tensor(ee).float().cpu()
+                # padded 20-D layout per arm: xyz(3) rot6d(6) grip(1) -> xyz at 0:3 and 10:13
+                ee_xyz = torch.stack([ee[:, 0:3], ee[:, 10:13]], dim=1)  # (B, 2, 3)
+                dist = (gp[:, 0] - ee_xyz).norm(dim=-1)  # (B, 2) metres
+                metrics[f"Valid/{pred_key}_palmdef_check_step0_dist_cm"] = dist.mean() * 100.0
+                self._dump["ee"].append(ee_xyz.numpy())
+            self._dump["pred"].append(pp.numpy())
+            self._dump["gt"].append(gp.numpy())
+        return metrics, images
+
+    def on_validation_end(self):
+        super().on_validation_end()
+        if self.save_dir and self._dump["pred"]:
+            os.makedirs(self.save_dir, exist_ok=True)
+            np.savez_compressed(
+                os.path.join(self.save_dir, "palm_cam_trajectories.npz"),
+                pred=np.concatenate(self._dump["pred"]),
+                gt=np.concatenate(self._dump["gt"]),
+                ee=(np.concatenate(self._dump["ee"]) if self._dump["ee"] else np.zeros(0)),
+                palm_idx=np.array(self.palm_idx),
+            )
+            print(f"[palm-eval] saved {self.save_dir}/palm_cam_trajectories.npz", flush=True)

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
@@ -1,23 +1,19 @@
 # MECKA_FOLD_FREEFORM_OPSPLIT_PI_6D — pi0.5 BC on the mecka FREEFORM fold-clothes
-# episodes (fold_clothes-derivative task names, 492 eps / 11.21 h under
+# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
 # processed_v3/mecka/freeform/; "freeform" is only visible in
-# zarr_processed_path, so the filter keys on '/mecka/freeform/'), stored under
-# the human_bimanual embodiment, with the held-out-OPERATOR train/val split.
+# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
+# either fold-clothes task spelling), stored under the human_bimanual
+# embodiment, with the held-out-OPERATOR train/val split.
 #
-# DATASET v2 (Aidan, 2026-09-01): every freeform task whose NAME contains a
-# fold_clothes derivative — 'fold' AND 'clothes' in the lowercased task name,
-# 'packag*' excluded, non-clothes folding (boxes/paper/napkins/fabric/...)
-# excluded by the 'clothes' requirement. Resolves today to 8 tasks
-# (cleaning_and_folding_clothes, dishwashing_and_folding_clothes, folding_and_bagging_clothes, folding_and_ironing_clothes, folding_and_packing_clothes, folding_clothes, ironing_and_folding_clothes, lint_rolling_and_folding_clothes)
-# = 492 eps / 1,211,002 frames / 11.21 h / 184 operators.
-#
-# OPERATOR SPLIT v2 (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 27 operators held out ENTIRELY, so
-# no val episode shares an operator with training. Same recipe as v1: skip the
-# 10 largest operators, random.Random(42) shuffle of the rest, accumulate
-# until >= 8 % of frames -> 27 operators, 43 episodes, 105,311 frames
-# (8.7 %) held out; train = 157 operators, 449 episodes,
-# 1,105,691 frames. Both sides use mode: total; the lists ARE the split.
+# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 25 operators held out ENTIRELY, so no
+# val episode shares an operator with training. Chosen deterministically on
+# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
+# skip the 10 largest operators (their data stays in train), seeded shuffle
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
+# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
+# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# mode: total (no random episode split); the lists ARE the split.
 #
 # WRIST-frame cartesian actions with the continuous 6D rotation (18D =
 # xyz+6D per arm, no gripper): each arm's 100-step chunk is expressed
@@ -59,10 +55,10 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
     mode: total
 
 valid_datasets:
@@ -73,10 +69,10 @@ valid_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
@@ -1,0 +1,102 @@
+# MECKA_FOLD_FREEFORM_OPSPLIT_PI_6D — pi0.5 BC on the mecka FREEFORM fold-clothes
+# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
+# processed_v3/mecka/freeform/; "freeform" is only visible in
+# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
+# either fold-clothes task spelling), stored under the human_bimanual
+# embodiment, with the held-out-OPERATOR train/val split.
+#
+# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 25 operators held out ENTIRELY, so no
+# val episode shares an operator with training. Chosen deterministically on
+# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
+# skip the 10 largest operators (their data stays in train), seeded shuffle
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
+# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
+# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# mode: total (no random episode split); the lists ARE the split.
+#
+# WRIST-frame cartesian actions with the continuous 6D rotation (18D =
+# xyz+6D per arm, no gripper): each arm's 100-step chunk is expressed
+# relative to that wrist's current pose; the head-frame proprio ee_pose is
+# 6D-encoded too. Pairs with model=pi0.5_bc_mecka_6d.
+#
+# Shared pipeline knobs (same as mecka_all_pi_6d): fix_mecka_left_wrist
+# (processed_v3 mecka zarrs have the LEFT wrist frame double-mirrored;
+# Rz(180°)-corrected before any frame math), pad_proprio_gripper (18 -> 20-dim
+# proprio so the State: prompt bins align with the robot layout), stride 1,
+# prompts from the `annotations` track. Pairs with evaluator=eval_pi_wristframe_6d
+# (+ `+evaluator@train_viz_evaluator=train_viz_pi_wristframe_6d`). Twins: mecka_fold_freeform_opsplit_pi_cam6d (cam frame), mecka_fold_freeform_opsplit_pi_keypoints (keypoint action).
+#
+# Norm stats: precompute on a CPU node (scripts/norm_fold_freeform_opsplit_wrist6d.sbatch) and point
+# training at norm_stats.precomputed_norm_path=<out>/norm_stats.
+#
+# folder_path: shared PACE mirror of processed_v3; all 462 episodes present.
+
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+train_datasets:
+  human_bimanual:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Human.get_keymap
+        # "_pi" suffix -> PaliGemma-style camera name (base_0_rgb).
+        keymap_mode: cartesian_pi
+        annotation_key: annotations
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Human.get_transform_list
+        mode: cartesian_wristframe_6d
+        stride: 1
+        fix_mecka_left_wrist: true
+        pad_proprio_gripper: true
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
+        # OPERATOR SPLIT — train = every operator NOT in the held-out set.
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+    mode: total
+
+valid_datasets:
+  human_bimanual:
+    _target_: ${...train_datasets.human_bimanual._target_}
+    resolver: ${...train_datasets.human_bimanual.resolver}
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
+        # OPERATOR SPLIT — valid = the 25 held-out operators only.
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+    mode: total
+
+# Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,
+# videos_train_viz/): same operators as train, no shuffle -> same slice every val.
+train_viz_datasets:
+  human_bimanual:
+    _target_: ${...train_datasets.human_bimanual._target_}
+    resolver: ${...train_datasets.human_bimanual.resolver}
+    filters: ${...train_datasets.human_bimanual.filters}
+    mode: total
+
+train_viz_dataloader_params:
+  human_bimanual:
+    batch_size: 32
+    num_workers: 2
+    shuffle: false
+
+train_dataloader_params:
+  human_bimanual:
+    batch_size: 64
+    num_workers: 8
+
+valid_dataloader_params:
+  human_bimanual:
+    batch_size: 64
+    num_workers: 8
+    shuffle: false

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
@@ -1,19 +1,23 @@
 # MECKA_FOLD_FREEFORM_OPSPLIT_PI_6D — pi0.5 BC on the mecka FREEFORM fold-clothes
-# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
+# episodes (fold_clothes-derivative task names, 492 eps / 11.21 h under
 # processed_v3/mecka/freeform/; "freeform" is only visible in
-# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
-# either fold-clothes task spelling), stored under the human_bimanual
-# embodiment, with the held-out-OPERATOR train/val split.
+# zarr_processed_path, so the filter keys on '/mecka/freeform/'), stored under
+# the human_bimanual embodiment, with the held-out-OPERATOR train/val split.
 #
-# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 25 operators held out ENTIRELY, so no
-# val episode shares an operator with training. Chosen deterministically on
-# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
-# skip the 10 largest operators (their data stays in train), seeded shuffle
-# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
-# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
-# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
-# mode: total (no random episode split); the lists ARE the split.
+# DATASET v2 (Aidan, 2026-09-01): every freeform task whose NAME contains a
+# fold_clothes derivative — 'fold' AND 'clothes' in the lowercased task name,
+# 'packag*' excluded, non-clothes folding (boxes/paper/napkins/fabric/...)
+# excluded by the 'clothes' requirement. Resolves today to 8 tasks
+# (cleaning_and_folding_clothes, dishwashing_and_folding_clothes, folding_and_bagging_clothes, folding_and_ironing_clothes, folding_and_packing_clothes, folding_clothes, ironing_and_folding_clothes, lint_rolling_and_folding_clothes)
+# = 492 eps / 1,211,002 frames / 11.21 h / 184 operators.
+#
+# OPERATOR SPLIT v2 (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 27 operators held out ENTIRELY, so
+# no val episode shares an operator with training. Same recipe as v1: skip the
+# 10 largest operators, random.Random(42) shuffle of the rest, accumulate
+# until >= 8 % of frames -> 27 operators, 43 episodes, 105,311 frames
+# (8.7 %) held out; train = 157 operators, 449 episodes,
+# 1,105,691 frames. Both sides use mode: total; the lists ARE the split.
 #
 # WRIST-frame cartesian actions with the continuous 6D rotation (18D =
 # xyz+6D per arm, no gripper): each arm's 100-step chunk is expressed
@@ -55,10 +59,10 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
     mode: total
 
 valid_datasets:
@@ -69,10 +73,10 @@ valid_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_6d.yaml
@@ -6,13 +6,14 @@
 # embodiment, with the held-out-OPERATOR train/val split.
 #
 # OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 25 operators held out ENTIRELY, so no
+# identical across them): validation = 31 operators held out ENTIRELY, so no
 # val episode shares an operator with training. Chosen deterministically on
 # 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
 # skip the 10 largest operators (their data stays in train), seeded shuffle
-# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
-# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
-# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 10 %
+# of frames (Aidan: a full 10 %, raised from 8 % the same evening) ->
+# 31 operators, 50 episodes, 115,681 frames (10.2 %) held out;
+# train = 147 operators, 412 episodes, 1,013,220 frames. Both sides use
 # mode: total (no random episode split); the lists ARE the split.
 #
 # WRIST-frame cartesian actions with the continuous 6D rotation (18D =
@@ -58,7 +59,7 @@ train_datasets:
         - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '693c78165cb6c2828a4c2087', '694604945c0479a0fb7f48a4', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '6973c3ae89fa4bc311d1bbe5', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6992b19ab9d55c9c2d48432c', '699429e18ef0252970048624', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287'}"
     mode: total
 
 valid_datasets:
@@ -72,7 +73,7 @@ valid_datasets:
         - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '693c78165cb6c2828a4c2087', '694604945c0479a0fb7f48a4', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '6973c3ae89fa4bc311d1bbe5', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6992b19ab9d55c9c2d48432c', '699429e18ef0252970048624', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
@@ -1,0 +1,101 @@
+# MECKA_FOLD_FREEFORM_OPSPLIT_PI_CAM6D — pi0.5 BC on the mecka FREEFORM fold-clothes
+# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
+# processed_v3/mecka/freeform/; "freeform" is only visible in
+# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
+# either fold-clothes task spelling), stored under the human_bimanual
+# embodiment, with the held-out-OPERATOR train/val split.
+#
+# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 25 operators held out ENTIRELY, so no
+# val episode shares an operator with training. Chosen deterministically on
+# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
+# skip the 10 largest operators (their data stays in train), seeded shuffle
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
+# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
+# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# mode: total (no random episode split); the lists ARE the split.
+#
+# CAM (head)-frame cartesian actions with the continuous 6D rotation (18D =
+# xyz+6D per arm, no gripper): chunks and proprio ee_pose expressed relative
+# to obs_head_pose. Pairs with model=pi0.5_bc_mecka_6d.
+#
+# Shared pipeline knobs (same as mecka_all_pi_6d): fix_mecka_left_wrist
+# (processed_v3 mecka zarrs have the LEFT wrist frame double-mirrored;
+# Rz(180°)-corrected before any frame math), pad_proprio_gripper (18 -> 20-dim
+# proprio so the State: prompt bins align with the robot layout), stride 1,
+# prompts from the `annotations` track. Pairs with evaluator=eval_pi_camframe_6d
+# (+ `+evaluator@train_viz_evaluator=train_viz_pi_camframe_6d`). Twins: mecka_fold_freeform_opsplit_pi_6d (wrist frame), mecka_fold_freeform_opsplit_pi_keypoints (keypoint action).
+#
+# Norm stats: precompute on a CPU node (scripts/norm_fold_freeform_opsplit_cam6d.sbatch) and point
+# training at norm_stats.precomputed_norm_path=<out>/norm_stats.
+#
+# folder_path: shared PACE mirror of processed_v3; all 462 episodes present.
+
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+train_datasets:
+  human_bimanual:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Human.get_keymap
+        # "_pi" suffix -> PaliGemma-style camera name (base_0_rgb).
+        keymap_mode: cartesian_pi
+        annotation_key: annotations
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Human.get_transform_list
+        mode: cartesian_6d
+        stride: 1
+        fix_mecka_left_wrist: true
+        pad_proprio_gripper: true
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
+        # OPERATOR SPLIT — train = every operator NOT in the held-out set.
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+    mode: total
+
+valid_datasets:
+  human_bimanual:
+    _target_: ${...train_datasets.human_bimanual._target_}
+    resolver: ${...train_datasets.human_bimanual.resolver}
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
+        # OPERATOR SPLIT — valid = the 25 held-out operators only.
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+    mode: total
+
+# Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,
+# videos_train_viz/): same operators as train, no shuffle -> same slice every val.
+train_viz_datasets:
+  human_bimanual:
+    _target_: ${...train_datasets.human_bimanual._target_}
+    resolver: ${...train_datasets.human_bimanual.resolver}
+    filters: ${...train_datasets.human_bimanual.filters}
+    mode: total
+
+train_viz_dataloader_params:
+  human_bimanual:
+    batch_size: 32
+    num_workers: 2
+    shuffle: false
+
+train_dataloader_params:
+  human_bimanual:
+    batch_size: 64
+    num_workers: 8
+
+valid_dataloader_params:
+  human_bimanual:
+    batch_size: 64
+    num_workers: 8
+    shuffle: false

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
@@ -6,13 +6,14 @@
 # embodiment, with the held-out-OPERATOR train/val split.
 #
 # OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 25 operators held out ENTIRELY, so no
+# identical across them): validation = 31 operators held out ENTIRELY, so no
 # val episode shares an operator with training. Chosen deterministically on
 # 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
 # skip the 10 largest operators (their data stays in train), seeded shuffle
-# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
-# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
-# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 10 %
+# of frames (Aidan: a full 10 %, raised from 8 % the same evening) ->
+# 31 operators, 50 episodes, 115,681 frames (10.2 %) held out;
+# train = 147 operators, 412 episodes, 1,013,220 frames. Both sides use
 # mode: total (no random episode split); the lists ARE the split.
 #
 # CAM (head)-frame cartesian actions with the continuous 6D rotation (18D =
@@ -57,7 +58,7 @@ train_datasets:
         - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '693c78165cb6c2828a4c2087', '694604945c0479a0fb7f48a4', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '6973c3ae89fa4bc311d1bbe5', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6992b19ab9d55c9c2d48432c', '699429e18ef0252970048624', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287'}"
     mode: total
 
 valid_datasets:
@@ -71,7 +72,7 @@ valid_datasets:
         - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '693c78165cb6c2828a4c2087', '694604945c0479a0fb7f48a4', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '6973c3ae89fa4bc311d1bbe5', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6992b19ab9d55c9c2d48432c', '699429e18ef0252970048624', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
@@ -1,23 +1,19 @@
 # MECKA_FOLD_FREEFORM_OPSPLIT_PI_CAM6D — pi0.5 BC on the mecka FREEFORM fold-clothes
-# episodes (fold_clothes-derivative task names, 492 eps / 11.21 h under
+# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
 # processed_v3/mecka/freeform/; "freeform" is only visible in
-# zarr_processed_path, so the filter keys on '/mecka/freeform/'), stored under
-# the human_bimanual embodiment, with the held-out-OPERATOR train/val split.
+# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
+# either fold-clothes task spelling), stored under the human_bimanual
+# embodiment, with the held-out-OPERATOR train/val split.
 #
-# DATASET v2 (Aidan, 2026-09-01): every freeform task whose NAME contains a
-# fold_clothes derivative — 'fold' AND 'clothes' in the lowercased task name,
-# 'packag*' excluded, non-clothes folding (boxes/paper/napkins/fabric/...)
-# excluded by the 'clothes' requirement. Resolves today to 8 tasks
-# (cleaning_and_folding_clothes, dishwashing_and_folding_clothes, folding_and_bagging_clothes, folding_and_ironing_clothes, folding_and_packing_clothes, folding_clothes, ironing_and_folding_clothes, lint_rolling_and_folding_clothes)
-# = 492 eps / 1,211,002 frames / 11.21 h / 184 operators.
-#
-# OPERATOR SPLIT v2 (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 27 operators held out ENTIRELY, so
-# no val episode shares an operator with training. Same recipe as v1: skip the
-# 10 largest operators, random.Random(42) shuffle of the rest, accumulate
-# until >= 8 % of frames -> 27 operators, 43 episodes, 105,311 frames
-# (8.7 %) held out; train = 157 operators, 449 episodes,
-# 1,105,691 frames. Both sides use mode: total; the lists ARE the split.
+# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 25 operators held out ENTIRELY, so no
+# val episode shares an operator with training. Chosen deterministically on
+# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
+# skip the 10 largest operators (their data stays in train), seeded shuffle
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
+# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
+# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# mode: total (no random episode split); the lists ARE the split.
 #
 # CAM (head)-frame cartesian actions with the continuous 6D rotation (18D =
 # xyz+6D per arm, no gripper): chunks and proprio ee_pose expressed relative
@@ -58,10 +54,10 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
     mode: total
 
 valid_datasets:
@@ -72,10 +68,10 @@ valid_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_cam6d.yaml
@@ -1,19 +1,23 @@
 # MECKA_FOLD_FREEFORM_OPSPLIT_PI_CAM6D — pi0.5 BC on the mecka FREEFORM fold-clothes
-# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
+# episodes (fold_clothes-derivative task names, 492 eps / 11.21 h under
 # processed_v3/mecka/freeform/; "freeform" is only visible in
-# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
-# either fold-clothes task spelling), stored under the human_bimanual
-# embodiment, with the held-out-OPERATOR train/val split.
+# zarr_processed_path, so the filter keys on '/mecka/freeform/'), stored under
+# the human_bimanual embodiment, with the held-out-OPERATOR train/val split.
 #
-# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 25 operators held out ENTIRELY, so no
-# val episode shares an operator with training. Chosen deterministically on
-# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
-# skip the 10 largest operators (their data stays in train), seeded shuffle
-# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
-# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
-# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
-# mode: total (no random episode split); the lists ARE the split.
+# DATASET v2 (Aidan, 2026-09-01): every freeform task whose NAME contains a
+# fold_clothes derivative — 'fold' AND 'clothes' in the lowercased task name,
+# 'packag*' excluded, non-clothes folding (boxes/paper/napkins/fabric/...)
+# excluded by the 'clothes' requirement. Resolves today to 8 tasks
+# (cleaning_and_folding_clothes, dishwashing_and_folding_clothes, folding_and_bagging_clothes, folding_and_ironing_clothes, folding_and_packing_clothes, folding_clothes, ironing_and_folding_clothes, lint_rolling_and_folding_clothes)
+# = 492 eps / 1,211,002 frames / 11.21 h / 184 operators.
+#
+# OPERATOR SPLIT v2 (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 27 operators held out ENTIRELY, so
+# no val episode shares an operator with training. Same recipe as v1: skip the
+# 10 largest operators, random.Random(42) shuffle of the rest, accumulate
+# until >= 8 % of frames -> 27 operators, 43 episodes, 105,311 frames
+# (8.7 %) held out; train = 157 operators, 449 episodes,
+# 1,105,691 frames. Both sides use mode: total; the lists ARE the split.
 #
 # CAM (head)-frame cartesian actions with the continuous 6D rotation (18D =
 # xyz+6D per arm, no gripper): chunks and proprio ee_pose expressed relative
@@ -54,10 +58,10 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
     mode: total
 
 valid_datasets:
@@ -68,10 +72,10 @@ valid_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
@@ -1,23 +1,19 @@
 # MECKA_FOLD_FREEFORM_OPSPLIT_PI_KEYPOINTS — pi0.5 BC on the mecka FREEFORM fold-clothes
-# episodes (fold_clothes-derivative task names, 492 eps / 11.21 h under
+# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
 # processed_v3/mecka/freeform/; "freeform" is only visible in
-# zarr_processed_path, so the filter keys on '/mecka/freeform/'), stored under
-# the human_bimanual embodiment, with the held-out-OPERATOR train/val split.
+# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
+# either fold-clothes task spelling), stored under the human_bimanual
+# embodiment, with the held-out-OPERATOR train/val split.
 #
-# DATASET v2 (Aidan, 2026-09-01): every freeform task whose NAME contains a
-# fold_clothes derivative — 'fold' AND 'clothes' in the lowercased task name,
-# 'packag*' excluded, non-clothes folding (boxes/paper/napkins/fabric/...)
-# excluded by the 'clothes' requirement. Resolves today to 8 tasks
-# (cleaning_and_folding_clothes, dishwashing_and_folding_clothes, folding_and_bagging_clothes, folding_and_ironing_clothes, folding_and_packing_clothes, folding_clothes, ironing_and_folding_clothes, lint_rolling_and_folding_clothes)
-# = 492 eps / 1,211,002 frames / 11.21 h / 184 operators.
-#
-# OPERATOR SPLIT v2 (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 27 operators held out ENTIRELY, so
-# no val episode shares an operator with training. Same recipe as v1: skip the
-# 10 largest operators, random.Random(42) shuffle of the rest, accumulate
-# until >= 8 % of frames -> 27 operators, 43 episodes, 105,311 frames
-# (8.7 %) held out; train = 157 operators, 449 episodes,
-# 1,105,691 frames. Both sides use mode: total; the lists ARE the split.
+# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 25 operators held out ENTIRELY, so no
+# val episode shares an operator with training. Chosen deterministically on
+# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
+# skip the 10 largest operators (their data stays in train), seeded shuffle
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
+# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
+# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# mode: total (no random episode split); the lists ARE the split.
 #
 # KEYPOINT actions in WRIST frame: 138-D wrist-first `actions_keypoints` =
 # per hand [wrist pose in its own current wrist frame (xyz+ypr, 6) | 21 MANO
@@ -69,10 +65,10 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
     mode: total
 
 valid_datasets:
@@ -83,10 +79,10 @@ valid_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
@@ -1,0 +1,112 @@
+# MECKA_FOLD_FREEFORM_OPSPLIT_PI_KEYPOINTS — pi0.5 BC on the mecka FREEFORM fold-clothes
+# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
+# processed_v3/mecka/freeform/; "freeform" is only visible in
+# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
+# either fold-clothes task spelling), stored under the human_bimanual
+# embodiment, with the held-out-OPERATOR train/val split.
+#
+# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 25 operators held out ENTIRELY, so no
+# val episode shares an operator with training. Chosen deterministically on
+# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
+# skip the 10 largest operators (their data stays in train), seeded shuffle
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
+# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
+# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# mode: total (no random episode split); the lists ARE the split.
+#
+# KEYPOINT actions in WRIST frame: 138-D wrist-first `actions_keypoints` =
+# per hand [wrist pose in its own current wrist frame (xyz+ypr, 6) | 21 MANO
+# keypoints in that wrist frame (63)] x {left, right}, 100-step chunks.
+# The `keypoints_wristframe_pi` transform ALSO builds the cartesian runs'
+# head-frame palm-origin `observations.state.ee_pose` (left-wrist fix, 6D,
+# grip-padded to 20) as the prompt proprio, so this run shares its prompt /
+# proprio with the cartesian twins and differs only in the action space.
+# Pairs with model=pi0.5_bc_mecka_keypoints (action_dim 140 = 138 + 2 pad).
+#
+# Shared pipeline knobs (same as mecka_all_pi_6d): fix_mecka_left_wrist
+# (processed_v3 mecka zarrs have the LEFT wrist frame double-mirrored;
+# Rz(180°)-corrected before any frame math), pad_proprio_gripper (18 -> 20-dim
+# proprio so the State: prompt bins align with the robot layout), stride 1,
+# prompts from the `annotations` track. Pairs with evaluator=eval_pi_keypoints_wristframe
+# (+ `+evaluator@train_viz_evaluator=train_viz_pi_keypoints_wristframe`). Twins: mecka_fold_freeform_opsplit_pi_6d (wrist-frame cartesian), mecka_fold_freeform_opsplit_pi_cam6d (cam-frame cartesian).
+# Also in the batch: `observations.state.keypoints` (138-D: wrist pose in head
+# frame + keypoints in wrist frame, per hand) — consumed by the eval revert
+# (wrist -> head frame), NOT binned into the prompt (proprio_keys_for_prompt
+# on the model config keeps the prompt to the 20-D ee_pose).
+#
+# Norm stats: precompute on a CPU node (scripts/norm_fold_freeform_opsplit_kp.sbatch) and point
+# training at norm_stats.precomputed_norm_path=<out>/norm_stats.
+#
+# folder_path: shared PACE mirror of processed_v3; all 462 episodes present.
+
+_target_: egomimic.pl_utils.pl_data_utils.MultiDataModuleWrapper
+
+train_datasets:
+  human_bimanual:
+    _target_: egomimic.rldb.zarr.zarr_dataset_multi.MultiDataset._from_resolver
+    resolver:
+      _target_: egomimic.rldb.zarr.zarr_dataset_multi.S3EpisodeResolver
+      folder_path: /storage/project/r-dxu345-0/shared/egoverseS3ZarrDatasets
+      key_map:
+        _target_: egomimic.rldb.embodiment.human.Human.get_keymap
+        # "_pi" suffix -> PaliGemma-style camera name (base_0_rgb).
+        keymap_mode: keypoints_pi
+        annotation_key: annotations
+        # keypoints keymap + the ee_pose keys the transform needs for the prompt proprio
+        include_ee_pose: true
+      transform_list:
+        _target_: egomimic.rldb.embodiment.human.Human.get_transform_list
+        mode: keypoints_wristframe_pi
+        stride: 1
+        fix_mecka_left_wrist: true
+        pad_proprio_gripper: true
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
+        # OPERATOR SPLIT — train = every operator NOT in the held-out set.
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+    mode: total
+
+valid_datasets:
+  human_bimanual:
+    _target_: ${...train_datasets.human_bimanual._target_}
+    resolver: ${...train_datasets.human_bimanual.resolver}
+    filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
+        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
+        # OPERATOR SPLIT — valid = the 25 held-out operators only.
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+    mode: total
+
+# Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,
+# videos_train_viz/): same operators as train, no shuffle -> same slice every val.
+train_viz_datasets:
+  human_bimanual:
+    _target_: ${...train_datasets.human_bimanual._target_}
+    resolver: ${...train_datasets.human_bimanual.resolver}
+    filters: ${...train_datasets.human_bimanual.filters}
+    mode: total
+
+train_viz_dataloader_params:
+  human_bimanual:
+    batch_size: 32
+    num_workers: 2
+    shuffle: false
+
+train_dataloader_params:
+  human_bimanual:
+    batch_size: 64
+    num_workers: 8
+
+valid_dataloader_params:
+  human_bimanual:
+    batch_size: 64
+    num_workers: 8
+    shuffle: false

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
@@ -1,19 +1,23 @@
 # MECKA_FOLD_FREEFORM_OPSPLIT_PI_KEYPOINTS — pi0.5 BC on the mecka FREEFORM fold-clothes
-# episodes (SQL task='folding_clothes', 462 eps / 1.13M frames under
+# episodes (fold_clothes-derivative task names, 492 eps / 11.21 h under
 # processed_v3/mecka/freeform/; "freeform" is only visible in
-# zarr_processed_path, so the filter keys on '/mecka/freeform/' and accepts
-# either fold-clothes task spelling), stored under the human_bimanual
-# embodiment, with the held-out-OPERATOR train/val split.
+# zarr_processed_path, so the filter keys on '/mecka/freeform/'), stored under
+# the human_bimanual embodiment, with the held-out-OPERATOR train/val split.
 #
-# OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 25 operators held out ENTIRELY, so no
-# val episode shares an operator with training. Chosen deterministically on
-# 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
-# skip the 10 largest operators (their data stays in train), seeded shuffle
-# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
-# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
-# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
-# mode: total (no random episode split); the lists ARE the split.
+# DATASET v2 (Aidan, 2026-09-01): every freeform task whose NAME contains a
+# fold_clothes derivative — 'fold' AND 'clothes' in the lowercased task name,
+# 'packag*' excluded, non-clothes folding (boxes/paper/napkins/fabric/...)
+# excluded by the 'clothes' requirement. Resolves today to 8 tasks
+# (cleaning_and_folding_clothes, dishwashing_and_folding_clothes, folding_and_bagging_clothes, folding_and_ironing_clothes, folding_and_packing_clothes, folding_clothes, ironing_and_folding_clothes, lint_rolling_and_folding_clothes)
+# = 492 eps / 1,211,002 frames / 11.21 h / 184 operators.
+#
+# OPERATOR SPLIT v2 (shared by every *_opsplit_* config — keep the lists byte-
+# identical across them): validation = 27 operators held out ENTIRELY, so
+# no val episode shares an operator with training. Same recipe as v1: skip the
+# 10 largest operators, random.Random(42) shuffle of the rest, accumulate
+# until >= 8 % of frames -> 27 operators, 43 episodes, 105,311 frames
+# (8.7 %) held out; train = 157 operators, 449 episodes,
+# 1,105,691 frames. Both sides use mode: total; the lists ARE the split.
 #
 # KEYPOINT actions in WRIST frame: 138-D wrist-first `actions_keypoints` =
 # per hand [wrist pose in its own current wrist frame (xyz+ypr, 6) | 21 MANO
@@ -65,10 +69,10 @@ train_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
     mode: total
 
 valid_datasets:
@@ -79,10 +83,10 @@ valid_datasets:
       _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: str(row.get('lab', '')).lower() == 'mecka'"
-        - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
+        - "lambda row: (lambda t: ('fold' in t) and ('clothes' in t) and ('packag' not in t))(str(row.get('task', '')).lower())"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) in {'68dfa6f8c33a1abcb8fc3b9e', '6931020e6e496b45b1e149e7', '693b9530c67c9e4814b20ab2', '6943d2ada2a8b5aee76632f9', '694911c05c0479a0fb834ccb', '6954f57320b100982d8134b8', '695d0b0983a9fdf2d84d9fc8', '6961c50f83a9fdf2d85ec95d', '6961ea0983a9fdf2d85f103c', '6964eced83a9fdf2d866a2d9', '6968e698567cdf8c87361404', '698021997c6b5a6b3c8b7367', '698daed99c7041a3a331d2e5', '6995a2c20f66510c389aec76', '699a5eab6fe91711a3b1c9bf', '699a63ba6fe91711a3b1cf8b', '699ba5ed6fe91711a3b368ba', '699e57006fe91711a3b74b88', '699f2e580aa6425a245d2e6f', '69a13ebca685e8b8b57a6e4a', '69a39ec9c4216c3e3ce49734', '69a4c3afc4216c3e3ce57305', '69a64691e72179bdc05f5df6', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287', '69ae24a6d22d99655253f2ba'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
+++ b/egomimic/hydra_configs/data/mecka_fold_freeform_opsplit_pi_keypoints.yaml
@@ -6,13 +6,14 @@
 # embodiment, with the held-out-OPERATOR train/val split.
 #
 # OPERATOR SPLIT (shared by every *_opsplit_* config — keep the lists byte-
-# identical across them): validation = 25 operators held out ENTIRELY, so no
+# identical across them): validation = 31 operators held out ENTIRELY, so no
 # val episode shares an operator with training. Chosen deterministically on
 # 2026-09-01 from SQL app.episodes (462 freeform fold eps / 178 operators):
 # skip the 10 largest operators (their data stays in train), seeded shuffle
-# (random.Random(42)) of the remaining operator ids, accumulate until >= 8 %
-# of frames -> 25 operators, 39 episodes, 91,550 frames (8.1 %) held out;
-# train = 153 operators, 423 episodes, 1,037,351 frames. Both sides use
+# (random.Random(42)) of the remaining operator ids, accumulate until >= 10 %
+# of frames (Aidan: a full 10 %, raised from 8 % the same evening) ->
+# 31 operators, 50 episodes, 115,681 frames (10.2 %) held out;
+# train = 147 operators, 412 episodes, 1,013,220 frames. Both sides use
 # mode: total (no random episode split); the lists ARE the split.
 #
 # KEYPOINT actions in WRIST frame: 138-D wrist-first `actions_keypoints` =
@@ -68,7 +69,7 @@ train_datasets:
         - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — train = every operator NOT in the held-out set.
-        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) not in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '693c78165cb6c2828a4c2087', '694604945c0479a0fb7f48a4', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '6973c3ae89fa4bc311d1bbe5', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6992b19ab9d55c9c2d48432c', '699429e18ef0252970048624', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287'}"
     mode: total
 
 valid_datasets:
@@ -82,7 +83,7 @@ valid_datasets:
         - "lambda row: str(row.get('task', '')).lower() in ('folding_clothes', 'fold_clothes')"
         - "lambda row: '/mecka/freeform/' in str(row.get('zarr_processed_path', ''))"
         # OPERATOR SPLIT — valid = the 25 held-out operators only.
-        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36'}"
+        - "lambda row: str(row.get('operator', '')) in {'68a8e70d1ffcf0417e08f0e5', '68e2fc680b158ea94ab4f5bc', '6930bf8a6e496b45b1e1122e', '6931784c6e496b45b1e1b1cd', '693a399ec67c9e4814b0c09f', '693b9530c67c9e4814b20ab2', '693c78165cb6c2828a4c2087', '694604945c0479a0fb7f48a4', '6948d23b5c0479a0fb8302b3', '69529a85c0d9448524bc7880', '6954f0b720b100982d812ed8', '6957464720b100982d83b76c', '695d07d783a9fdf2d84d9371', '695d084183a9fdf2d84d955a', '6961c50f83a9fdf2d85ec95d', '69624a8683a9fdf2d86013c0', '6973c3ae89fa4bc311d1bbe5', '69842643f8ca4464d9920799', '698937a5f8ca4464d99dce94', '6992b19ab9d55c9c2d48432c', '699429e18ef0252970048624', '6996d5eded1708063b2fe419', '6999d17c8f173e14271f9890', '69a24256c4216c3e3ce33834', '69a39ec9c4216c3e3ce49734', '69a57a78c4216c3e3ce6323c', '69a725a347e12c9b3390ba33', '69a7943547e12c9b33911c02', '69a84eed47e12c9b339208fd', '69ab87207bf9cbce29a3cb36', '69ae2463d22d99655253f287'}"
     mode: total
 
 # Train-set spot check for the TrainVizEvalVideo head (train_viz/ metrics,

--- a/egomimic/hydra_configs/evaluator/eval_pi_keypoints_palm.yaml
+++ b/egomimic/hydra_configs/evaluator/eval_pi_keypoints_palm.yaml
@@ -1,0 +1,20 @@
+# Offline / eval-only evaluator for the keypoint-action runs: everything
+# eval_pi_keypoints_wristframe computes, plus the palm-origin cam-frame MSE
+# derived from the reverted 21 keypoints with the mecka ee_pose definition
+# (centroid of MANO 0, 5, 9, 13, 17), so the run can be compared to the
+# cartesian runs' cam_xyz metric on the same target. Metrics only (no viz).
+defaults:
+  - viz@viz_func: pi_keypoints_lang_wrist
+  - _self_
+
+_target_: egomimic.eval.eval_pi_palm.PIEvalKeypointPalm
+
+viz_every_n_epochs: 1000000
+viz_max_batches: 0
+palm_idx: [0, 5, 9, 13, 17]
+save_dir: ${hydra:runtime.output_dir}/palm_eval
+
+transform_lists:
+  human_bimanual:
+    _target_: egomimic.rldb.embodiment.human._build_human_keypoints_revert_eef_frame_transform_list
+    is_quat: false

--- a/egomimic/hydra_configs/evaluator/eval_pi_keypoints_wristframe.yaml
+++ b/egomimic/hydra_configs/evaluator/eval_pi_keypoints_wristframe.yaml
@@ -1,0 +1,26 @@
+defaults:
+  - viz@viz_func: pi_keypoints_lang_wrist
+  - _self_
+
+_target_: egomimic.eval.eval_pi.PIEvalVideo
+
+# Render the val viz video only when (current_epoch + 1) is a multiple of
+# this (see eval_pi.yaml).
+viz_every_n_epochs: 100
+# Same render cap as eval_pi_wristframe_6d; the train_viz wrapper inherits it.
+viz_max_batches: 10
+
+# Wrist-frame KEYPOINT variant: use with a data config that applies the
+# `keypoints_wristframe_pi` (or keypoints_wristframe_ypr) transform mode. The
+# model predicts the 138-D wrist-first action [wrist pose (6) | 21 keypoints
+# (63)] x 2 in each hand's wrist frame; the revert projects the two 63-D
+# keypoint chunks back to head (camera) frame via the head-frame wrist pose in
+# `observations.state.keypoints`, giving a 126-D head-frame `actions_keypoints`
+# for the cam-frame keypoint MSE and the overlay video (the 6-D wrist slices
+# are consumed by the revert, not scored separately). Native-frame metrics
+# (paired/final MSE, Frechet, DTW, reverse-KL family) run on the full 138-D.
+# The xyz/ypr split and geodesic-rotation metrics are skipped (unknown width).
+transform_lists:
+  human_bimanual:
+    _target_: egomimic.rldb.embodiment.human._build_human_keypoints_revert_eef_frame_transform_list
+    is_quat: false

--- a/egomimic/hydra_configs/evaluator/train_viz_pi_keypoints_wristframe.yaml
+++ b/egomimic/hydra_configs/evaluator/train_viz_pi_keypoints_wristframe.yaml
@@ -1,0 +1,15 @@
+# Keypoint twin of train_viz_pi_wristframe_6d: wraps eval_pi_keypoints_wristframe
+# so the same forward/metric/viz logic runs a second time against the
+# `train_viz` dataloader (metrics `train_viz/`, videos `videos_train_viz/`).
+# The M-sample (reverse-KL) metrics are forced off for this pass.
+#
+# Enable via `+evaluator@train_viz_evaluator=train_viz_pi_keypoints_wristframe`
+# with a data config that defines `train_viz_datasets`.
+
+defaults:
+  - /evaluator@base: eval_pi_keypoints_wristframe
+  - _self_
+
+_target_: egomimic.eval.eval_train_viz.TrainVizEvalVideo
+
+limit_val_batches: 50

--- a/egomimic/hydra_configs/evaluator/viz/pi_keypoints_lang_wrist.yaml
+++ b/egomimic/hydra_configs/evaluator/viz/pi_keypoints_lang_wrist.yaml
@@ -1,0 +1,9 @@
+# Keypoint twin of pi_cartesian_lang_wrist: MANO keypoint overlay on the pi
+# camera key with the sampled prompt drawn on the frame.
+defaults:
+  - keypoints_wrist
+  - _self_
+
+human_bimanual:
+  image_key: base_0_rgb
+  annotation_key: sampled_prompt

--- a/egomimic/hydra_configs/model/pi0.5_bc_mecka_keypoints.yaml
+++ b/egomimic/hydra_configs/model/pi0.5_bc_mecka_keypoints.yaml
@@ -1,0 +1,44 @@
+defaults:
+  - pi0.5_base
+  - _self_
+
+# pi0.5 BC on mecka data with the 138-D wrist-first MANO KEYPOINT action
+# (per hand: wrist xyz+ypr in its own wrist frame (6) + 21 keypoints in that
+# wrist frame (63); see Human.get_transform_list("keypoints_wristframe_pi")).
+# The vendored openpi PyTorch port hard-codes 32-wide action projections, so
+# PI re-initializes action_in_proj / action_out_proj at `action_dim` after
+# the strict base-weight load (everything else is the pi05 base). 140 =
+# 138 + 2 zero pad (headroom for eva's two grip slots in a later cotrain).
+# Encoding is `legacy_normalized_ypr_rot6d`: the batch action is already
+# quantile-normalized by norm_stats and the converter is a pure pad/slice —
+# no rotation math in the model (the 6 wrist-ypr dims stay ypr; in wrist
+# frame they are near zero, far from the +-pi wrap).
+# Pairs with data=mecka_fold_freeform_opsplit_pi_keypoints and
+# evaluator=eval_pi_keypoints_wristframe.
+robomimic_model:
+  camera_transforms: {}
+  config:
+    # Same M-sample val metrics as the cartesian twins.
+    reverse_kl_samples: 4
+    model:
+      action_dim: 140
+  ac_keys:
+    human_bimanual: "actions_keypoints"
+  domains: ["human_bimanual"]
+
+  action_encoding: "legacy_normalized_ypr_rot6d"
+  # Same prompt as pi0.5_bc_mecka_6d: "State: <bins>" from the 20-D head-frame
+  # ee_pose only (the 138-D keypoint proprio would blow the 128-token budget);
+  # no "Embodiment:" block.
+  proprio_keys_for_prompt: ["observations.state.ee_pose"]
+  embodiment_label: false
+
+  action_converters:
+    rules:
+      HUMAN_BIMANUAL:
+        _target_: egomimic.utils.action_utils.HumanBimanualKeypoints
+        action_dim: 140
+        native_dim: 138
+    # optional fallback if no match is found
+    fallback:
+      _target_: egomimic.utils.action_utils.BaseActionConverter

--- a/egomimic/rldb/embodiment/human.py
+++ b/egomimic/rldb/embodiment/human.py
@@ -228,6 +228,7 @@ class Human(Embodiment):
         has_head_pose: bool = True,
         include_aria_keypoints: bool = False,
         include_grip_keypoints: bool = False,
+        include_ee_pose: bool = False,
         norm_mode: bool = False,
         annotation_key: str = None,
         high_annotation_key=None,
@@ -243,6 +244,7 @@ class Human(Embodiment):
             has_head_pose=has_head_pose,
             include_aria_keypoints=include_aria_keypoints,
             include_grip_keypoints=include_grip_keypoints,
+            include_ee_pose=include_ee_pose,
         )
         if annotation_key is not None and not norm_mode:
             key_map[annotation_key] = {
@@ -275,6 +277,7 @@ class Human(Embodiment):
         has_head_pose: bool = True,
         include_aria_keypoints: bool = False,
         include_grip_keypoints: bool = False,
+        include_ee_pose: bool = False,
     ):
         """Canonical MANO keymap. A ``_pi`` suffix swaps the front image key to
         ``PI_FRONT_KEY``; ``include_aria_keypoints`` additionally exposes the raw
@@ -368,6 +371,23 @@ class Human(Embodiment):
                     "zarr_key": "right.obs_wrist_pose",
                 },
             }
+            if include_ee_pose:
+                # Palm-origin ee_pose alongside the keypoints: lets the
+                # ``keypoints_wristframe_pi`` transform build the SAME
+                # head-frame ``observations.state.ee_pose`` proprio the
+                # cartesian pi runs put in the prompt (left-wrist fix, 6D,
+                # grip-padded), so a keypoint-action run differs from them
+                # only in the action space.
+                for side in ("left", "right"):
+                    key_map[f"{side}.action_ee_pose"] = {
+                        "key_type": "action_keys",
+                        "zarr_key": f"{side}.obs_ee_pose",
+                        "horizon": horizon,
+                    }
+                    key_map[f"{side}.obs_ee_pose"] = {
+                        "key_type": "proprio_keys",
+                        "zarr_key": f"{side}.obs_ee_pose",
+                    }
             if include_aria_keypoints:
                 # Raw Aria-layout keypoints exposed alongside the canonical MANO
                 # ones (proprio, no horizon: no transform consumes them).
@@ -402,6 +422,7 @@ class Human(Embodiment):
             "keypoints_headframe_quat",
             "keypoints_wristframe_ypr",
             "keypoints_wristframe_quat",
+            "keypoints_wristframe_pi",
         ],
         stride: int = 3,
         fix_mecka_left_wrist: bool = False,
@@ -456,7 +477,7 @@ class Human(Embodiment):
 
         prefix: list[Transform] = list(grip_prefix)
         if fix_mecka_left_wrist:
-            if mode.startswith("keypoints"):
+            if mode.startswith("keypoints") and mode != "keypoints_wristframe_pi":
                 raise ValueError(
                     "fix_mecka_left_wrist only applies to cartesian modes "
                     "(keypoints modes never read the constructed wrist pose)"
@@ -522,6 +543,33 @@ class Human(Embodiment):
                     else []
                 )
                 + grip_suffix
+            )
+        if mode == "keypoints_wristframe_pi":
+            # pi0.5 keypoint-action recipe: the 138-D wrist-first wrist-frame
+            # keypoint action (exactly ``keypoints_wristframe_ypr``) PLUS the
+            # cartesian pipeline's head-frame palm-origin
+            # ``observations.state.ee_pose`` (left-wrist fix via ``prefix``,
+            # 6D-encoded, grip-padded like ``cartesian_6d``) as the prompt
+            # proprio, so the run shares its prompt / proprio with the
+            # cartesian pi runs and differs only in the action space. The
+            # cartesian builder keeps ``obs_head_pose`` alive for the keypoint
+            # builder (delete_target_world=False); its ``actions_cartesian``
+            # by-product is dropped.
+            return (
+                prefix
+                + _build_human_cartesian_bimanual_transform_list(
+                    stride=stride, delete_target_world=False
+                )
+                + [CartesianYPRToRot6D(action_key="observations.state.ee_pose")]
+                + (
+                    [PadGripperZeros(action_key="observations.state.ee_pose")]
+                    if pad_proprio_gripper
+                    else []
+                )
+                + [DeleteKeys(keys_to_delete=["actions_cartesian"])]
+                + _build_human_keypoints_eef_frame_transform_list(
+                    stride=stride, is_quat=False
+                )
             )
         if mode == "keypoints_headframe_ypr":
             return _build_human_keypoints_bimanual_transform_list(

--- a/egomimic/scripts/eval_cart_ep.sbatch
+++ b/egomimic/scripts/eval_cart_ep.sbatch
@@ -28,6 +28,12 @@ export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
 export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
 if grep -q api.wandb.ai ~/.netrc 2>/dev/null; then export WANDB_MODE=online; else export WANDB_MODE=offline; fi
 export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+# Private compile caches: two same-user jobs autotuning on one node with the
+# shared /tmp/torchinductor_agao81 raced and both died in a compile-worker
+# subprocess (2026-09-02, jobs 12752435/36 on atl1-1-03-020-18-0).
+export TORCHINDUCTOR_CACHE_DIR="${TMPDIR:-/tmp}/torchinductor_${USER}_${SLURM_JOB_ID}"
+export TRITON_CACHE_DIR="${TMPDIR:-/tmp}/triton_${USER}_${SLURM_JOB_ID}"
+mkdir -p "$TORCHINDUCTOR_CACHE_DIR" "$TRITON_CACHE_DIR"
 
 FRAME="${FRAME:?cam|wrist}"; CKPT="${CKPT:?}"; LABEL="${LABEL:?}"
 if [[ "$FRAME" == "cam" ]]; then DATA=mecka_fold_freeform_opsplit_pi_cam6d; EV=eval_pi_camframe_6d; NORM=cam6d; EXTRA="+evaluator.viz_max_batches=0"

--- a/egomimic/scripts/eval_cart_ep.sbatch
+++ b/egomimic/scripts/eval_cart_ep.sbatch
@@ -1,0 +1,52 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=120G
+#SBATCH -p gpu-h200
+#SBATCH --gres=gpu:h200:1
+#SBATCH --time=01:30:00
+#SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
+#SBATCH --job-name=eval_cart_ep
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/eval_cart_%x_%j.log
+
+# Eval-only pass of a CARTESIAN opsplit checkpoint through the same offline
+# path as eval_palm_kp*.sbatch (1 GPU, 160 val batches, reverse-KL off, no viz),
+# so its cam_xyz_paired_mse_avg can be compared with the keypoint run's
+# offline palm-origin MSE without the offline-vs-in-training discrepancy.
+#   FRAME=cam|wrist  CKPT=<path>  LABEL=<wandb/hydra name>
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+if grep -q api.wandb.ai ~/.netrc 2>/dev/null; then export WANDB_MODE=online; else export WANDB_MODE=offline; fi
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+FRAME="${FRAME:?cam|wrist}"; CKPT="${CKPT:?}"; LABEL="${LABEL:?}"
+if [[ "$FRAME" == "cam" ]]; then DATA=mecka_fold_freeform_opsplit_pi_cam6d; EV=eval_pi_camframe_6d; NORM=cam6d; EXTRA="+evaluator.viz_max_batches=0"
+else DATA=mecka_fold_freeform_opsplit_pi_6d; EV=eval_pi_wristframe_6d; NORM=wrist6d; EXTRA="evaluator.viz_max_batches=0"; fi
+
+echo "[eval] cwd=$(pwd) commit=$(git rev-parse HEAD) frame=$FRAME ckpt=$CKPT"
+"$PY" -u egomimic/trainHydra.py \
+  --config-name=train_zarr_cartesian_pi \
+  data=$DATA model=pi0.5_bc_mecka_6d evaluator=$EV $EXTRA \
+  evaluator.viz_every_n_epochs=1000000 \
+  +evaluator.limit_val_batches=160 \
+  launch_params.gpus_per_node=1 \
+  ++mode=eval \
+  "ckpt_path='$CKPT'" \
+  norm_stats.precomputed_norm_path=/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_$NORM/norm_stats \
+  model.robomimic_model.config.pytorch_weight_path=$REPO/egomimic/algo/pi_checkpoints/pi05_base_pytorch \
+  model.robomimic_model.config.reverse_kl_samples=1 \
+  ~data.train_viz_datasets ~data.train_viz_dataloader_params \
+  "name=$LABEL" description=ep99_valset_160batches \
+  "+logger.wandb.name=$LABEL" \
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+echo "[eval] exit=$?"

--- a/egomimic/scripts/eval_palm_kp49.sbatch
+++ b/egomimic/scripts/eval_palm_kp49.sbatch
@@ -5,9 +5,12 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=120G
-#SBATCH -p gpu-h200,gpu-h100
-#SBATCH --gres=gpu:1
-#SBATCH --time=03:00:00
+# Typed gres: an untyped --gres=gpu:1 over -p gpu-h200,gpu-h100 landed on a
+# V100 node (atl1-1-03-006-35-0) on 2026-09-02 - no bf16, compiled sampler
+# fell back to eager at ~2.6 min/batch.
+#SBATCH -p gpu-h200
+#SBATCH --gres=gpu:h200:1
+#SBATCH --time=01:30:00
 #SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
 #SBATCH --job-name=eval_palm_kp49
 #SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/eval_palm_kp49_%j.log

--- a/egomimic/scripts/eval_palm_kp49.sbatch
+++ b/egomimic/scripts/eval_palm_kp49.sbatch
@@ -1,0 +1,51 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=120G
+#SBATCH -p gpu-h200,gpu-h100
+#SBATCH --gres=gpu:1
+#SBATCH --time=03:00:00
+#SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
+#SBATCH --job-name=eval_palm_kp49
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/eval_palm_kp49_%j.log
+
+# Eval-only pass of the keypoint run's epoch-49 checkpoint over the held-out-
+# operator validation set (160 batches x 64, the same slice the training val
+# sees across its 2 ranks): standard keypoint metrics + palm-origin cam-frame
+# MSE (eval_pi_keypoints_palm), reverse-KL sampling off to halve the cost.
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+if grep -q api.wandb.ai ~/.netrc 2>/dev/null; then export WANDB_MODE=online; else export WANDB_MODE=offline; fi
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+CKPT="${CKPT-/storage/project/r-dxu345-0/agao81/EgoVerse/logs/keypoints_fold_clothes_freeform_fit_test_flat5e-5_opsplit/bs64x2_flat5e-5_kp_opsplit_2026-09-02_02-54-36/checkpoints/epoch_epoch=49.ckpt}"
+LABEL="${LABEL-eval_palm_kp49}"
+
+echo "[eval] cwd=$(pwd) commit=$(git rev-parse HEAD) ckpt=$CKPT"
+"$PY" -u egomimic/trainHydra.py \
+  --config-name=train_zarr_cartesian_pi \
+  data=mecka_fold_freeform_opsplit_pi_keypoints \
+  model=pi0.5_bc_mecka_keypoints \
+  evaluator=eval_pi_keypoints_palm \
+  +evaluator.limit_val_batches=160 \
+  launch_params.gpus_per_node=1 \
+  ++mode=eval \
+  "ckpt_path='$CKPT'" \
+  norm_stats.precomputed_norm_path=/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp/norm_stats \
+  model.robomimic_model.config.pytorch_weight_path=$REPO/egomimic/algo/pi_checkpoints/pi05_base_pytorch \
+  model.robomimic_model.config.reverse_kl_samples=1 \
+  ~data.train_viz_datasets ~data.train_viz_dataloader_params \
+  "name=$LABEL" description=ep49_valset_160batches \
+  "+logger.wandb.name=$LABEL" \
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+echo "[eval] exit=$?"

--- a/egomimic/scripts/eval_palm_kp49_h100.sbatch
+++ b/egomimic/scripts/eval_palm_kp49_h100.sbatch
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=120G
+# Typed gres: an untyped --gres=gpu:1 over -p gpu-h200,gpu-h100 landed on a
+# V100 node (atl1-1-03-006-35-0) on 2026-09-02 - no bf16, compiled sampler
+# fell back to eager at ~2.6 min/batch.
+#SBATCH -p gpu-h100
+#SBATCH --gres=gpu:h100:1
+#SBATCH --time=01:30:00
+#SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
+#SBATCH --job-name=eval_palm_kp49_h100
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/eval_palm_kp49_h100_%j.log
+
+# Eval-only pass of the keypoint run's epoch-49 checkpoint over the held-out-
+# operator validation set (160 batches x 64, the same slice the training val
+# sees across its 2 ranks): standard keypoint metrics + palm-origin cam-frame
+# MSE (eval_pi_keypoints_palm), reverse-KL sampling off to halve the cost.
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+if grep -q api.wandb.ai ~/.netrc 2>/dev/null; then export WANDB_MODE=online; else export WANDB_MODE=offline; fi
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+CKPT="${CKPT-/storage/project/r-dxu345-0/agao81/EgoVerse/logs/keypoints_fold_clothes_freeform_fit_test_flat5e-5_opsplit/bs64x2_flat5e-5_kp_opsplit_2026-09-02_02-54-36/checkpoints/epoch_epoch=49.ckpt}"
+LABEL="${LABEL-eval_palm_kp49_h100}"
+
+echo "[eval] cwd=$(pwd) commit=$(git rev-parse HEAD) ckpt=$CKPT"
+"$PY" -u egomimic/trainHydra.py \
+  --config-name=train_zarr_cartesian_pi \
+  data=mecka_fold_freeform_opsplit_pi_keypoints \
+  model=pi0.5_bc_mecka_keypoints \
+  evaluator=eval_pi_keypoints_palm \
+  +evaluator.limit_val_batches=160 \
+  launch_params.gpus_per_node=1 \
+  ++mode=eval \
+  "ckpt_path='$CKPT'" \
+  norm_stats.precomputed_norm_path=/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp/norm_stats \
+  model.robomimic_model.config.pytorch_weight_path=$REPO/egomimic/algo/pi_checkpoints/pi05_base_pytorch \
+  model.robomimic_model.config.reverse_kl_samples=1 \
+  ~data.train_viz_datasets ~data.train_viz_dataloader_params \
+  "name=$LABEL" description=ep49_valset_160batches \
+  "+logger.wandb.name=$LABEL" \
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+echo "[eval] exit=$?"

--- a/egomimic/scripts/norm_fold_freeform_opsplit_cam6d.sbatch
+++ b/egomimic/scripts/norm_fold_freeform_opsplit_cam6d.sbatch
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=96G
+#SBATCH --time=04:00:00
+#SBATCH --job-name=norm_fold_freeform_opsplit_cam6d
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/norm_fold_freeform_opsplit_cam6d_%j.log
+
+# CPU-only: 0.1-frac quantile norm stats for the mecka FREEFORM fold-clothes
+# set, held-out-OPERATOR split (train side: 423 eps / 1.04M frames), cam6d
+# pipeline (data=mecka_fold_freeform_opsplit_pi_cam6d, model=pi0.5_bc_mecka_6d).
+# Run from the aidan/fold-freeform-keypoints worktree.
+#
+# Output: /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_cam6d/norm_stats/norm_stats.json
+# Training uses:
+#   norm_stats.precomputed_norm_path=/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_cam6d/norm_stats
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+echo "[norm] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+"$PY" egomimic/scripts/precompute_norm_stats.py \
+  --data mecka_fold_freeform_opsplit_pi_cam6d \
+  --model pi0.5_bc_mecka_6d \
+  --sample-frac 0.1 \
+  --num-workers 22 \
+  --out /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_cam6d

--- a/egomimic/scripts/norm_fold_freeform_opsplit_kp.sbatch
+++ b/egomimic/scripts/norm_fold_freeform_opsplit_kp.sbatch
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=96G
+#SBATCH --time=04:00:00
+#SBATCH --job-name=norm_fold_freeform_opsplit_kp
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/norm_fold_freeform_opsplit_kp_%j.log
+
+# CPU-only: 0.1-frac quantile norm stats for the mecka FREEFORM fold-clothes
+# set, held-out-OPERATOR split (train side: 423 eps / 1.04M frames), kp
+# pipeline (data=mecka_fold_freeform_opsplit_pi_keypoints, model=pi0.5_bc_mecka_keypoints).
+# Run from the aidan/fold-freeform-keypoints worktree.
+#
+# Output: /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp/norm_stats/norm_stats.json
+# Training uses:
+#   norm_stats.precomputed_norm_path=/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp/norm_stats
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+echo "[norm] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+"$PY" egomimic/scripts/precompute_norm_stats.py \
+  --data mecka_fold_freeform_opsplit_pi_keypoints \
+  --model pi0.5_bc_mecka_keypoints \
+  --sample-frac 0.1 \
+  --num-workers 22 \
+  --out /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp

--- a/egomimic/scripts/norm_fold_freeform_opsplit_wrist6d.sbatch
+++ b/egomimic/scripts/norm_fold_freeform_opsplit_wrist6d.sbatch
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=96G
+#SBATCH --time=04:00:00
+#SBATCH --job-name=norm_fold_freeform_opsplit_wrist6d
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/norm_fold_freeform_opsplit_wrist6d_%j.log
+
+# CPU-only: 0.1-frac quantile norm stats for the mecka FREEFORM fold-clothes
+# set, held-out-OPERATOR split (train side: 423 eps / 1.04M frames), wrist6d
+# pipeline (data=mecka_fold_freeform_opsplit_pi_6d, model=pi0.5_bc_mecka_6d).
+# Run from the aidan/fold-freeform-keypoints worktree.
+#
+# Output: /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_wrist6d/norm_stats/norm_stats.json
+# Training uses:
+#   norm_stats.precomputed_norm_path=/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_wrist6d/norm_stats
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+echo "[norm] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+"$PY" egomimic/scripts/precompute_norm_stats.py \
+  --data mecka_fold_freeform_opsplit_pi_6d \
+  --model pi0.5_bc_mecka_6d \
+  --sample-frac 0.1 \
+  --num-workers 22 \
+  --out /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_wrist6d

--- a/egomimic/scripts/smoke_keypoints_cpu.sbatch
+++ b/egomimic/scripts/smoke_keypoints_cpu.sbatch
@@ -1,0 +1,50 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=160G
+#SBATCH --time=03:00:00
+#SBATCH --job-name=smoke_kp_cpu
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/smoke_keypoints_cpu_%j.log
+
+# CPU smoke test of the pi0.5 KEYPOINT pipeline (every GPU partition is days
+# deep): 2 episodes per split, batch 2, fp32, 2 train steps + 1 val batch
+# through eval_pi_keypoints_wristframe (revert + metrics + overlay viz) and the
+# train_viz head, from the pi05 base weights with the action projections
+# re-initialized at action_dim 140. In-run norm stats (0.05 frac of 2 eps).
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 WANDB_MODE=offline
+export OMP_NUM_THREADS=24 MKL_NUM_THREADS=24
+
+echo "[smoke] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+"$PY" -u egomimic/trainHydra.py \
+  --config-name=train_zarr_cartesian_pi \
+  data=mecka_fold_freeform_opsplit_pi_keypoints \
+  model=pi0.5_bc_mecka_keypoints \
+  evaluator=eval_pi_keypoints_wristframe \
+  +evaluator@train_viz_evaluator=train_viz_pi_keypoints_wristframe \
+  trainer=default trainer.accelerator=cpu trainer.devices=1 trainer.precision=32 \
+  trainer.max_epochs=1 trainer.min_epochs=1 ++trainer.max_steps=2 \
+  trainer.limit_train_batches=2 trainer.limit_val_batches=1 trainer.check_val_every_n_epoch=1 \
+  +trainer.inference_mode=false +trainer.num_sanity_val_steps=0 \
+  model.robomimic_model.config.pytorch_training_precision=float32 \
+  model.robomimic_model.config.reverse_kl_samples=1 \
+  model.optimizer.lr=5e-5 model.scheduler=null \
+  model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch \
+  +data.train_datasets.human_bimanual.debug=2 +data.valid_datasets.human_bimanual.debug=2 +data.train_viz_datasets.human_bimanual.debug=2 \
+  data.train_dataloader_params.human_bimanual.batch_size=2 data.valid_dataloader_params.human_bimanual.batch_size=2 data.train_viz_dataloader_params.human_bimanual.batch_size=2 \
+  data.train_dataloader_params.human_bimanual.num_workers=2 data.valid_dataloader_params.human_bimanual.num_workers=2 data.train_viz_dataloader_params.human_bimanual.num_workers=1 \
+  norm_stats.sample_frac=0.05 norm_stats.num_workers=4 \
+  evaluator.viz_max_batches=1 evaluator.viz_every_n_epochs=1 train_viz_evaluator.limit_val_batches=1 \
+  name=smoke_keypoints_cpu description=cpu_2steps \
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+echo "[smoke] exit=$?"

--- a/egomimic/scripts/smoke_keypoints_cpu_ddp.sbatch
+++ b/egomimic/scripts/smoke_keypoints_cpu_ddp.sbatch
@@ -1,0 +1,52 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=160G
+#SBATCH --time=03:00:00
+#SBATCH --job-name=smoke_kp_cpu_ddp
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/smoke_keypoints_cpu_ddp_%j.log
+
+# CPU smoke test (1-process DDP on CPU: the codebase calls torch.distributed
+# unconditionally, so trainer=default without a process group dies) of the
+# pi0.5 KEYPOINT pipeline (every GPU partition is days
+# deep): 2 episodes per split, batch 2, fp32, 2 train steps + 1 val batch
+# through eval_pi_keypoints_wristframe (revert + metrics + overlay viz) and the
+# train_viz head, from the pi05 base weights with the action projections
+# re-initialized at action_dim 140. In-run norm stats (0.05 frac of 2 eps).
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 WANDB_MODE=offline
+export OMP_NUM_THREADS=24 MKL_NUM_THREADS=24
+
+echo "[smoke] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+"$PY" -u egomimic/trainHydra.py \
+  --config-name=train_zarr_cartesian_pi \
+  data=mecka_fold_freeform_opsplit_pi_keypoints \
+  model=pi0.5_bc_mecka_keypoints \
+  evaluator=eval_pi_keypoints_wristframe \
+  +evaluator@train_viz_evaluator=train_viz_pi_keypoints_wristframe \
+  trainer=ddp_pi trainer.accelerator=cpu trainer.devices=1 trainer.num_nodes=1 trainer.strategy=ddp_find_unused_parameters_true trainer.sync_batchnorm=false trainer.precision=32 \
+  trainer.max_epochs=1 trainer.min_epochs=1 ++trainer.max_steps=2 \
+  trainer.limit_train_batches=2 trainer.limit_val_batches=1 trainer.check_val_every_n_epoch=1 \
+  trainer.num_sanity_val_steps=0 \
+  model.robomimic_model.config.pytorch_training_precision=float32 \
+  model.robomimic_model.config.reverse_kl_samples=1 \
+  model.optimizer.lr=5e-5 model.scheduler=null \
+  model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch \
+  +data.train_datasets.human_bimanual.debug=2 +data.valid_datasets.human_bimanual.debug=2 +data.train_viz_datasets.human_bimanual.debug=2 \
+  data.train_dataloader_params.human_bimanual.batch_size=2 data.valid_dataloader_params.human_bimanual.batch_size=2 data.train_viz_dataloader_params.human_bimanual.batch_size=2 \
+  data.train_dataloader_params.human_bimanual.num_workers=2 data.valid_dataloader_params.human_bimanual.num_workers=2 data.train_viz_dataloader_params.human_bimanual.num_workers=1 \
+  norm_stats.sample_frac=0.05 norm_stats.num_workers=4 \
+  evaluator.viz_max_batches=1 evaluator.viz_every_n_epochs=1 train_viz_evaluator.limit_val_batches=1 \
+  name=smoke_keypoints_cpu description=cpu_2steps_ddp1_fup \
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+echo "[smoke] exit=$?"

--- a/egomimic/scripts/train_camframe_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_camframe_fold_freeform_opsplit.sbatch
@@ -16,8 +16,9 @@
 # on the mecka FREEFORM fold-clothes episodes (423 train eps / 39 val eps from
 # 25 held-out operators), from the pi05 base weights. Flat lr 5e-5
 # (scheduler=null), 64/GPU x 2xH200 = global 128. Cadence (epoch =
-# limit_train_batches = 100 steps): val every 50 epochs, viz every 100 (both
-# heads, <=10 batches), ckpt every 50 epochs (top-3 by step + last).
+# limit_train_batches = 100 steps): val every 20 epochs (Aidan, 2026-09-01), viz
+# every 100 (both heads, <=10 batches; 100 is a multiple of 20 so viz still lands
+# on a val epoch), ckpt every 50 epochs (top-3 by step + last).
 # Eval = eval_pi_camframe_6d (6D -> ypr only) + train_viz head (train_viz_pi_camframe_6d).
 #
 # Requires the CPU norm job's output (norm_fold_freeform_opsplit_cam6d.sbatch):
@@ -79,7 +80,7 @@ ARGS=(
   model.scheduler=null
   "norm_stats.precomputed_norm_path=$NORM_PATH"
   model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
-  trainer.check_val_every_n_epoch=50
+  trainer.check_val_every_n_epoch=20
   callbacks.model_checkpoint.every_n_epochs=50
   "name=$LABEL"
   description=bs64x2_flat5e-5_cam6d_opsplit

--- a/egomimic/scripts/train_camframe_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_camframe_fold_freeform_opsplit.sbatch
@@ -6,7 +6,11 @@
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=250G
 #SBATCH --gres=gpu:h200:2
-#SBATCH --time=24:00:00
+#SBATCH --time=72:00:00
+# atl1-1-02-012-16-0 GPU-1776d65d and atl1-1-02-014-9-0 GPU-8375b1cd were
+# thermally throttled (93 C, SM ~350-420 MHz) on 2026-09-01 and clamped the
+# first-round runs to ~3 eps/h; keep the sweep off those nodes.
+#SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
 #SBATCH --job-name=camframe_fold_freeform_opsplit
 #SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/camframe_fold_clothes_freeform_fit_test_flat5e-5_opsplit_%j.log
 

--- a/egomimic/scripts/train_camframe_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_camframe_fold_freeform_opsplit.sbatch
@@ -1,0 +1,96 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks-per-node=2
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=250G
+#SBATCH --gres=gpu:h200:2
+#SBATCH --time=24:00:00
+#SBATCH --job-name=camframe_fold_freeform_opsplit
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/camframe_fold_clothes_freeform_fit_test_flat5e-5_opsplit_%j.log
+
+# pi0.5 fit test on the aidan/eval_gating recipe, held-out-OPERATOR split:
+# CAM (head)-frame cartesian actions, continuous 6D rotation (cartesian_6d,
+# left-wrist fix, padded 20-dim proprio)
+# on the mecka FREEFORM fold-clothes episodes (423 train eps / 39 val eps from
+# 25 held-out operators), from the pi05 base weights. Flat lr 5e-5
+# (scheduler=null), 64/GPU x 2xH200 = global 128. Cadence (epoch =
+# limit_train_batches = 100 steps): val every 50 epochs, viz every 100 (both
+# heads, <=10 batches), ckpt every 50 epochs (top-3 by step + last).
+# Eval = eval_pi_camframe_6d (6D -> ypr only) + train_viz head (train_viz_pi_camframe_6d).
+#
+# Requires the CPU norm job's output (norm_fold_freeform_opsplit_cam6d.sbatch):
+#   /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_cam6d/norm_stats
+# Submit with --dependency=afterok:<norm job id>.
+#
+# Runs from the aidan/fold-freeform-keypoints worktree (code = eval_gating +
+# fold-freeform-frames + the keypoint/opsplit commit); PYTHONPATH pins
+# `import egomimic` to it; hydra outputs are forced into the primary
+# checkout's logs/ so checkpoints outlive the worktree.
+#
+# Env knobs:
+#   NORM_PATH  - precomputed norm_stats dir (default above)
+#   CKPT_PATH  - resume from a Lightning checkpoint
+#   LR         - optimizer lr (default 5e-5)
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+# wandb online (key from apikey.txt); falls back to offline if absent.
+if grep -q WANDB_API_KEY "$REPO/apikey.txt" 2>/dev/null; then
+  export WANDB_API_KEY="$(grep -oP 'WANDB_API_KEY=\K.*' "$REPO/apikey.txt")"
+  export WANDB_MODE=online
+elif grep -q api.wandb.ai ~/.netrc 2>/dev/null; then
+  export WANDB_MODE=online   # netrc-authenticated
+else
+  export WANDB_MODE=offline
+fi
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+NORM_PATH="${NORM_PATH-/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_cam6d/norm_stats}"
+CKPT_PATH="${CKPT_PATH-}"
+LR="${LR-5e-5}"
+LABEL=camframe_fold_clothes_freeform_fit_test_flat5e-5_opsplit
+
+if [[ ! -f "$NORM_PATH/norm_stats.json" ]]; then
+  echo "ERROR: precomputed norm stats not found: $NORM_PATH/norm_stats.json" >&2
+  echo "Run egomimic/scripts/norm_fold_freeform_opsplit_cam6d.sbatch first." >&2
+  exit 1
+fi
+
+ARGS=(
+  --config-name=train_zarr_cartesian_pi
+  data=mecka_fold_freeform_opsplit_pi_cam6d
+  model=pi0.5_bc_mecka_6d
+  evaluator=eval_pi_camframe_6d
+  # eval_pi_camframe_6d lacks the render cap eval_pi_wristframe_6d carries.
+  +evaluator.viz_max_batches=10
+  # Second eval head: metrics + videos on TRAIN data each val (train_viz/).
+  +evaluator@train_viz_evaluator=train_viz_pi_camframe_6d
+  launch_params.gpus_per_node=2
+  "model.optimizer.lr=$LR"
+  # Flat LR: drop pi0.5_base's constant-with-warmup (2000 warmup steps).
+  model.scheduler=null
+  "norm_stats.precomputed_norm_path=$NORM_PATH"
+  model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
+  trainer.check_val_every_n_epoch=50
+  callbacks.model_checkpoint.every_n_epochs=50
+  "name=$LABEL"
+  description=bs64x2_flat5e-5_cam6d_opsplit
+  "+logger.wandb.name=$LABEL"
+  # Keep outputs (checkpoints, norm-stats cache) out of the worktree.
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+)
+# Lightning names checkpoints "epoch_epoch=..." — quote so hydra's grammar
+# doesn't choke on '='.
+[[ -n "$CKPT_PATH" ]] && ARGS+=("ckpt_path='$CKPT_PATH'")
+
+echo "[train] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+echo "[train] srun python -u egomimic/trainHydra.py ${ARGS[*]}"
+srun "$PY" -u egomimic/trainHydra.py "${ARGS[@]}"

--- a/egomimic/scripts/train_keypoints_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_keypoints_fold_freeform_opsplit.sbatch
@@ -6,7 +6,11 @@
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=250G
 #SBATCH --gres=gpu:h200:2
-#SBATCH --time=24:00:00
+#SBATCH --time=72:00:00
+# atl1-1-02-012-16-0 GPU-1776d65d and atl1-1-02-014-9-0 GPU-8375b1cd were
+# thermally throttled (93 C, SM ~350-420 MHz) on 2026-09-01 and clamped the
+# first-round runs to ~3 eps/h; keep the sweep off those nodes.
+#SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
 #SBATCH --job-name=keypoints_fold_freeform_opsplit
 #SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/keypoints_fold_clothes_freeform_fit_test_flat5e-5_opsplit_%j.log
 

--- a/egomimic/scripts/train_keypoints_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_keypoints_fold_freeform_opsplit.sbatch
@@ -1,0 +1,96 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks-per-node=2
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=250G
+#SBATCH --gres=gpu:h200:2
+#SBATCH --time=24:00:00
+#SBATCH --job-name=keypoints_fold_freeform_opsplit
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/keypoints_fold_clothes_freeform_fit_test_flat5e-5_opsplit_%j.log
+
+# pi0.5 fit test on the aidan/eval_gating recipe, held-out-OPERATOR split:
+# 138-D wrist-first MANO KEYPOINT actions in wrist frame (keypoints_wristframe_pi:
+# wrist pose (6) + 21 keypoints (63) per hand; prompt proprio = the same 20-D
+# head-frame ee_pose as the cartesian twins), model action_dim 140
+# on the mecka FREEFORM fold-clothes episodes (423 train eps / 39 val eps from
+# 25 held-out operators), from the pi05 base weights. Flat lr 5e-5
+# (scheduler=null), 64/GPU x 2xH200 = global 128. Cadence (epoch =
+# limit_train_batches = 100 steps): val every 50 epochs, viz every 100 (both
+# heads, <=10 batches), ckpt every 50 epochs (top-3 by step + last).
+# Eval = eval_pi_keypoints_wristframe (wrist -> head-frame keypoint revert, 126-D
+# cam-frame keypoint MSE + overlay video) + train_viz head.
+#
+# Requires the CPU norm job's output (norm_fold_freeform_opsplit_kp.sbatch):
+#   /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp/norm_stats
+# Submit with --dependency=afterok:<norm job id>.
+#
+# Runs from the aidan/fold-freeform-keypoints worktree (code = eval_gating +
+# fold-freeform-frames + the keypoint/opsplit commit); PYTHONPATH pins
+# `import egomimic` to it; hydra outputs are forced into the primary
+# checkout's logs/ so checkpoints outlive the worktree.
+#
+# Env knobs:
+#   NORM_PATH  - precomputed norm_stats dir (default above)
+#   CKPT_PATH  - resume from a Lightning checkpoint
+#   LR         - optimizer lr (default 5e-5)
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+# wandb online (key from apikey.txt); falls back to offline if absent.
+if grep -q WANDB_API_KEY "$REPO/apikey.txt" 2>/dev/null; then
+  export WANDB_API_KEY="$(grep -oP 'WANDB_API_KEY=\K.*' "$REPO/apikey.txt")"
+  export WANDB_MODE=online
+elif grep -q api.wandb.ai ~/.netrc 2>/dev/null; then
+  export WANDB_MODE=online   # netrc-authenticated
+else
+  export WANDB_MODE=offline
+fi
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+NORM_PATH="${NORM_PATH-/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_kp/norm_stats}"
+CKPT_PATH="${CKPT_PATH-}"
+LR="${LR-5e-5}"
+LABEL=keypoints_fold_clothes_freeform_fit_test_flat5e-5_opsplit
+
+if [[ ! -f "$NORM_PATH/norm_stats.json" ]]; then
+  echo "ERROR: precomputed norm stats not found: $NORM_PATH/norm_stats.json" >&2
+  echo "Run egomimic/scripts/norm_fold_freeform_opsplit_kp.sbatch first." >&2
+  exit 1
+fi
+
+ARGS=(
+  --config-name=train_zarr_cartesian_pi
+  data=mecka_fold_freeform_opsplit_pi_keypoints
+  model=pi0.5_bc_mecka_keypoints
+  evaluator=eval_pi_keypoints_wristframe
+  # Second eval head: metrics + videos on TRAIN data each val (train_viz/).
+  +evaluator@train_viz_evaluator=train_viz_pi_keypoints_wristframe
+  launch_params.gpus_per_node=2
+  "model.optimizer.lr=$LR"
+  # Flat LR: drop pi0.5_base's constant-with-warmup (2000 warmup steps).
+  model.scheduler=null
+  "norm_stats.precomputed_norm_path=$NORM_PATH"
+  model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
+  trainer.check_val_every_n_epoch=50
+  callbacks.model_checkpoint.every_n_epochs=50
+  "name=$LABEL"
+  description=bs64x2_flat5e-5_kp_opsplit
+  "+logger.wandb.name=$LABEL"
+  # Keep outputs (checkpoints, norm-stats cache) out of the worktree.
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+)
+# Lightning names checkpoints "epoch_epoch=..." — quote so hydra's grammar
+# doesn't choke on '='.
+[[ -n "$CKPT_PATH" ]] && ARGS+=("ckpt_path='$CKPT_PATH'")
+
+echo "[train] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+echo "[train] srun python -u egomimic/trainHydra.py ${ARGS[*]}"
+srun "$PY" -u egomimic/trainHydra.py "${ARGS[@]}"

--- a/egomimic/scripts/train_keypoints_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_keypoints_fold_freeform_opsplit.sbatch
@@ -17,8 +17,9 @@
 # on the mecka FREEFORM fold-clothes episodes (423 train eps / 39 val eps from
 # 25 held-out operators), from the pi05 base weights. Flat lr 5e-5
 # (scheduler=null), 64/GPU x 2xH200 = global 128. Cadence (epoch =
-# limit_train_batches = 100 steps): val every 50 epochs, viz every 100 (both
-# heads, <=10 batches), ckpt every 50 epochs (top-3 by step + last).
+# limit_train_batches = 100 steps): val every 20 epochs (Aidan, 2026-09-01), viz
+# every 100 (both heads, <=10 batches; 100 is a multiple of 20 so viz still lands
+# on a val epoch), ckpt every 50 epochs (top-3 by step + last).
 # Eval = eval_pi_keypoints_wristframe (wrist -> head-frame keypoint revert, 126-D
 # cam-frame keypoint MSE + overlay video) + train_viz head.
 #
@@ -79,7 +80,7 @@ ARGS=(
   model.scheduler=null
   "norm_stats.precomputed_norm_path=$NORM_PATH"
   model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
-  trainer.check_val_every_n_epoch=50
+  trainer.check_val_every_n_epoch=20
   callbacks.model_checkpoint.every_n_epochs=50
   "name=$LABEL"
   description=bs64x2_flat5e-5_kp_opsplit

--- a/egomimic/scripts/train_wristframe_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_wristframe_fold_freeform_opsplit.sbatch
@@ -16,8 +16,9 @@
 # on the mecka FREEFORM fold-clothes episodes (423 train eps / 39 val eps from
 # 25 held-out operators), from the pi05 base weights. Flat lr 5e-5
 # (scheduler=null), 64/GPU x 2xH200 = global 128. Cadence (epoch =
-# limit_train_batches = 100 steps): val every 50 epochs, viz every 100 (both
-# heads, <=10 batches), ckpt every 50 epochs (top-3 by step + last).
+# limit_train_batches = 100 steps): val every 20 epochs (Aidan, 2026-09-01), viz
+# every 100 (both heads, <=10 batches; 100 is a multiple of 20 so viz still lands
+# on a val epoch), ckpt every 50 epochs (top-3 by step + last).
 # Eval = eval_pi_wristframe_6d (6D -> ypr, wrist -> cam revert) + train_viz head.
 #
 # Requires the CPU norm job's output (norm_fold_freeform_opsplit_wrist6d.sbatch):
@@ -77,7 +78,7 @@ ARGS=(
   model.scheduler=null
   "norm_stats.precomputed_norm_path=$NORM_PATH"
   model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
-  trainer.check_val_every_n_epoch=50
+  trainer.check_val_every_n_epoch=20
   callbacks.model_checkpoint.every_n_epochs=50
   "name=$LABEL"
   description=bs64x2_flat5e-5_wrist6d_opsplit

--- a/egomimic/scripts/train_wristframe_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_wristframe_fold_freeform_opsplit.sbatch
@@ -1,0 +1,94 @@
+#!/bin/bash
+#SBATCH -A gts-dxu345-rl2
+#SBATCH -q inferno
+#SBATCH -N1
+#SBATCH --ntasks-per-node=2
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=250G
+#SBATCH --gres=gpu:h200:2
+#SBATCH --time=24:00:00
+#SBATCH --job-name=wristframe_fold_freeform_opsplit
+#SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/wristframe_fold_clothes_freeform_fit_test_flat5e-5_opsplit_%j.log
+
+# pi0.5 fit test on the aidan/eval_gating recipe, held-out-OPERATOR split:
+# WRIST-frame cartesian actions, continuous 6D rotation (cartesian_wristframe_6d,
+# left-wrist fix, padded 20-dim proprio)
+# on the mecka FREEFORM fold-clothes episodes (423 train eps / 39 val eps from
+# 25 held-out operators), from the pi05 base weights. Flat lr 5e-5
+# (scheduler=null), 64/GPU x 2xH200 = global 128. Cadence (epoch =
+# limit_train_batches = 100 steps): val every 50 epochs, viz every 100 (both
+# heads, <=10 batches), ckpt every 50 epochs (top-3 by step + last).
+# Eval = eval_pi_wristframe_6d (6D -> ypr, wrist -> cam revert) + train_viz head.
+#
+# Requires the CPU norm job's output (norm_fold_freeform_opsplit_wrist6d.sbatch):
+#   /storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_wrist6d/norm_stats
+# Submit with --dependency=afterok:<norm job id>.
+#
+# Runs from the aidan/fold-freeform-keypoints worktree (code = eval_gating +
+# fold-freeform-frames + the keypoint/opsplit commit); PYTHONPATH pins
+# `import egomimic` to it; hydra outputs are forced into the primary
+# checkout's logs/ so checkpoints outlive the worktree.
+#
+# Env knobs:
+#   NORM_PATH  - precomputed norm_stats dir (default above)
+#   CKPT_PATH  - resume from a Lightning checkpoint
+#   LR         - optimizer lr (default 5e-5)
+
+set -euo pipefail
+WT=/storage/project/r-dxu345-0/agao81/EgoVerse/.claude/worktrees/fold-freeform-kp
+REPO=/storage/project/r-dxu345-0/agao81/EgoVerse
+cd "$WT"
+export PYTHONPATH="$WT${PYTHONPATH:+:$PYTHONPATH}"
+PY=/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin/python
+export PATH="/storage/home/hcoda1/5/agao81/r-dxu345-0/EgoVerse/emimic/bin:$PATH"
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+# wandb online (key from apikey.txt); falls back to offline if absent.
+if grep -q WANDB_API_KEY "$REPO/apikey.txt" 2>/dev/null; then
+  export WANDB_API_KEY="$(grep -oP 'WANDB_API_KEY=\K.*' "$REPO/apikey.txt")"
+  export WANDB_MODE=online
+elif grep -q api.wandb.ai ~/.netrc 2>/dev/null; then
+  export WANDB_MODE=online   # netrc-authenticated
+else
+  export WANDB_MODE=offline
+fi
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+
+NORM_PATH="${NORM_PATH-/storage/project/r-dxu345-0/agao81/norm_stats/fold_freeform_opsplit_wrist6d/norm_stats}"
+CKPT_PATH="${CKPT_PATH-}"
+LR="${LR-5e-5}"
+LABEL=wristframe_fold_clothes_freeform_fit_test_flat5e-5_opsplit
+
+if [[ ! -f "$NORM_PATH/norm_stats.json" ]]; then
+  echo "ERROR: precomputed norm stats not found: $NORM_PATH/norm_stats.json" >&2
+  echo "Run egomimic/scripts/norm_fold_freeform_opsplit_wrist6d.sbatch first." >&2
+  exit 1
+fi
+
+ARGS=(
+  --config-name=train_zarr_cartesian_pi
+  data=mecka_fold_freeform_opsplit_pi_6d
+  model=pi0.5_bc_mecka_6d
+  evaluator=eval_pi_wristframe_6d
+  # Second eval head: metrics + videos on TRAIN data each val (train_viz/).
+  +evaluator@train_viz_evaluator=train_viz_pi_wristframe_6d
+  launch_params.gpus_per_node=2
+  "model.optimizer.lr=$LR"
+  # Flat LR: drop pi0.5_base's constant-with-warmup (2000 warmup steps).
+  model.scheduler=null
+  "norm_stats.precomputed_norm_path=$NORM_PATH"
+  model.robomimic_model.config.pytorch_weight_path=/storage/project/r-dxu345-0/agao81/EgoVerse/egomimic/algo/pi_checkpoints/pi05_base_pytorch
+  trainer.check_val_every_n_epoch=50
+  callbacks.model_checkpoint.every_n_epochs=50
+  "name=$LABEL"
+  description=bs64x2_flat5e-5_wrist6d_opsplit
+  "+logger.wandb.name=$LABEL"
+  # Keep outputs (checkpoints, norm-stats cache) out of the worktree.
+  'hydra.run.dir=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/${name}/${description}_${now:%Y-%m-%d_%H-%M-%S}'
+)
+# Lightning names checkpoints "epoch_epoch=..." — quote so hydra's grammar
+# doesn't choke on '='.
+[[ -n "$CKPT_PATH" ]] && ARGS+=("ckpt_path='$CKPT_PATH'")
+
+echo "[train] cwd=$(pwd) commit=$(git rev-parse HEAD) branch=$(git rev-parse --abbrev-ref HEAD)"
+echo "[train] srun python -u egomimic/trainHydra.py ${ARGS[*]}"
+srun "$PY" -u egomimic/trainHydra.py "${ARGS[@]}"

--- a/egomimic/scripts/train_wristframe_fold_freeform_opsplit.sbatch
+++ b/egomimic/scripts/train_wristframe_fold_freeform_opsplit.sbatch
@@ -6,7 +6,11 @@
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=250G
 #SBATCH --gres=gpu:h200:2
-#SBATCH --time=24:00:00
+#SBATCH --time=72:00:00
+# atl1-1-02-012-16-0 GPU-1776d65d and atl1-1-02-014-9-0 GPU-8375b1cd were
+# thermally throttled (93 C, SM ~350-420 MHz) on 2026-09-01 and clamped the
+# first-round runs to ~3 eps/h; keep the sweep off those nodes.
+#SBATCH --exclude=atl1-1-02-012-16-0,atl1-1-02-014-9-0
 #SBATCH --job-name=wristframe_fold_freeform_opsplit
 #SBATCH --output=/storage/project/r-dxu345-0/agao81/EgoVerse/logs/wristframe_fold_clothes_freeform_fit_test_flat5e-5_opsplit_%j.log
 

--- a/egomimic/utils/action_utils.py
+++ b/egomimic/utils/action_utils.py
@@ -268,6 +268,50 @@ class BaseActionConverter:
         )
 
 
+
+class HumanBimanualKeypoints(BaseActionConverter):
+    """138-D wrist-first MANO keypoint action, per hand
+    ``[wrist xyz+ypr in its own wrist frame (6) | 21 keypoints in that wrist
+    frame (63)]`` x {left, right} (see
+    ``Human.get_transform_list("keypoints_wristframe_pi")``), packed
+    identity-first into the model's ``action_dim``-wide vector with zero
+    trailing pad. Pairs with the ``legacy_normalized_ypr_rot6d`` encoding,
+    which just calls ``to32`` / ``from32`` on the norm-stats-normalized
+    action — no rotation math here (the 6 wrist-ypr dims stay ypr).
+
+    ``action_dim`` must match ``model.config.model.action_dim`` (PI resizes
+    openpi's action projections to it).
+    """
+
+    def __init__(self, action_dim: int = 140, native_dim: int = 138):
+        if action_dim < native_dim:
+            raise ValueError(
+                f"HumanBimanualKeypoints: action_dim {action_dim} < native {native_dim}"
+            )
+        self.action_dim = int(action_dim)
+        self.native_dim = int(native_dim)
+
+    def to32(self, actions: torch.Tensor) -> torch.Tensor:
+        actions = _ensure_bsd(actions)
+        D = actions.shape[-1]
+        if D != self.native_dim:
+            raise ValueError(
+                f"HumanBimanualKeypoints: expected {self.native_dim}-dim, got {D}"
+            )
+        if D == self.action_dim:
+            return actions
+        pad = torch.zeros(
+            *actions.shape[:-1],
+            self.action_dim - D,
+            dtype=actions.dtype,
+            device=actions.device,
+        )
+        return torch.cat([actions, pad], dim=-1)
+
+    def from32(self, actions32: torch.Tensor) -> torch.Tensor:
+        actions32 = _ensure_bsd(actions32)
+        return actions32[..., : self.native_dim]
+
 # ============================================================
 #                     ROBOT CONVERTERS
 # ============================================================


### PR DESCRIPTION
pi0.5 keypoint action path + held-out-operator split for the fold-freeform fit tests: keypoints_wristframe_pi transform (138-D wrist-first keypoints + cartesian ee_pose prompt proprio), HumanBimanualKeypoints converter, PI resizes openpi action projections for action_dim!=32, opsplit data configs (cam6d/wrist6d/kp), keypoint evaluator/viz, norm + train launchers, CPU smoke

smoke: CPU keypoint smoke needs 1-process DDP (find_unused_parameters) — pl_model on_fit_start barriers; add working smoke_keypoints_cpu_ddp launcher

dataset v2: fold_clothes-derivative task-name rule (fold+clothes, no packaging; 492 eps / 11.2 h / 8 tasks) + operator split v2 (27 held-out ops, 8.7%)

revert dataset to folding_clothes only (v1: 462 eps / 10.45 h, operator split 25 held-out ops) per Aidan — drop the v2 task-name-rule expansion

opsplit launchers: validate every 20 epochs instead of 50 (viz still every 100, ckpt every 50)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z

opsplit launchers: 72h wall, exclude the two thermally throttled H200 nodes

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z

opsplit: hold out a full 10% of frames by operator (was 8%)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z

eval: palm-origin cam-frame metric for keypoint runs (PIEvalKeypointPalm) + eval-only launcher for the epoch-49 checkpoint

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z

eval launcher: typed h200 gres (untyped gres over a partition list landed on a V100)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z

eval: offline launcher for cartesian opsplit checkpoints (same path as the keypoint palm eval)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z

eval launcher: per-job inductor/triton cache dirs (same-node autotune race)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AaLp3ZC4xVapZZvE5Pd4Z