### PR TITLE
feat(val): nested validation dataset groups

### DIFF
--- a/egomimic/eval/eval_video.py
+++ b/egomimic/eval/eval_video.py
@@ -5,6 +5,7 @@ import torch
 import torchvision.io as tvio
 
 from egomimic.eval.eval import Eval
+from egomimic.pl_utils.pl_data_utils import DEFAULT_VALID_GROUP
 from egomimic.rldb.embodiment.embodiment import get_embodiment
 
 
@@ -20,17 +21,44 @@ class EvalVideo(Eval):
         limit_val_batches: int = 400,
         viz_func: dict = None,
         transform_lists: dict | None = None,
+        video_chunk_frames: int = 1000,
+        max_episode_frames: int = 6000,
     ):
         super().__init__()
         self.trainer = None
         self.model = None
         self.viz_func = viz_func
+        # Frames per file on the LEGACY path only -- batches that arrive
+        # without `episode_hash` still flush a fresh file every this many
+        # frames. Episode-aware batches ignore it and cut on episode
+        # boundaries instead.
+        self.video_chunk_frames = int(video_chunk_frames)
+        # Safety cap on a single episode's video, and the memory bound on the
+        # per-episode path: an open episode is held in RAM until its boundary,
+        # so peak use is about
+        #     2 (embodiments) * max_episode_frames * H * W * 3 bytes
+        # -- at 480x640 that is ~0.9 MB/frame, so 6000 frames is ~5.5 GB per
+        # embodiment worst case. Episodes longer than this are truncated
+        # rather than split, so the file still maps 1:1 to an episode.
+        self.max_episode_frames = int(max_episode_frames)
         # Per-embodiment list[Transform] applied once during eval to project
         # the model's wrist-frame actions back into cam (head) frame. Reused for
         # both cam-frame MSE and the viz video so we don't transform twice.
         self.transform_lists = transform_lists or {}
+        # All keyed by (val_group, image key) rather than image key alone:
+        # with more than one val group the same embodiment appears in each, and
+        # a key-only buffer would let one group's leftover frames spill into
+        # the next group's video.
         self.val_image_buffer = {}
         self.val_counter = {}
