### PR TITLE
fix(configs): fix paths for data hydra yaml configs

### DIFF
--- a/egomimic/hydra_configs/data/aria.yaml
+++ b/egomimic/hydra_configs/data/aria.yaml
@@ -20,7 +20,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  human_bimanual: ${train_datasets.human_bimanual}
+  human_bimanual: ${data.train_datasets.human_bimanual}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/aria_keypoints.yaml
+++ b/egomimic/hydra_configs/data/aria_keypoints.yaml
@@ -20,7 +20,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  human_bimanual: ${train_datasets.human_bimanual}
+  human_bimanual: ${data.train_datasets.human_bimanual}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/aria_keypoints_wrist.yaml
+++ b/egomimic/hydra_configs/data/aria_keypoints_wrist.yaml
@@ -20,7 +20,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  human_bimanual: ${train_datasets.human_bimanual}
+  human_bimanual: ${data.train_datasets.human_bimanual}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/aria_pi.yaml
+++ b/egomimic/hydra_configs/data/aria_pi.yaml
@@ -18,7 +18,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  human_bimanual: ${train_datasets.human_bimanual}
+  human_bimanual: ${data.train_datasets.human_bimanual}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/aria_qwen.yaml
+++ b/egomimic/hydra_configs/data/aria_qwen.yaml
@@ -24,11 +24,11 @@ train_datasets:
 
 valid_datasets:
   human_bimanual:
-    _target_: ${train_datasets.human_bimanual._target_}
-    resolver: ${train_datasets.human_bimanual.resolver}
-    filters: ${train_datasets.human_bimanual.filters}
+    _target_: ${data.train_datasets.human_bimanual._target_}
+    resolver: ${data.train_datasets.human_bimanual.resolver}
+    filters: ${data.train_datasets.human_bimanual.filters}
     mode: valid
-    valid_ratio: ${train_datasets.human_bimanual.valid_ratio}
+    valid_ratio: ${data.train_datasets.human_bimanual.valid_ratio}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/cotrain_pi_base.yaml
+++ b/egomimic/hydra_configs/data/cotrain_pi_base.yaml
@@ -35,17 +35,17 @@ train_datasets:
 
 valid_datasets:
   eva_bimanual:
-    _target_: ${train_datasets.eva_bimanual._target_}
-    resolver: ${train_datasets.eva_bimanual.resolver}
-    filters: ${train_datasets.eva_bimanual.filters}
+    _target_: ${data.train_datasets.eva_bimanual._target_}
+    resolver: ${data.train_datasets.eva_bimanual.resolver}
+    filters: ${data.train_datasets.eva_bimanual.filters}
     mode: valid
-    valid_ratio: ${train_datasets.eva_bimanual.valid_ratio}
+    valid_ratio: ${data.train_datasets.eva_bimanual.valid_ratio}
   human_bimanual:
-    _target_: ${train_datasets.human_bimanual._target_}
-    resolver: ${train_datasets.human_bimanual.resolver}
-    filters: ${train_datasets.human_bimanual.filters}
+    _target_: ${data.train_datasets.human_bimanual._target_}
+    resolver: ${data.train_datasets.human_bimanual.resolver}
+    filters: ${data.train_datasets.human_bimanual.filters}
     mode: valid
-    valid_ratio: ${train_datasets.human_bimanual.valid_ratio}
+    valid_ratio: ${data.train_datasets.human_bimanual.valid_ratio}
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/eva.yaml
+++ b/egomimic/hydra_configs/data/eva.yaml
@@ -19,7 +19,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  eva_bimanual: ${train_datasets.eva_bimanual}
+  eva_bimanual: ${data.train_datasets.eva_bimanual}
 
 train_dataloader_params:
   eva_bimanual:

--- a/egomimic/hydra_configs/data/eva_pi.yaml
+++ b/egomimic/hydra_configs/data/eva_pi.yaml
@@ -17,5 +17,5 @@ train_datasets:
   human_bimanual: null
 
 valid_datasets:
-  eva_bimanual: ${train_datasets.eva_bimanual}
+  eva_bimanual: ${data.train_datasets.eva_bimanual}
   human_bimanual: null

--- a/egomimic/hydra_configs/data/industry_eva_pi.yaml
+++ b/egomimic/hydra_configs/data/industry_eva_pi.yaml
@@ -39,14 +39,14 @@ train_datasets:
 
 valid_datasets:
   eva_bimanual:
