### PR TITLE
add pyright type checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ scratch/
 sample_data/
 external_ckpts/
 external/MANO/
+docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,10 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.pyright]
+venvPath = "."
+venv = "emimic"
+pythonVersion = "3.11"
+typeCheckingMode = "basic"
+exclude = ["emimic", "external", "logs", "scratch", "assets", "**/__pycache__", "**/*.egg-info"]


### PR DESCRIPTION
## Summary
- Adds a `[tool.pyright]` block to `pyproject.toml` so Pyright/Pylance resolve imports against the `emimic` venv (Python 3.11, basic mode) and skip vendored, venv, and log dirs.
- Ignores `docs/` so local design notes and reviews stay out of the repo.

## Test plan
- Config only; no runtime path reads either change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvmNRmVFGU5dr2WR2CFuj3