+        # episode_hash currently accumulating per (group, key), and the set of
+        # hashes already written this epoch. The latter is what makes the
+        # CombinedLoader's `max_size_cycle` harmless: when the shorter
+        # embodiment wraps and replays episodes to match the longer one, those
+        # frames are recognised as already written and dropped instead of being
+        # appended a second time.
+        self.val_open_episode = {}
+        self.val_written = {}
         self.override_dict = {
             "strategy": "ddp_find_unused_parameters_true",
             "limit_train_batches": 0,
@@ -43,6 +71,47 @@ class EvalVideo(Eval):
 
     def video_dir(self):
         return os.path.join(self.root_dir(), "videos")
+
+    def val_group(self, dataloader_idx=0):
+        """Name of the val group Lightning is currently iterating.
+
+        Resolved from the datamodule's positional `valid_group_names` rather
+        than plumbed through the evaluator API, so composite evaluators that
+        already forward `dataloader_idx` to their children get it for free.
+        Falls back to the default group when the datamodule predates groups
+        (or when running under a bare eval harness with no datamodule).
+        """
+        datamodule = getattr(self.trainer, "datamodule", None)
+        names = getattr(datamodule, "valid_group_names", None) or []
+        if 0 <= dataloader_idx < len(names):
+            return names[dataloader_idx]
+        return DEFAULT_VALID_GROUP
+
+    def _group_video_dir(self, group, key):
+        """`videos/epoch_N/[group/]{embodiment}` -- the group segment is
+        omitted for the default group so existing runs keep their layout."""
+        parts = [self.video_dir(), f"epoch_{self.trainer.current_epoch}"]
+        if group != DEFAULT_VALID_GROUP:
+            parts.append(str(group))
+        parts.append(str(get_embodiment(key)))
+        return os.path.join(*parts)
+
+    @staticmethod
+    def _namespace_metrics(metrics, group):
+        """Move `Valid/...` keys into `Valid_{group}/...` for non-default groups.
+
+        The leading path segment is what wandb uses to section a chart list, so
+        this is what puts the held-out-task numbers in their own panel instead
+        of overwriting the in-domain ones. Keys that are not `Valid/`-prefixed
+        are left alone -- they are not per-group val metrics.
+        """
+        if group == DEFAULT_VALID_GROUP:
+            return metrics
+        prefix = f"Valid_{group}/"
+        return {
+            (prefix + k[len("Valid/"):] if k.startswith("Valid/") else k): v
+            for k, v in metrics.items()
+        }
 
     @abstractmethod
     def compute_metrics_and_viz(self, batch):
@@ -58,7 +127,98 @@ class EvalVideo(Eval):
         """
         raise NotImplementedError
 
+    @staticmethod
+    def _episode_hashes(batch, key, n_images):
+        """Per-sample episode_hash for the images this embodiment produced.
+
+        `episode_hash` is stamped on every sample by ZarrDataset and survives
+        `process_batch_for_training` (it is not a registered zarr key, so it
+        falls through under its own name). Returns None when it is absent or
+        shorter than the image count -- callers then fall back to fixed-size
+        chunking rather than mislabelling frames.
+        """
+        sub = batch.get(key) if isinstance(batch, dict) else None
+        hashes = sub.get("episode_hash") if isinstance(sub, dict) else None
+        if not isinstance(hashes, (list, tuple)) or len(hashes) < n_images:
+            return None
+        return [str(h) for h in hashes[:n_images]]
+
+    def _write_video(self, out_dir, name, frames):
+        os.makedirs(out_dir, exist_ok=True)
+        tvio.write_video(
+            os.path.join(out_dir, f"{name}.mp4"),
+            torch.stack(list(frames)),
+            fps=30,
+            video_codec="h264",
+        )
+
+    def _flush_episode(self, buf_key, out_dir):
+        """Write the open episode's buffer as `{episode_hash}.mp4`."""
+        episode = self.val_open_episode.get(buf_key)
+        buffer = self.val_image_buffer.get(buf_key) or []
+        if episode is not None and len(buffer) != 0:
+            self._write_video(out_dir, episode, buffer)
+            self.val_written.setdefault(buf_key, set()).add(episode)
+        self.val_image_buffer[buf_key] = []
+        self.val_open_episode[buf_key] = None
+
+    def _buffer_per_episode(self, buf_key, out_dir, frames, hashes):
+        """One mp4 per episode, cut where episode_hash changes.
+
+        Validation runs with shuffle=False and MultiDataset lays its index map
+        out episode by episode, so samples arrive grouped by episode and in
+        frame order -- the boundary is simply where the hash changes.
+        """
+        written = self.val_written.setdefault(buf_key, set())
+        for frame, episode in zip(frames, hashes):
+            open_episode = self.val_open_episode.get(buf_key)
+            if episode in written:
+                # Replay from max_size_cycle (or frames past the safety cap).
+                # Seeing a finished episode also means whatever is still open
+                # has ended -- without this the LAST episode of a cycling
+                # embodiment never hits a boundary and keeps accumulating a
+                # copy of itself on every wrap.
+                if open_episode is not None:
+                    self._flush_episode(buf_key, out_dir)
+                continue
+            if open_episode is None:
+                self.val_open_episode[buf_key] = episode
+                self.val_image_buffer[buf_key] = []
+            elif episode != open_episode:
+                self._flush_episode(buf_key, out_dir)
+                self.val_open_episode[buf_key] = episode
+                self.val_image_buffer[buf_key] = []
+            buffer = self.val_image_buffer[buf_key]
+            buffer.append(frame)
+            if len(buffer) >= self.max_episode_frames:
+                # Episode longer than the safety cap: write what we have and
+                # mark it done so the remainder is dropped rather than
+                # spilling into the next episode's file.
+                self._flush_episode(buf_key, out_dir)
+
+    def _buffer_chunked(self, buf_key, out_dir, frames):
+        """Legacy path for batches with no episode_hash: fixed-size files."""
+        if self.val_image_buffer.get(buf_key) is None:
+            self.val_image_buffer[buf_key] = []
+            self.val_counter[buf_key] = 0
+        self.val_image_buffer[buf_key].extend(frames)
+        if len(self.val_image_buffer[buf_key]) >= self.video_chunk_frames:
+            self._write_video(
+                out_dir,
+                f"validation_video_{self.val_counter[buf_key]}",
+                self.val_image_buffer[buf_key],
+            )
+            self.val_image_buffer[buf_key].clear()
+            self.val_counter[buf_key] += 1
+
     def on_validation_start(self):
+        # Per-epoch reset. `val_written` in particular MUST be cleared here:
+        # it is the "already have a video for this episode" guard, and carrying
+        # it across epochs would silently skip every episode after epoch 0.
+        self.val_image_buffer = {}
+        self.val_counter = {}
+        self.val_open_episode = {}
+        self.val_written = {}
         if self.trainer.is_global_zero:
             os.makedirs(
                 os.path.join(self.video_dir(), f"epoch_{self.trainer.current_epoch}"),
@@ -66,29 +226,28 @@ class EvalVideo(Eval):
             )
 
     def on_validation_end(self):
-        for key, buffer in self.val_image_buffer.items():
-            os.makedirs(
-                os.path.join(
-                    self.video_dir(),
-                    f"epoch_{self.trainer.current_epoch}",
-                    str(get_embodiment(key)),
-                ),
-                exist_ok=True,
-            )
-            if len(buffer) != 0:
-                frames = torch.stack(buffer)
-                path = os.path.join(
-                    self.video_dir(),
-                    f"epoch_{self.trainer.current_epoch}",
-                    str(get_embodiment(key)),
-                    f"validation_video_{self.val_counter[key]}.mp4",
+        # Fires once after ALL val groups have run, so the buffer key carries
+        # the group each tail of frames belongs to. The last episode of every
+        # (group, embodiment) is still open at this point -- nothing followed
+        # it to trigger a boundary flush -- so this is what writes it.
+        for buf_key in list(self.val_image_buffer):
+            group, key = buf_key
+            out_dir = self._group_video_dir(group, key)
+            if self.val_open_episode.get(buf_key) is not None:
+                self._flush_episode(buf_key, out_dir)
+            elif len(self.val_image_buffer[buf_key]) != 0:
+                # chunked fallback tail
+                self._write_video(
+                    out_dir,
+                    f"validation_video_{self.val_counter.get(buf_key, 0)}",
+                    self.val_image_buffer[buf_key],
                 )
-                tvio.write_video(path, frames, fps=30, video_codec="h264")
-
-            self.val_counter[key] = 0
-            self.val_image_buffer[key] = []
+            self.val_counter[buf_key] = 0
+            self.val_image_buffer[buf_key] = []
+            self.val_open_episode[buf_key] = None
 
     def on_validation_step(self, batch, batch_idx, dataloader_idx=0):
+        group = self.val_group(dataloader_idx)
         metrics, images_dict = self.compute_metrics_and_viz(batch)
 
         device = self.trainer.lightning_module.device
@@ -96,31 +255,26 @@ class EvalVideo(Eval):
             k: (v.to(device) if torch.is_tensor(v) else torch.tensor(v, device=device))
             for k, v in metrics.items()
         }
+        metrics = self._namespace_metrics(metrics, group)
 
         ## images is now a dict
         for key, images in images_dict.items():
-            os.makedirs(
-                os.path.join(
-                    self.video_dir(),
-                    f"epoch_{self.trainer.current_epoch}",
-                    str(get_embodiment(key)),
-                ),
-                exist_ok=True,
-            )
-            if key not in self.val_image_buffer or self.val_image_buffer[key] is None:
-                self.val_image_buffer[key] = []
-                self.val_counter[key] = 0
-            self.val_image_buffer[key].extend(torch.from_numpy(images))
-            if len(self.val_image_buffer[key]) >= 1000:
-                frames = torch.stack(self.val_image_buffer[key])
-                path = os.path.join(
-                    self.video_dir(),
-                    f"epoch_{self.trainer.current_epoch}",
-                    str(get_embodiment(key)),
-                    f"validation_video_{self.val_counter[key]}.mp4",
-                )
-                tvio.write_video(path, frames, fps=30, video_codec="h264")
-                self.val_image_buffer[key].clear()
-                self.val_counter[key] += 1
+            buf_key = (group, key)
+            out_dir = self._group_video_dir(group, key)
+            os.makedirs(out_dir, exist_ok=True)
+            frames = torch.from_numpy(images)
+            hashes = self._episode_hashes(batch, key, len(frames))
+            if hashes is None:
+                self._buffer_chunked(buf_key, out_dir, frames)
+            else:
+                self._buffer_per_episode(buf_key, out_dir, frames, hashes)
 
-        self.trainer.lightning_module.log_dict(metrics, sync_dist=True)
+        # add_dataloader_idx=False: one dataloader per val group means Lightning
+        # would otherwise append `/dataloader_idx_N` to every key, splitting one
+        # chart in two and burying the group name. `_namespace_metrics` already
+        # disambiguates the groups (`Valid/` vs `Valid_{group}/`), so the suffix
+        # is redundant, and without it the same metric from a single-group run
+        # and a multi-group run share an axis.
+        self.trainer.lightning_module.log_dict(
+            metrics, sync_dist=True, add_dataloader_idx=False
+        )

--- a/egomimic/pl_utils/pl_data_utils.py
+++ b/egomimic/pl_utils/pl_data_utils.py
@@ -6,11 +6,101 @@ import numpy as np
 import torch
 from lightning import LightningDataModule
 from lightning.pytorch.utilities.combined_loader import CombinedLoader
+
+from egomimic.rldb.embodiment.embodiment import get_embodiment_id
 from termcolor import cprint
 from torch.utils.data import DataLoader, default_collate
 from transformers import AutoTokenizer
 
 logger = logging.getLogger(__name__)
+
+# Name of the val group that keeps the pre-groups behaviour: its metrics stay
+# `Valid/...` and its videos stay in `videos/epoch_N/{embodiment}/`, so runs
+# predating multi-group validation overlay on the same wandb charts. Every
+# other group is namespaced (`Valid_{group}/...`, `videos/epoch_N/{group}/...`).
+DEFAULT_VALID_GROUP = "valid"
+
+
+def _is_embodiment_name(name) -> bool:
+    """True when *name* is an embodiment (or legacy alias) the algo can route.
+
+    This is what separates the two shapes `valid_datasets` accepts. It is the
+    same lookup `process_batch_for_training` performs on the batch dict key
+    (`algo.py`, `get_embodiment_id(embodiment_name)`), so a key that passes
+    here is exactly a key the algo can consume.
+    """
+    try:
+        get_embodiment_id(str(name))
+    except (KeyError, AttributeError):
+        return False
+    return True
+
+
+def _as_valid_groups(valid_datasets: dict) -> dict:
+    """Normalise `valid_datasets` to `{group_name: {embodiment: dataset}}`.
+
+    Two accepted shapes:
+
+      * FLAT -- `{embodiment: dataset}`. Every key is an embodiment name, so
+        the whole mapping becomes the single `DEFAULT_VALID_GROUP` group. This
+        is the historical shape and stays byte-identical in behaviour.
+      * GROUPED -- `{group_name: {embodiment: dataset}}`. Keys are arbitrary
+        labels (`valid`, `newtask`, ...), each mapping to a per-embodiment
+        dict. Lightning runs one val loop per group, in insertion order.
+
+    The shapes are told apart by whether the top-level keys are embodiment
+    names rather than by inspecting value types -- hydra hands us instantiated
+    objects for the flat shape and DictConfig/dict for the grouped one, and
+    that distinction is fragile across omegaconf versions.
+    """
+    if not valid_datasets:
+        return {}
+
+    keys = list(valid_datasets.keys())
+    if all(_is_embodiment_name(k) for k in keys):
+        return {DEFAULT_VALID_GROUP: dict(valid_datasets)}
+
+    mixed = [k for k in keys if _is_embodiment_name(k)]
+    if mixed:
+        raise ValueError(
+            "valid_datasets mixes embodiment keys with val-group keys "
+            f"({mixed} look like embodiments, {[k for k in keys if k not in mixed]} "
+            "do not). Use either {embodiment: dataset} or "
+            "{group: {embodiment: dataset}}, not both."
+        )
+
+    groups = {}
+    for group_name, members in valid_datasets.items():
+        try:
+            members = dict(members)
+        except TypeError as exc:
+            raise ValueError(
+                f"val group {group_name!r} must map embodiment -> dataset, got "
+                f"{type(members).__name__}."
+            ) from exc
+        bad = [k for k in members if not _is_embodiment_name(k)]
+        if bad:
+            raise ValueError(
+                f"val group {group_name!r} has non-embodiment keys {bad}. Every "
+                "key must be an embodiment because the algo routes batches by "
+                "that key (process_batch_for_training -> get_embodiment_id)."
+            )
+        groups[group_name] = members
+    return groups
+
+
+def _params_for_group(valid_dataloader_params: dict, group_name: str) -> dict:
+    """Per-group dataloader params, falling back to a single shared block.
+
+    `valid_dataloader_params` may be keyed by embodiment (one block shared by
+    every group) or by group name (a block per group). The former is the
+    historical shape.
+    """
+    if not valid_dataloader_params:
+        return {}
+    if all(_is_embodiment_name(k) for k in valid_dataloader_params):
+        return valid_dataloader_params
+    return valid_dataloader_params.get(group_name, {})
 
 
 
@@ -47,10 +137,42 @@ class MultiDataModuleWrapper(LightningDataModule):
         # `None` entries arise when an inheriting data config opts out of a
         # dataset defined in a base (e.g. `aria_bimanual: null`).
         self.train_datasets = {k: v for k, v in train_datasets.items() if v is not None}
-        self.valid_datasets = {k: v for k, v in valid_datasets.items() if v is not None}
+        # `valid_datasets` may be flat ({embodiment: dataset}) or grouped
+        # ({group: {embodiment: dataset}}); normalise to the grouped form and
+        # drop `None` slots inside each group.
+        self.valid_groups = {
+            group: {k: v for k, v in members.items() if v is not None}
+            for group, members in _as_valid_groups(valid_datasets).items()
+        }
+        self.valid_groups = {g: m for g, m in self.valid_groups.items() if m}
+        # Positional: Lightning hands `validation_step` a `dataloader_idx` that
+        # indexes this list, and that is how the evaluator recovers the group
+        # name for metric prefixes and video paths.
+        self.valid_group_names = list(self.valid_groups.keys())
+        # Kept for callers (and checkpoint/eval paths) that expect the flat
+        # attribute; it is the default group when present, else the first.
+        self.valid_datasets = self.valid_groups.get(
+            DEFAULT_VALID_GROUP,
+            next(iter(self.valid_groups.values()), {}),
+        )
         self.train_dataloader_params = train_dataloader_params
         self.valid_dataloader_params = valid_dataloader_params
         self.collate_fn = annotation_collate
+
+    def iter_valid_datasets(self):
+        """Yield ``(group, embodiment, dataset)`` for EVERY val dataset.
+
+        Use this for anything that must touch all of validation -- norm-stats
+        wiring above all. ``self.valid_datasets`` is only a back-compat alias for
+        a SINGLE group (the default if present, else the first), so iterating it
+        silently skips every other group. That is exactly how the `newtask` group
+        shipped unnormalised: its datasets never received norm stats, the
+        evaluator unnormalised them anyway, and both its overlays and its metrics
+        were computed on doubly-unnormalised actions.
+        """
+        for group, members in self.valid_groups.items():
+            for embodiment, dataset in members.items():
+                yield group, embodiment, dataset
 
     def train_dataloader(self):
         iterables = dict()
@@ -69,13 +191,14 @@ class MultiDataModuleWrapper(LightningDataModule):
 
         return CombinedLoader(iterables, "max_size_cycle")
 
-    def val_dataloader(self):
+    def _val_loader_for_group(self, group_name: str) -> CombinedLoader:
+        group_params = _params_for_group(self.valid_dataloader_params, group_name)
         iterables = dict()
-        for dataset_name, dataset in self.valid_datasets.items():
-            dataset_params = self.valid_dataloader_params.get(dataset_name)
+        for dataset_name, dataset in self.valid_groups[group_name].items():
+            dataset_params = group_params.get(dataset_name)
             if dataset_params is None or len(dataset_params) == 0:
                 raise ValueError(
-                    f"No dataloader params found for dataset {dataset_name}. Please add {dataset_name} into your data config valid_dataloader_params."
+                    f"No dataloader params found for dataset {dataset_name} in val group {group_name!r}. Please add {dataset_name} into your data config valid_dataloader_params."
                 )
             dataset_params = dict(dataset_params)
             shuffle = dataset_params.pop("shuffle", False)
@@ -87,6 +210,20 @@ class MultiDataModuleWrapper(LightningDataModule):
             )
 
         return CombinedLoader(iterables, "max_size_cycle")