-    _target_: ${train_datasets.eva_bimanual._target_}
-    resolver: ${train_datasets.eva_bimanual.resolver}
-    filters: ${train_datasets.eva_bimanual.filters}
+    _target_: ${data.train_datasets.eva_bimanual._target_}
+    resolver: ${data.train_datasets.eva_bimanual.resolver}
+    filters: ${data.train_datasets.eva_bimanual.filters}
     mode: valid
   human_bimanual:
-    _target_: ${train_datasets.human_bimanual._target_}
-    resolver: ${train_datasets.human_bimanual.resolver}
-    filters: ${train_datasets.human_bimanual.filters}
+    _target_: ${data.train_datasets.human_bimanual._target_}
+    resolver: ${data.train_datasets.human_bimanual.resolver}
+    filters: ${data.train_datasets.human_bimanual.filters}
     mode: valid
 
 train_dataloader_params:

--- a/egomimic/hydra_configs/data/mecka.yaml
+++ b/egomimic/hydra_configs/data/mecka.yaml
@@ -20,7 +20,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  human_bimanual: ${train_datasets.human_bimanual}
+  human_bimanual: ${data.train_datasets.human_bimanual}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/mecka_pi.yaml
+++ b/egomimic/hydra_configs/data/mecka_pi.yaml
@@ -12,15 +12,16 @@ train_datasets:
         _target_: egomimic.rldb.embodiment.human.Human.get_transform_list
         stride: 1
     filters:
-      lab: "mecka"
-      task: "folding_clothes"
+      _target_: egomimic.rldb.filters.DatasetFilter
+      filter_lambdas:
+        - "lambda row: row['lab'] == 'mecka' and row['task'] == 'fold_clothes'"
     mode: train
 
 valid_datasets:
   human_bimanual:
-    _target_: ${train_datasets.human_bimanual._target_}
-    resolver: ${train_datasets.human_bimanual.resolver}
-    filters: ${train_datasets.human_bimanual.filters}
+    _target_: ${data.train_datasets.human_bimanual._target_}
+    resolver: ${data.train_datasets.human_bimanual.resolver}
+    filters: ${data.train_datasets.human_bimanual.filters}
     mode: valid
 
 train_dataloader_params:

--- a/egomimic/hydra_configs/data/mecka_scale_cotrain_pi.yaml
+++ b/egomimic/hydra_configs/data/mecka_scale_cotrain_pi.yaml
@@ -25,9 +25,9 @@ train_datasets:
 
 valid_datasets:
   human_bimanual:
-    _target_: ${train_datasets.human_bimanual._target_}
-    resolver: ${train_datasets.human_bimanual.resolver}
-    filters: ${train_datasets.human_bimanual.filters}
+    _target_: ${data.train_datasets.human_bimanual._target_}
+    resolver: ${data.train_datasets.human_bimanual.resolver}
+    filters: ${data.train_datasets.human_bimanual.filters}
     mode: valid
 
 train_dataloader_params:

--- a/egomimic/hydra_configs/data/scale.yaml
+++ b/egomimic/hydra_configs/data/scale.yaml
@@ -21,7 +21,7 @@ train_datasets:
     mode: total
 
 valid_datasets:
-  human_bimanual: ${train_datasets.human_bimanual}
+  human_bimanual: ${data.train_datasets.human_bimanual}
 
 train_dataloader_params:
   human_bimanual:

--- a/egomimic/hydra_configs/data/scale_pi.yaml
+++ b/egomimic/hydra_configs/data/scale_pi.yaml
@@ -13,17 +13,16 @@ train_datasets:
         _target_: egomimic.rldb.embodiment.human.Human.get_transform_list
         stride: 1
     filters:
+      _target_: egomimic.rldb.filters.DatasetFilter
       filter_lambdas:
         - "lambda row: ((row['task'] == 'Folding Clothes') | (row['task'] == '[flagship] Folding Clothes')) & (row['lab'] == 'scale') & (row['embodiment'] == 'human_bimanual') & (row['is_deleted'] == false)"
     mode: train
 
 valid_datasets:
   human_bimanual:
-    _target_: ${train_datasets.human_bimanual._target_}
-    resolver: ${train_datasets.human_bimanual.resolver}
-    filters:
-      task:
-        - "lambda row: ((row['task'] == 'Folding Clothes') | (row['task'] == '[flagship] Folding Clothes')) & (row['lab'] == 'scale') & (row['embodiment'] == 'human_bimanual') & (row['is_deleted'] == false)"
+    _target_: ${data.train_datasets.human_bimanual._target_}
+    resolver: ${data.train_datasets.human_bimanual.resolver}
+    filters: ${data.train_datasets.human_bimanual.filters}
     mode: valid
 
 train_dataloader_params:

