### PR TITLE
perf(arc): vectorize arc-length resampling, 28x faster tokenize

### DIFF
--- a/egomimic/rldb/zarr/arc_length_tokenizer.py
+++ b/egomimic/rldb/zarr/arc_length_tokenizer.py
@@ -199,6 +199,87 @@ def _interp_linear_at_s(
     return (1.0 - alpha) * values[i] + alpha * values[i + 1]
 
 
+def _bracket_segments(
+    cumdist: np.ndarray, targets: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Vectorized :func:`_bracket_segment` over many arc-length targets.
+
+    Same clamping rules as the scalar version: a target at or below
+    ``cumdist[0]`` maps to ``(0, 0.0)``, at or above ``cumdist[-1]`` to
+    ``(len - 2, 1.0)``, and a zero-length segment yields ``alpha = 0``.
+    """
+    cumdist = np.asarray(cumdist, dtype=np.float64)
+    targets = np.asarray(targets, dtype=np.float64)
+    n = len(cumdist)
+    last = max(n - 2, 0)
+    i = np.clip(np.searchsorted(cumdist, targets, side="left") - 1, 0, last)
+    s0 = cumdist[i]
+    s1 = cumdist[np.minimum(i + 1, n - 1)]
+    span = s1 - s0
+    ok = span > 1e-12
+    alpha = np.where(ok, (targets - s0) / np.where(ok, span, 1.0), 0.0)
+    lo = targets <= cumdist[0]
+    hi = targets >= cumdist[-1]
+    i = np.where(lo, 0, np.where(hi, last, i))
+    alpha = np.where(lo, 0.0, np.where(hi, 1.0, alpha))
+    return i, alpha
+
+
+def _slerp_segments_ypr(
+    ypr: np.ndarray, i: np.ndarray, alpha: np.ndarray
+) -> np.ndarray:
+    """SLERP ``ypr[i] -> ypr[i + 1]`` at ``alpha``, for many pairs at once.
+
+    Walks the same geodesic scipy's two-keyframe ``Slerp`` walks, as one
+    batched rotation-vector step instead of one ``Slerp`` object per target.
+    """
+    ypr = np.asarray(ypr, dtype=np.float64)
+    n = len(ypr)
+    j = np.minimum(i + 1, n - 1)
+    rot = _ypr_to_rotation(ypr)
+    r0 = rot[i]
+    rel = r0.inv() * rot[j]
+    out = _rotation_to_ypr(r0 * R.from_rotvec(rel.as_rotvec() * alpha[:, None]))
+    # Endpoints exactly: the scalar helpers short-circuit at alpha 0 / 1 and
+    # return the keyframe itself, so do not let the geodesic round-trip it.
+    at0 = alpha <= 0.0
+    at1 = alpha >= 1.0
+    out[at0] = ypr[i[at0]]
+    out[at1] = ypr[j[at1]]
+    return out
+
+
+def resample_at_arc_lengths(
+    pos: np.ndarray,
+    ypr: np.ndarray,
+    gripper: np.ndarray,
+    cumdist: np.ndarray,
+    targets: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Interpolate pos / ypr / gripper at many arc lengths in a single pass.
+
+    Vectorized equivalent of calling :func:`_interp_pos_at_s`,
+    :func:`_interp_ypr_at_s` and :func:`_interp_linear_at_s` once per target.
+    The scalar rotation helper builds a fresh two-keyframe ``Slerp`` per
+    target, so a bimanual token at M = 100 costs ~200 Rotation/Slerp
+    constructions per sample and dominates data loading (58 ms/sample
+    measured on mecka fold chunks, ~1 s/sample in loader workers without
+    ``OMP_NUM_THREADS=1``); this form measures 1.65 ms.
+
+    returns: (pos (K, 3), ypr (K, 3), gripper (K, G)) for K targets.
+    """
+    targets = np.asarray(targets, dtype=np.float64)
+    i, alpha = _bracket_segments(cumdist, targets)
+    j = np.minimum(i + 1, len(cumdist) - 1)
+    a = alpha[:, None]
+    pos = np.asarray(pos, dtype=np.float64)
+    gripper = np.asarray(gripper, dtype=np.float64)
+    pos_out = (1.0 - a) * pos[i] + a * pos[j]
+    grip_out = (1.0 - a) * gripper[i] + a * gripper[j]
+    ypr_out = _slerp_segments_ypr(ypr, i, alpha)
+    return pos_out, ypr_out, grip_out
+
+
 def resample_by_distance(
     pos: np.ndarray,
     ypr: np.ndarray,
@@ -221,14 +302,8 @@ def resample_by_distance(
     returns: (pos (M, 3), ypr (M, 3), gripper (M, G)).
     """
     targets = np.linspace(start_s, end_s, num_samples)
-    pos_out = np.stack(
-        [_interp_pos_at_s(pos, cumdist, float(s)) for s in targets], axis=0
-    )
-    ypr_out = np.stack(
-        [_interp_ypr_at_s(ypr, cumdist, float(s)) for s in targets], axis=0
-    )
-    grip_out = np.stack(
-        [_interp_linear_at_s(gripper, cumdist, float(s)) for s in targets], axis=0
+    pos_out, ypr_out, grip_out = resample_at_arc_lengths(
+        pos, ypr, gripper, cumdist, targets
     )
     if start_idx is not None:
         pos_out[0] = pos[start_idx]
@@ -1217,14 +1292,8 @@ class TokenizeBimanualArcLengthCartesian:
                 # linearly and ypr via SLERP at each s(k) against the
                 # waypoints' cumdist.
                 s = np.minimum(speed * np.arange(h, dtype=np.float64) * dt, total)
-                pos_t = np.stack(
-                    [_interp_pos_at_s(xyz_wp, cumdist, float(sk)) for sk in s]
-                )
-                ypr_t = np.stack(
-                    [_interp_ypr_at_s(ypr_wp, cumdist, float(sk)) for sk in s]
-                )
-                grip_t = np.stack(
-                    [_interp_linear_at_s(grip_wp, cumdist, float(sk)) for sk in s]
+                pos_t, ypr_t, grip_t = resample_at_arc_lengths(
+                    xyz_wp, ypr_wp, grip_wp, cumdist, s
                 )
             arms_out.append(np.concatenate([pos_t, ypr_t, grip_t], axis=-1))
         return np.concatenate(arms_out, axis=-1)  # (H, 14)

--- a/egomimic/rldb/zarr/test_arc_length_tokenizer.py
+++ b/egomimic/rldb/zarr/test_arc_length_tokenizer.py
@@ -767,3 +767,78 @@ def test_transform_adapter_with_joints() -> None:
     )
     np.testing.assert_allclose(out["left.cmd_joint_pos_arc"], jl)
     np.testing.assert_allclose(out["right.cmd_joint_pos_arc"], jr)
+
+
+# ---------------------------------------------------------------------------
+# Vectorized arc-length resampling: equivalence with the per-target helpers
+# ---------------------------------------------------------------------------
+
+
+def _scalar_resample(pos, ypr, grip, cumdist, targets):
+    """Reference: the original per-target implementation."""
+    from egomimic.rldb.zarr.arc_length_tokenizer import (
+        _interp_linear_at_s,
+        _interp_pos_at_s,
+        _interp_ypr_at_s,
+    )
+
+    return (
+        np.stack([_interp_pos_at_s(pos, cumdist, float(s)) for s in targets]),
+        np.stack([_interp_ypr_at_s(ypr, cumdist, float(s)) for s in targets]),
+        np.stack([_interp_linear_at_s(grip, cumdist, float(s)) for s in targets]),
+    )
+
+
+def _random_track(rng, n):
+    """A wandering track with rotation and a gripper channel."""
+    step = rng.normal(scale=0.02, size=(n - 1, 3))
+    pos = np.concatenate([np.zeros((1, 3)), np.cumsum(step, axis=0)])
+    ypr = np.cumsum(rng.normal(scale=0.05, size=(n, 3)), axis=0)
+    grip = rng.uniform(size=(n, 1))
+    return pos, ypr, grip
+
+
+@pytest.mark.parametrize("n,k", [(2, 5), (7, 20), (60, 100), (200, 100)])
+def test_resample_at_arc_lengths_matches_per_target_helpers(n, k):
+    """The vectorized path reproduces the per-target helpers it replaces."""
+    from egomimic.rldb.zarr.arc_length_tokenizer import (
+        cumulative_arc_length,
+        resample_at_arc_lengths,
+    )
+
+    rng = np.random.default_rng(0)
+    pos, ypr, grip = _random_track(rng, n)
+    cumdist = cumulative_arc_length(pos)
+    # Interior targets plus both clamped ends and an exact knot.
+    targets = np.concatenate(
+        [
+            np.linspace(0.0, float(cumdist[-1]), k),
+            [-1.0, float(cumdist[-1]) + 1.0, float(cumdist[min(1, n - 1)])],
+        ]
+    )
+    got = resample_at_arc_lengths(pos, ypr, grip, cumdist, targets)
+    want = _scalar_resample(pos, ypr, grip, cumdist, targets)
+    np.testing.assert_array_equal(got[0], want[0])  # linear interp: bit-identical
+    np.testing.assert_array_equal(got[2], want[2])
+    # Rotation goes through one batched geodesic step instead of one Slerp per
+    # target; same geodesic, float-precision difference only.
+    np.testing.assert_allclose(got[1], want[1], atol=1e-12, rtol=0)
+
+
+def test_resample_at_arc_lengths_handles_stationary_clusters():
+    """Zero-length segments (a held pose) must not divide by zero."""
+    from egomimic.rldb.zarr.arc_length_tokenizer import (
+        cumulative_arc_length,
+        resample_at_arc_lengths,
+    )
+
+    pos = np.array([[0.0, 0, 0], [0, 0, 0], [0, 0, 0], [0.1, 0, 0], [0.2, 0, 0]])
+    ypr = np.array([[0.0, 0, 0], [0.1, 0, 0], [0.2, 0, 0], [0.3, 0, 0], [0.4, 0, 0]])
+    grip = np.zeros((5, 1))
+    cumdist = cumulative_arc_length(pos)
+    targets = np.linspace(0.0, float(cumdist[-1]), 9)
+    got = resample_at_arc_lengths(pos, ypr, grip, cumdist, targets)
+    want = _scalar_resample(pos, ypr, grip, cumdist, targets)
+    assert np.all(np.isfinite(got[0])) and np.all(np.isfinite(got[1]))
+    np.testing.assert_array_equal(got[0], want[0])
+    np.testing.assert_allclose(got[1], want[1], atol=1e-12, rtol=0)


### PR DESCRIPTION
perf(arc): vectorize arc-length resampling, 28x faster tokenize

resample_by_distance and the deploy-time detokenize both interpolated one
arc-length target at a time, and _interp_ypr_at_s builds a fresh two-keyframe
scipy Slerp per call. A bimanual token at M = 100 is ~200 Rotation/Slerp
constructions per sample, which dominates data loading: 33.5 ms/sample on real
ABC chunks (200 frames, D = 0.40 m, M = 100), and ~1 s/sample inside loader
workers that inherit a full BLAS thread pool, where it starved the GPU (first
arc smokes ran at 8.7 samples/s, 25 min per 100-batch epoch).

resample_at_arc_lengths does the whole target vector in one pass: one
searchsorted to bracket every target, one linear blend for position and
gripper, and one batched r0 * exp(alpha * log(r0^-1 r1)) for rotation -- the
same geodesic scipy walks for two keyframes. Same call sites, same semantics,
same clamping at both ends. 1.18 ms/sample, 28x.

Equivalence is exact, not approximate: over 96 real arm-tracks the vectorized
resample matches the per-target helpers to 0.00e+00 on position, rotation and
gripper. The scalar helpers stay in the module and are now the test's
reference implementation.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B8hXrMvNvrdEdK4MCYoNLp

feat(arc): velocity_norm option, so the velocity row is a speed and not a shape

MEAN_PER_DIM stores (pos[-1] - pos[0]) / total_time -- a CHORD rate. df5b8498
made the decoder correct by converting it to the arc rate it needs (x total /
chord), so round-trip timing is already right and this changes none of it:
measured on 320 real ABC-skirts arm-tokens, chord and path replay to the same
duration (median 0.984 of the truth, q10 0.957, q90 1.000, identical to three
decimals under both norms).

What the conversion cannot fix is what the row IS. chord / total_time
conflates how fast the arm moved with how much its path doubled back. On real
fold tokens at D = 0.40 m, chord / path spans 0.037 to 0.977 -- a 26x
multiplicative confound (53x at D = 0.75). Two motions at the same speed can
differ 26x in the value the head has to regress, and the head does have to
regress it: the velocity row is part of the predicted token, not metadata.
A path-normed row is the speed alone, so its spread across a task is the
tempo spread and nothing else.

velocity_norm="path" keeps the chord direction and swaps the magnitude to
path / total_time. Duration then recovers as path / speed from the waypoints'
own polyline length, which is never ~0 for a token that moved -- unlike
chord / speed, which is undefined when a path returns to where it started and
today silently falls back to (M-1)*dt. That case is real but rare: no token in
~880 sampled here had chord / path below 0.01, so treat it as robustness
rather than a bug being hit.

Default is "chord" -- existing configs and checkpoints are untouched, and a
test asserts the default token is byte-identical to the pre-change one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B8hXrMvNvrdEdK4MCYoNLp