### PR TITLE
feat: restore HPT Qwen language stem plumbing

### DIFF
--- a/egomimic/algo/hpt/algo.py
+++ b/egomimic/algo/hpt/algo.py
@@ -1,4 +1,5 @@
 import os
+import random
 from collections import OrderedDict
 from functools import partial
 
@@ -376,6 +377,16 @@ class HPTModel(nn.Module):
             stem = self.stems[f"{domain}_{modality}"]
             if modality in self.encoders:
                 data[modality] = self.encoders[modality](data[modality])
+
+            # Text-prompt modality: input is a list of raw strings (one per
+            # batch item). Skip positional embedding / horizon handling -- the
+            # stem (e.g. QwenPooledEncoder) owns tokenization and produces its
+            # own contextual feature for cross-attention.
+            if isinstance(data[modality], list):
+                stem_token = stem.compute_latent(data[modality])
+                feats.append(stem_token)
+                feat_dict[modality] = stem_token
+                continue
 
             data_shape = data[modality].shape
             data_horizon = data_shape[1]
@@ -805,6 +816,13 @@ class HPT(Algo):
         head_specs: dict = None,
         shared_stem_specs: dict = None,
         shared_obs_keys: list = None,
+        # ---------------------------
+        # Language / annotation-prompt conditioning (Qwen/T5 text stem)
+        # ---------------------------
+        annotation_key: str = None,
+        annotation_sampling_mode: str = "random",
+        annotation_modality: str = "annotation",
+        default_prompt: str = "",
         encoder_specs: dict = None,
         domains: list = None,
         auxiliary_ac_keys: Optional[dict] = None,
@@ -830,6 +848,16 @@ class HPT(Algo):
 
         self.shared_stem_specs = shared_stem_specs
         self.shared_obs_keys = shared_obs_keys
+
+        # Language-prompt conditioning: when annotation_key is set, one
+        # annotation string per batch item is sampled (see _build_prompts) and
+        # fed to the text stem registered under `annotation_modality`. Defaults
+        # reproduce the pre-existing no-language behavior (annotation_key=None
+        # => no prompts built, no extra modality injected).
+        self.annotation_key = annotation_key
+        self.annotation_sampling_mode = annotation_sampling_mode
+        self.annotation_modality = annotation_modality
+        self.default_prompt = default_prompt
 
         self.pretrained = pretrained
         self.pretrained_checkpoint = pretrained_checkpoint
@@ -954,6 +982,29 @@ class HPT(Algo):
 
         self.training_step = 0
 