--- a/egomimic/hydra_configs/paths/default.yaml
+++ b/egomimic/hydra_configs/paths/default.yaml
@@ -1,7 +1,6 @@
-# # path to root directory
-# # this requires PROJECT_ROOT environment variable to exist
-# # you can replace it with "." if you want the root to be the current working directory
-# root_dir: ${oc.env:PROJECT_ROOT}
+# path to root directory: $PROJECT_ROOT if set, else the directory the run was
+# launched from (which is also what the relative `hydra.run.dir` is rooted at)
+root_dir: ${oc.env:PROJECT_ROOT,${hydra:runtime.cwd}}
 
 # # path to data directory
 # data_dir: ${paths.root_dir}/data/

--- a/egomimic/hydra_configs/train_zarr_keypoint_wrist.yaml
+++ b/egomimic/hydra_configs/train_zarr_keypoint_wrist.yaml
@@ -1,6 +1,6 @@
 defaults:
   - train_zarr_cartesian
   - override model: hpt_bc_keypoints_base
-  - override data: aria_keypoints
-  - override evaluator/viz@evaluator.viz_func: eva_cartesian_aria_keypoints
+  - override data: aria_keypoints_wrist
+  - override evaluator/viz@evaluator.viz_func: keypoints_wrist
   - _self_

--- a/egomimic/hydra_configs/train_zarr_keypoints.yaml
+++ b/egomimic/hydra_configs/train_zarr_keypoints.yaml
@@ -1,6 +1,6 @@
 defaults:
   - train_zarr_cartesian
   - override model: hpt_bc_keypoints_base
-  - override data: aria_keypoints_wrist
-  - override evaluator/viz@evaluator.viz_func: eva_cartesian_aria_keypoints_wrist
+  - override data: aria_keypoints
+  - override evaluator/viz@evaluator.viz_func: keypoints
   - _self_

--- a/egomimic/hydra_configs/viz_language.yaml
+++ b/egomimic/hydra_configs/viz_language.yaml
@@ -1,4 +1,5 @@
 defaults:
+  - paths: default
   - data: cotrain_pi_lang
   - evaluator/viz@viz_func: cotrain_lang
   - _self_