+
+    def val_dataloader(self):
+        """One CombinedLoader per val group.
+
+        A single group returns the bare CombinedLoader, which is exactly what
+        this method returned before groups existed -- so single-group runs keep
+        their old dataloader topology and `dataloader_idx` stays 0. Multiple
+        groups return a list, and Lightning then runs the val loops back to
+        back in list order, passing the group's index as `dataloader_idx`.
+        """
+        loaders = [self._val_loader_for_group(g) for g in self.valid_group_names]
+        if len(loaders) == 1:
+            return loaders[0]
+        return loaders
 
 
 

--- a/egomimic/pl_utils/pl_model.py
+++ b/egomimic/pl_utils/pl_model.py
@@ -13,6 +13,27 @@ import egomimic.utils.tensor_utils as TensorUtils
 from egomimic.rldb.zarr.zarr_dataset_multi import MultiDataset
 
 
+def _unwrap_combined_loader_batch(batch):
+    """Undo the extra tuple Lightning leaks when val groups are NESTED.
+
+    ``MultiDataModuleWrapper.val_dataloader`` returns one CombinedLoader per val
+    group. With a single group it returns that loader bare, Lightning iterates it
+    directly and unpacks its ``(batch, batch_idx, dataloader_idx)`` yield, so
+    ``batch`` arrives as the ``{embodiment: data}`` dict this expects.
+
+    With two or more groups it returns a LIST of CombinedLoaders. Lightning wraps
+    that list in a sequential CombinedLoader of its own, which treats each inner
+    CombinedLoader as a plain iterable -- so the inner loader's 3-tuple is passed
+    through as the batch and one unpack is not enough. The outer loop still hands
+    us the correct batch_idx and dataloader_idx (the group index), so the inner
+    pair is redundant and dropped. Without this the run dies at the first val
+    step with "'tuple' object has no attribute 'items'".
+    """
+    while isinstance(batch, tuple) and len(batch) == 3:
+        batch = batch[0]
+    return batch
+
+
 class ModelWrapper(LightningModule):
     """
     Wrapper class around robomimic models to ensure compatibility with Pytorch Lightning.
@@ -208,6 +229,7 @@ class ModelWrapper(LightningModule):
         """
         if self.evaluator is None:
             return