+    def _build_prompts(self, _batch, batch_size: int) -> list:
+        """Sample one annotation per batch item, falling back to default_prompt
+        on empty / missing annotations. Mirrors the Pi algo flow.
+
+        MultiDataset already resolves the episode's JSON annotation records --
+        {"text", "start_idx", "end_idx"} -- down to the plain texts whose span
+        overlaps the sampled chunk (``_annotations_for_span``), so what arrives
+        here is a list[str] per item and no parsing is needed. Episodes whose
+        chunk overlaps no annotation give an empty list and fall back to
+        ``default_prompt``.
+        """
+        if self.annotation_key is None or self.annotation_key not in _batch:
+            return [self.default_prompt] * batch_size
+        prompts = []
+        for sample in _batch[self.annotation_key]:
+            if not sample:
+                prompts.append(self.default_prompt)
+            elif self.annotation_sampling_mode == "random":
+                prompts.append(sample[random.randint(0, len(sample) - 1)])
+            else:  # "first"
+                prompts.append(sample[0])
+        return prompts
+
     @override
     def process_batch_for_training(self, batch):
         """
@@ -1001,6 +1052,14 @@ class HPT(Algo):
             processed_batch[embodiment_id]["pad_mask"] = torch.ones(
                 B, S, 1, device=device
             )
+
+            # Sample one annotation per item (random/first, default fallback for
+            # empty). Stays as list[str]; the Qwen/T5 stem owns tokenization.
+            # No-op when annotation_key is None (default) -> no language branch.
+            if self.annotation_key is not None:
+                processed_batch[embodiment_id]["sampled_prompt"] = self._build_prompts(
+                    _batch, B
+                )
 
             # Samples are already normalized by MultiDataset.__getitem__.
             processed_batch[embodiment_id]["embodiment"] = torch.tensor(
@@ -1378,6 +1437,12 @@ class HPT(Algo):
         for key in lang_keys:
             if key in batch:
                 data[key] = batch[key]
+
+        # Raw-string annotation prompt; consumed by the Qwen/T5 text stem (if
+        # wired via shared_stem_specs[annotation_modality]). Present only when
+        # annotation_key was set, so the default no-language path is unchanged.
+        if "sampled_prompt" in batch:
+            data[self.annotation_modality] = batch["sampled_prompt"]
 
         data["is_6dof"] = self.is_6dof
         data["pad_mask"] = batch["pad_mask"]

--- a/egomimic/models/stems/text_encoders.py
+++ b/egomimic/models/stems/text_encoders.py
@@ -1,0 +1,148 @@
+"""Frozen text-encoder STEM modules for HPT language conditioning.
+
+Role home for the Qwen3-Embedding stems that turn a batch of raw prompt
+strings into cross-attention tokens. Ported here from the pre-batchflow
+``models/hpt_nets.py`` (class bodies behaviour-identical); the
+:class:`PolicyStem` base now lives in ``egomimic.models.stems.hpt_stems``.
+
+Unlike every other stem, these consume ``list[str]`` rather than a tensor —
+the stem owns tokenization, so ``HPTModel.stem_process`` routes list-valued
+modalities straight to ``compute_latent`` with no positional embedding or
+horizon masking.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from egomimic.models.stems.hpt_stems import PolicyStem
+
+
+def _qwen_last_token_pool(
+    last_hidden_states: torch.Tensor, attention_mask: torch.Tensor
+) -> torch.Tensor:
+    """Last-token pooling per the official Qwen3-Embedding recipe.
+
+    Handles both left- and right-padding. For each row we read the hidden state
+    at the position of the final non-padded token.
+    """
+    left_padded = bool((attention_mask[:, -1].sum() == attention_mask.shape[0]).item())
+    if left_padded:
+        return last_hidden_states[:, -1]
+    seq_lens = attention_mask.sum(dim=1) - 1
+    batch_idx = torch.arange(
+        last_hidden_states.size(0), device=last_hidden_states.device
+    )
+    return last_hidden_states[batch_idx, seq_lens]
+
+
+class _Qwen3BaseEncoder(PolicyStem):
+    """Shared base for Qwen3-Embedding stems used by HPT.
+
+    Owns the tokenizer + transformer encoder so HPT.process_batch_for_training
+    only needs to pass a list of raw prompt strings. Subclasses pick whether
+    the feature passed to cross-attention is a pooled (B, 1, D) summary or the
+    full per-token (B, L, D) sequence.
+
+    Args:
+        model_name: HF identifier for the Qwen3-Embedding checkpoint.
+        max_length: tokenizer truncation length.
+        freeze: if True (default), freeze the encoder weights and run in
+            eval mode under no_grad. If False, the encoder is trainable.
+        dtype: weight dtype for the HF model (fp16 by default to keep VRAM
+            cost down when frozen).
+        output_dim: projects Qwen's hidden_size down to the cross-attn
+            modality_embed_dim; must match the trunk's embed_dim.
+    """
+
+    DEFAULT_MODEL = "Qwen/Qwen3-Embedding-0.6B"
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL,
+        max_length: int = 128,
+        freeze: bool = True,
+        dtype: str = "float16",
+        output_dim: int | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        from transformers import AutoModel, AutoTokenizer
+
+        self.model_name = model_name
+        self.max_length = max_length
+        self.freeze_encoder = freeze
+        torch_dtype = getattr(torch, dtype) if isinstance(dtype, str) else dtype
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
+        self.encoder = AutoModel.from_pretrained(model_name, torch_dtype=torch_dtype)
+        if freeze:
+            for p in self.encoder.parameters():
+                p.requires_grad = False
+            self.encoder.eval()
+        self.hidden_size = int(self.encoder.config.hidden_size)
+        # Project Qwen's hidden_size (typ. 1024) down to the cross-attn
+        # modality_embed_dim. Must match the trunk's embed_dim so the post-stem
+        # token tensors concat with other modalities' tokens in
+        # ``HPTModel.preprocess_tokens``.
+        self.output_dim = output_dim if output_dim is not None else self.hidden_size
+        self.proj = (
+            nn.Linear(self.hidden_size, self.output_dim)
+            if self.output_dim != self.hidden_size
+            else nn.Identity()
+        )
+
+    def _encode(self, prompts):
+        tokens = self.tokenizer(
+            prompts,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="pt",
+        ).to(self.device)
+        if self.freeze_encoder:
+            with torch.no_grad():
+                out = self.encoder(**tokens)
+        else:
+            out = self.encoder(**tokens)
+        return out.last_hidden_state, tokens["attention_mask"]
+
+    def train(self, mode: bool = True):
+        """Keep the frozen encoder in eval mode regardless of outer train flag."""
+        super().train(mode)
+        if self.freeze_encoder:
+            self.encoder.eval()
+        return self
+
+
+class QwenPooledEncoder(_Qwen3BaseEncoder):
+    """Qwen3-Embedding stem with last-token pooling -> (B, 1, output_dim)."""
+
+    def forward(self, prompts):
+        hidden, mask = self._encode(prompts)
+        pooled = _qwen_last_token_pool(hidden, mask)
+        pooled = F.normalize(pooled.float(), p=2, dim=1)
+        pooled = self.proj(pooled)
+        return pooled.unsqueeze(1)  # (B, 1, output_dim)
+
+    def compute_latent(self, prompts):
+        feat = self(prompts)  # (B, 1, output_dim)
+        stem_tokens = self.tokens.repeat(feat.shape[0], 1, 1)
+        return self.cross_attention(stem_tokens, feat)
+
+
+class QwenPerTokenEncoder(_Qwen3BaseEncoder):
+    """Qwen3-Embedding stem returning per-token hidden states (B, L, output_dim).
+
+    Padding positions are zeroed before cross-attention so they don't pull
+    information from the learnable stem tokens.
+    """
+
+    def forward(self, prompts):
+        hidden, mask = self._encode(prompts)
+        feat = hidden.float() * mask.unsqueeze(-1).float()
+        return self.proj(feat)  # (B, L, output_dim)
+
+    def compute_latent(self, prompts):
+        feat = self(prompts)  # (B, L, output_dim)
+        stem_tokens = self.tokens.repeat(feat.shape[0], 1, 1)
+        return self.cross_attention(stem_tokens, feat)


### PR DESCRIPTION
The hydra-config refactor dropped the text stem and annotation_key path.
Bring both back as no-ops when annotation_key is unset so existing runs
stay unchanged.