--- a/tests/unit/test_hydra_configs.py
+++ b/tests/unit/test_hydra_configs.py
@@ -1,0 +1,101 @@
+"""Every shipped Hydra config must compose and fully resolve.
+
+No data, network, GPU or cluster path is touched: this composes the config tree
+the way ``trainHydra.py`` does, then forces every interpolation. It catches
+absolute ``${train_datasets.x}`` references that break once a data config is
+mounted under ``data.``, missing config-group files, and dead ``${paths.*}`` keys.
+
+A second check instantiates only the ``filters`` nodes of every data config:
+``DatasetFilter`` needs no DB or S3, and the zarr resolver rejects anything else.
+"""
+
+from pathlib import Path
+
+import hydra
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, OmegaConf, open_dict
+
+import egomimic
+import egomimic.trainHydra  # noqa: F401  -- registers the ``eval`` and custom resolvers
+from egomimic.rldb.filters import DatasetFilter
+
+CONFIG_DIR = Path(egomimic.__file__).parent / "hydra_configs"
+
+
+def _options(group: str) -> list[str]:
+    return sorted(p.stem for p in (CONFIG_DIR / group).glob("*.yaml"))
+
+
+TOP_LEVEL = sorted(p.stem for p in CONFIG_DIR.glob("*.yaml"))
+TRAIN_TOP_LEVEL = [c for c in TOP_LEVEL if c.startswith("train_")]
+
+
+def _compose_and_resolve(config_name: str, overrides: list[str]) -> DictConfig:
+    with initialize_config_dir(config_dir=str(CONFIG_DIR), version_base=None):
+        cfg = compose(
+            config_name=config_name,
+            overrides=overrides,
+            return_hydra_config=True,
+        )
+    # ``${hydra:runtime.output_dir}`` is only filled in by a real Hydra run.
+    OmegaConf.set_readonly(cfg.hydra, False)
+    with open_dict(cfg):
+        cfg.hydra.runtime.output_dir = "/nonexistent/output_dir"
+    HydraConfig.instance().set_config(cfg)  # makes ``${hydra:...}`` resolvable
+    # ``set_config`` freezes ``cfg.hydra``; resolve the task config on its own root.
+    task_cfg = OmegaConf.masked_copy(cfg, [k for k in cfg if k != "hydra"])
+    # Same flag ``hydra.utils.instantiate`` sets before it resolves: lets resolvers
+    # such as ``${oc.select:..., []}`` yield plain Python containers.
+    task_cfg._set_flag("allow_objects", True)
+    OmegaConf.resolve(task_cfg)
+    return task_cfg
+
+
+@pytest.mark.parametrize("config_name", TOP_LEVEL)
+def test_top_level_config_resolves(config_name):
+    _compose_and_resolve(config_name, [])
+
+
+@pytest.mark.parametrize("data", _options("data"))
+@pytest.mark.parametrize("top", TRAIN_TOP_LEVEL)
+def test_data_option_resolves_under_every_train_config(top, data):
+    _compose_and_resolve(top, [f"data={data}"])
+
+
+@pytest.mark.parametrize("model", _options("model"))
+def test_model_option_resolves(model):
+    _compose_and_resolve("train_zarr_cartesian", [f"model={model}"])
+
+
+@pytest.mark.parametrize("evaluator", _options("evaluator"))
+def test_evaluator_option_resolves(evaluator):
+    _compose_and_resolve("train_zarr_cartesian", [f"evaluator={evaluator}"])
+
+
+@pytest.mark.parametrize("viz", _options("evaluator/viz"))
+def test_evaluator_viz_option_resolves(viz):
+    _compose_and_resolve(
+        "train_zarr_cartesian", [f"evaluator/viz@evaluator.viz_func={viz}"]
+    )
+
+
+@pytest.mark.parametrize("data", _options("data"))
+def test_data_filters_instantiate_to_dataset_filter(data):
+    cfg = _compose_and_resolve("train_zarr_cartesian", [f"data={data}"])
+    for split in ("train_datasets", "valid_datasets"):
+        for name, ds in (cfg.data.get(split) or {}).items():
+            if ds is None or ds.get("filters") is None:
+                continue
+            target = ds.filters.get("_target_")
+            assert target is not None, (
+                f"{data}: {split}.{name}.filters is a plain dict; the zarr resolver "
+                "only accepts a DatasetFilter (add _target_ and filter_lambdas)"
+            )
+            cls = hydra.utils.get_class(target)
+            assert issubclass(
+                cls, DatasetFilter
+            ), f"{data}: {target} is not a DatasetFilter"
+            if cls is DatasetFilter:  # subclasses may need network / API keys
+                assert isinstance(hydra.utils.instantiate(ds.filters), DatasetFilter)


### PR DESCRIPTION
- paths/default.yaml: restore `root_dir` (${oc.env:PROJECT_ROOT,${hydra:runtime.cwd}});
  `log_dir` had referenced it while it was commented out, so every top-level
  config failed a full resolve.
- data/*.yaml (14 files): `${train_datasets.x}` -> `${data.train_datasets.x}`. Data
  configs are mounted under `data.`, so the root-relative form raised
  InterpolationKeyError on the first `cfg.data.valid_datasets[name]` access;
  the repo default `data: eva` had been unrunnable since 4ca49ca71 (May).
- data/mecka_pi.yaml, data/scale_pi.yaml: plain-dict / untargeted `filters:` ->
  DatasetFilter with filter_lambdas (the zarr resolver rejects anything else).
  mecka_pi's task string becomes 'fold_clothes', the value every other mecka
  config filters on; 'folding_clothes' matched nothing.
- train_zarr_keypoints / train_zarr_keypoint_wrist: viz override pointed at
  `eva_cartesian_aria_keypoints*`, removed in 9788e2be1 (now `keypoints*`);
  the two files also had each other's data config.
- viz_language.yaml: add the `paths` group its data config interpolates.
- tests/unit/test_hydra_configs.py: composes and fully resolves every top-level
  config, every data option under every train config, every model / evaluator /
  viz option, and checks each data config's `filters` is a DatasetFilter
  (instantiated only for the base class; subclasses may need API keys).
  164 parametrized cases, no data, network, or cluster paths.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UHDiN8yfERcsiFdz4mXuZi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHDiN8yfERcsiFdz4mXuZi