+        batch = _unwrap_combined_loader_batch(batch)
         batch = self.model.process_batch_for_training(batch)
         print(
             f"[VAL_STEP] rank={self.global_rank}, batch_idx={batch_idx}",

--- a/egomimic/trainHydra.py
+++ b/egomimic/trainHydra.py
@@ -187,8 +187,39 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     # transform_list aliasing trap.
     for ds in datamodule.train_datasets.values():
         ds.set_norm_stats_from(norm_stats)
-    for ds in datamodule.valid_datasets.values():
-        ds.set_norm_stats_from(norm_stats)
+    # EVERY val group, via the datamodule's own iterator. Do not iterate
+    # `datamodule.valid_datasets` here: it is a back-compat alias for a single
+    # group (the default if present, else the first), so it silently skips the
+    # rest. That is how `newtask` shipped unnormalised -- its datasets never got
+    # norm stats, the evaluator unnormalised them anyway, and both its overlays
+    # and its `Valid/*` metrics were computed on doubly-unnormalised actions.
+    for _group, _emb, _ds in datamodule.iter_valid_datasets():
+        _ds.set_norm_stats_from(norm_stats)
+
+    # Fail loudly rather than silently mis-normalising a split: every train and
+    # val dataset must now share the stats object by reference.
+    _unwired = [
+        f"train/{name}"
+        for name, ds in datamodule.train_datasets.items()
+        if getattr(ds, "norm_stats", None) is not norm_stats.norm_stats
+    ] + [
+        f"{group}/{emb}"
+        for group, emb, ds in datamodule.iter_valid_datasets()
+        if getattr(ds, "norm_stats", None) is not norm_stats.norm_stats
+    ]
+    if _unwired:
+        raise RuntimeError(
+            "norm stats were not wired to every dataset; these would emit "
+            f"unnormalised samples that the evaluator then unnormalises again: {_unwired}"
+        )
+    # f-string, not %-args: the pylogger wrapper consumes a positional arg for its
+    # rank prefix, so %-style placeholders come up short and logging raises.
+    log.info(
+        f"norm stats wired to {len(datamodule.train_datasets)} train and "
+        f"{sum(1 for _ in datamodule.iter_valid_datasets())} valid datasets "
+        f"across {len(datamodule.valid_groups)} val group(s): "
+        f"{list(datamodule.valid_groups)}"
+    )
 
     log.info(f"Instantiating model <{cfg.model._target_}>")
     model: LightningModule = ModelWrapper(


### PR DESCRIPTION
valid_datasets now accepts {group: {embodiment: dataset}} as well as the old
flat {embodiment: dataset}. Each group gets its own dataloader, metric
namespace and video directory, so a held-out split can be evaluated alongside
the in-distribution one in a single run.

Videos are cut on episode boundaries and named by episode_hash instead of
fixed-size chunks, with a per-episode frame cap and a fallback to the old
chunking when a batch carries no episode_hash.

Norm stats are wired through MultiDataModuleWrapper.iter_valid_datasets() and
guarded. valid_datasets is a back-compat alias for a single group, so iterating
it left every other group unnormalised while the evaluator unnormalised it
anyway, silently corrupting that group's overlays and metrics.

Also unwraps the extra tuple Lightning leaks when CombinedLoaders nest, which
otherwise fails with 'tuple object has no attribute items'.